### PR TITLE
Fixes: implicit convergence, floors, MPI, domains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ include_directories(external/variant/include)
 #add_subdirectory(external/kokkos-kernels)
 include_directories(external/kokkos-kernels/src)
 include_directories(external/kokkos-kernels/src/batched)
+include_directories(external/kokkos-kernels/src/common)
 include_directories(external/kokkos-kernels/src/batched/dense)
 include_directories(external/kokkos-kernels/src/batched/dense/impl)
 

--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -233,11 +233,13 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
     // Print this unless we quash everything
     int verbose = pmesh->packages.Get("B_CD")->Param<int>("verbose");
     if (verbose >= 0) {
-        Real max_divb = B_CD::MaxDivB(md);
-        max_divb = MPIReduce(max_divb, MPI_MAX);
+        static Reduce<Real> max_divb;
+        max_divb.val = B_CD::MaxDivB(md);
+        max_divb.StartReduce(0, MPI_MAX);
+        while (max_divb.CheckReduce() == TaskStatus::incomplete);
 
         if(MPIRank0()) {
-            cout << "Max DivB: " << max_divb << endl;
+            cout << "Max DivB: " << max_divb.val << endl;
         }
     }
 

--- a/kharma/b_cd/b_cd.hpp
+++ b/kharma/b_cd/b_cd.hpp
@@ -58,7 +58,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, Packages_t pack
 
 /**
  * Get the primitive variables, which in Parthenon's nomenclature are "derived".
- * Also applies floors to the calculated primitives, and fixes up any inversion errors
+ * Also applies floors to the calculated primitives, and fixes up any inversion errors.
+ * 
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
  *
  * input: Conserved B = sqrt(-gdet) * B^i
  * output: Primitive B = B^i

--- a/kharma/b_flux_ct/b_flux_ct.hpp
+++ b/kharma/b_flux_ct/b_flux_ct.hpp
@@ -59,7 +59,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, Packages_t pack
 /**
  * Get the primitive variables, which in Parthenon's nomenclature are "derived".
  * Also applies floors to the calculated primitives, and fixes up any inversion errors
- *
+ * 
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
+ * 
  * input: Conserved B = sqrt(-gdet) * B^i
  * output: Primitive B = B^i
  */
@@ -73,7 +75,7 @@ inline TaskStatus FillDerivedBlockTask(MeshBlockData<Real> *rc) { UtoP(rc); retu
 /**
  * Inverse of above. Generally only for initialization.
  */
-void PtoU(MeshBlockData<Real> *md, IndexDomain domain=IndexDomain::entire, bool coarse=false);
+void PtoU(MeshBlockData<Real> *md, IndexDomain domain=IndexDomain::interior, bool coarse=false);
 
 /**
  * Modify the B field fluxes to take a constrained-transport step as in Toth (2000)
@@ -107,7 +109,7 @@ inline TaskStatus MaxDivBTask(MeshData<Real> *md, double& divb_max)
  * Currently only used when resizing inputs.
  * TODO option to sprinkle into updates every N steps
  */
-void CleanupDivergence(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::entire, bool coarse=false);
+void CleanupDivergence(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::interior, bool coarse=false);
 
 /**
  * Diagnostics printed/computed after each step

--- a/kharma/b_flux_ct/seed_B_ct.cpp
+++ b/kharma/b_flux_ct/seed_B_ct.cpp
@@ -96,7 +96,7 @@ TaskStatus B_FluxCT::SeedBField(MeshBlockData<Real> *rc, ParameterInput *pin)
         break;
     }
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);
@@ -132,7 +132,7 @@ TaskStatus B_FluxCT::SeedBField(MeshBlockData<Real> *rc, ParameterInput *pin)
 
     // Find the magnetic vector potential.  In X3 symmetry only A_phi is non-zero,
     // But for tilted conditions we must keep track of all components
-    // TODO there's probably an ncorners
+    // TODO there should be an ncornersi,j,k
     ParArrayND<double> A("A", NVEC, n3+1, n2+1, n1+1);
     pmb->par_for("B_field_A", ks, ke+1, js, je+1, is, ie+1,
         KOKKOS_LAMBDA_3D {

--- a/kharma/current/current.cpp
+++ b/kharma/current/current.cpp
@@ -69,6 +69,7 @@ TaskStatus Current::CalculateCurrent(MeshBlockData<Real> *rc0, MeshBlockData<Rea
 
     // Calculate time-centered primitives
     // We could pack, but we just need the vectors, U1,2,3 and B1,2,3
+    // Apply over the whole grid, as calculating j requires neighbors
     IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
     IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
     IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);

--- a/kharma/debug.hpp
+++ b/kharma/debug.hpp
@@ -50,19 +50,17 @@ TaskStatus CheckNaN(MeshData<Real> *md, int dir, IndexDomain domain=IndexDomain:
  * Check the primitive and conserved variables for negative values that definitely shouldn't be negative
  * That is: primitive rho, u, conserved rho*u^t
  */
-TaskStatus CheckNegative(MeshData<Real> *md, IndexDomain domain);
-
-// The compiler is not so good with aliases.  We guide it.
-// using ParArrayNDHost = ParArrayNDGeneric<Kokkos::View<Real ******, parthenon::LayoutWrapper, Kokkos::HostSpace::memory_space>>;
-// using ParArrayNDIntHost = ParArrayNDGeneric<Kokkos::View<int ******, parthenon::LayoutWrapper, Kokkos::HostSpace::memory_space>>;
+TaskStatus CheckNegative(MeshData<Real> *md, IndexDomain domain=IndexDomain::interior);
 
 /**
- * Function for counting & printing pflags.  Note this needs a host-side array! Call pflags.getHostMirrorAndCopy() first!
+ * Function for counting & printing pflags.
+ * Note that domain::entire will double-count overlapping zones
  */
-int CountPFlags(MeshData<Real> *md, IndexDomain domain=IndexDomain::entire, int verbose=0);
+int CountPFlags(MeshData<Real> *md, IndexDomain domain=IndexDomain::interior, int verbose=0);
 
 /**
- * Function for counting & printing pflags.  Note this needs a host-side array! Call fflags.getHostMirrorAndCopy() first!
+ * Function for counting & printing pflags.
+ * Note that domain::entire will double-count overlapping zones
  */
 int CountFFlags(MeshData<Real> *md, IndexDomain domain=IndexDomain::interior, int verbose=0);
 

--- a/kharma/electrons/electrons.cpp
+++ b/kharma/electrons/electrons.cpp
@@ -173,7 +173,7 @@ TaskStatus InitElectrons(MeshBlockData<Real> *rc, ParameterInput *pin)
     const Real game = pmb->packages.Get("Electrons")->Param<Real>("gamma_e");
     const Real fel0 = pmb->packages.Get("Electrons")->Param<Real>("fel_0");
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);

--- a/kharma/electrons/electrons.hpp
+++ b/kharma/electrons/electrons.hpp
@@ -82,6 +82,8 @@ TaskStatus InitElectrons(MeshBlockData<Real> *rc, ParameterInput *pin);
  * It's easiest to define them with these defaults in the header, register the FillDerived version as
  * Parthenon's callback, and then add the UtoP version in kharma.cpp.
  * 
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
+ * 
  * Function in this package: Get the specific entropy primitive value, by dividing the total entropy K/(rho*u^0)
  */
 void UtoP(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::entire, bool coarse=false);

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -150,7 +150,7 @@ TaskStatus PostFillDerivedBlock(MeshBlockData<Real> *rc)
     }
 }
 
-TaskStatus ApplyFloors(MeshBlockData<Real> *rc)
+TaskStatus ApplyFloors(MeshBlockData<Real> *rc, IndexDomain domain)
 {
     Flag(rc, "Apply floors");
     auto pmb = rc->GetBlockPointer();
@@ -169,12 +169,12 @@ TaskStatus ApplyFloors(MeshBlockData<Real> *rc)
     const Floors::Prescription floors(pmb->packages.Get("Floors")->AllParams());
 
     // Apply floors over the same zones we just updated with UtoP
-    // This selects the entire zone, but we then require pflag >= 0,
+    // This selects the entire domain, but we then require pflag >= 0,
     // which keeps us from covering completely uninitialized zones
     // (but still applies to failed UtoP!)
-    const IndexRange ib = rc->GetBoundsI(IndexDomain::entire);
-    const IndexRange jb = rc->GetBoundsJ(IndexDomain::entire);
-    const IndexRange kb = rc->GetBoundsK(IndexDomain::entire);
+    const IndexRange ib = rc->GetBoundsI(domain);
+    const IndexRange jb = rc->GetBoundsJ(domain);
+    const IndexRange kb = rc->GetBoundsK(domain);
     pmb->par_for("apply_floors", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA_3D {
             if (((int) pflag(k, j, i)) >= InversionStatus::success) {
@@ -183,10 +183,17 @@ TaskStatus ApplyFloors(MeshBlockData<Real> *rc)
                 fflag(k, j, i) = (comboflag / HIT_FLOOR_GEOM_RHO) * HIT_FLOOR_GEOM_RHO;
 
                 // Record the pflag as well.  KHARMA did not traditionally do this,
-                // as it ran floors over uninitialized zones.  We do better now.
-                // This both saves time and is more correct, as it reflects the *current*
-                // invertibility/physicality of U, not the version before floor applications
-                pflag(k, j, i) = comboflag % HIT_FLOOR_GEOM_RHO;
+                // because floors were run over uninitialized zones, and thus wrote
+                // garbage pflags.  We now prevent this.
+                // Note that the pflag is recorded only if inversion failed --
+                // floors can paper over zones that really *should* be discarded,
+                // even if they now technically correspond to a physical state.
+                // Zones next to the sharp edge of the initial torus, for example,
+                // can produce negative u when inverted, then magically stay invertible
+                // after floors when they should be diffused.
+                if (comboflag % HIT_FLOOR_GEOM_RHO) {
+                    pflag(k, j, i) = comboflag % HIT_FLOOR_GEOM_RHO;
+                }
 
 #if !FUSE_FLOOR_KERNELS
             }

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -182,10 +182,12 @@ TaskStatus ApplyFloors(MeshBlockData<Real> *rc)
                 int comboflag = apply_floors(G, P, m_p, gam, k, j, i, floors, U, m_u);
                 fflag(k, j, i) = (comboflag / HIT_FLOOR_GEOM_RHO) * HIT_FLOOR_GEOM_RHO;
 
-                // The floors as they're written guarantee a consistent state in their cells,
-                // so we do not flag any additional cells, nor do we remove existing flags
-                // (which might have only "needed floors" due to being left untouched by UtoP)
-                // TODO record these flags separately, they are likely common depending on floor prescriptions
+                // Record the pflag as well.  KHARMA did not traditionally do this,
+                // as it ran floors over uninitialized zones.  We do better now.
+                // This both saves time and is more correct, as it reflects the *current*
+                // invertibility/physicality of U, not the version before floor applications
+                pflag(k, j, i) = comboflag % HIT_FLOOR_GEOM_RHO;
+
 #if !FUSE_FLOOR_KERNELS
             }
         }

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -79,7 +79,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
  * 
  * LOCKSTEP: this function respects P and returns consistent P<->U
  */
-TaskStatus ApplyFloors(MeshBlockData<Real> *rc);
+TaskStatus ApplyFloors(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::entire);
 
 /**
  * Parthenon call wrapper for ApplyFloors, called just after FillDerived == UtoP

--- a/kharma/flux.hpp
+++ b/kharma/flux.hpp
@@ -67,7 +67,7 @@ TaskStatus ApplyFluxes(MeshData<Real> *md, MeshData<Real> *mdudt);
  * Second declaration is for Parthenon's benefit, similar to e.g.
  * declaring UtoP vs FillDerived in GRMHD package.
  */
-TaskStatus PtoU(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::entire);
+TaskStatus PtoU(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::interior);
 inline TaskStatus PtoUTask(MeshBlockData<Real> *rc) { return PtoU(rc); }
 
 // Fluxes a.k.a. "Approximate Riemann Solvers"

--- a/kharma/grmhd/fixup.cpp
+++ b/kharma/grmhd/fixup.cpp
@@ -64,6 +64,7 @@ TaskStatus GRMHD::FixUtoP(MeshBlockData<Real> *rc)
     const int verbose = pars.Get<int>("verbose");
     const Floors::Prescription floors(pmb->packages.Get("Floors")->AllParams());
 
+    // Just as UtoP needs to be applied over all zones, it needs to be fixed over all zones
     const IndexRange ib = rc->GetBoundsI(IndexDomain::entire);
     const IndexRange jb = rc->GetBoundsJ(IndexDomain::entire);
     const IndexRange kb = rc->GetBoundsK(IndexDomain::entire);

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -492,9 +492,10 @@ AmrTag CheckRefinement(MeshBlockData<Real> *rc)
     auto pmb = rc->GetBlockPointer();
     auto v = rc->Get("prims.rho").data;
 
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+    IndexDomain domain = IndexDomain::interior;
+    IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
+    IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
+    IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
 
     typename Kokkos::MinMax<Real>::value_type minmax;
     pmb->par_reduce("check_refinement", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -536,6 +536,7 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
     // Check for a soundspeed (ctop) of 0 or NaN
     // This functions as a "last resort" check to stop a
     // simulation on obviously bad data
+    // TODO also be able to print what zone dictated timestep
     if (extra_checks >= 1) {
         CheckNaN(md, X1DIR);
         if (pmesh->ndim > 1) CheckNaN(md, X2DIR);

--- a/kharma/grmhd/grmhd.hpp
+++ b/kharma/grmhd/grmhd.hpp
@@ -56,6 +56,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, Packages_t pack
  * This just computes P, and only for the fluid varaibles.
  * Other packages must convert P->U by registering their version as "FillDerived"
  *
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
+ * 
  * input: U, whatever form
  * output: U and P match down to inversion errors
  */
@@ -68,9 +70,6 @@ inline TaskStatus FillDerivedBlockTask(MeshBlockData<Real> *rc) { UtoP(rc); retu
 /**
  * Smooth over inversion failures by averaging values from each neighboring zone
  * a.k.a. Diffusion?  What diffusion?  There is no diffusion here.
- *
- * TODO These happen often, and we can do better here.
- * See e.g. Beckwith & Stone for a truly defense-in-depth approach
  * 
  * LOCKSTEP: this function expects and should preserve P<->U
  */

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin)
     // Implicit solver parameters
     Real jacobian_delta = pin->GetOrAddReal("implicit", "jacobian_delta", 4.e-8);
     params.Add("jacobian_delta", jacobian_delta);
-    Real rootfind_tol = pin->GetOrAddReal("implicit", "rootfind_tol", 1.e-3);
+    Real rootfind_tol = pin->GetOrAddReal("implicit", "rootfind_tol", 1.e-9);
     params.Add("rootfind_tol", rootfind_tol);
     Real linesearch_lambda = pin->GetOrAddReal("implicit", "linesearch_lambda", 1.0);
     params.Add("linesearch_lambda", linesearch_lambda);

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -118,6 +118,7 @@ TaskStatus Step(MeshData<Real> *mci, MeshData<Real> *mc0, MeshData<Real> *dudt,
 
     const auto& implicit_par = pmb0->packages.Get("Implicit")->AllParams();
     const int iter_max = implicit_par.Get<int>("max_nonlinear_iter");
+    const Real rootfind_tol = implicit_par.Get<Real>("rootfind_tol");
     const Real lambda = implicit_par.Get<Real>("linesearch_lambda");
     const Real delta = implicit_par.Get<Real>("jacobian_delta");
     const Real gam = pmb0->packages.Get("GRMHD")->Param<Real>("gamma");
@@ -351,6 +352,7 @@ TaskStatus Step(MeshData<Real> *mci, MeshData<Real> *mc0, MeshData<Real> *dudt,
         , norm_max);
         max_norm = MPIReduce(max_norm, MPI_MAX);
         if (MPIRank0()) fprintf(stdout, "Nonlinear iter %d. Max L2 norm: %g\n", iter, max_norm);
+        if (max_norm < rootfind_tol) break;
     }
 
     Flag(mc_solver, "Implicit Iteration: final");

--- a/kharma/mpi.hpp
+++ b/kharma/mpi.hpp
@@ -58,4 +58,10 @@ inline void MPIBarrier() {}
 inline bool MPIRank() { return 0; }
 inline bool MPIRank0() { return true; }
 
+template<typename T>
+inline T MPIReduce_once(T f, MPI_Op O)
+{
+    return f;
+}
+
 #endif // MPI_PARALLEL

--- a/kharma/mpi.hpp
+++ b/kharma/mpi.hpp
@@ -14,7 +14,8 @@
 
 static auto comm = MPI_COMM_WORLD;
 
-// UNIVERSAL
+// Wrappers to make Parthenon-scope MPI interface global,
+// plus an easy barrier in case you need it for debugging
 inline bool MPIRank()
 {
     return parthenon::Globals::my_rank;
@@ -28,29 +29,23 @@ inline void MPIBarrier()
     MPI_Barrier(comm);
 }
 
+/**
+ * Perform a Parthenon MPI reduction. ONCE.
+ * Parthenon does not clean up communicators, and
+ * it is further bad practice to allocate a new one per-step.
+ * So, avoid this function except in initialization.
+ * 
+ * Instead, copy/paste the contents & use a static declaration for
+ * the AllReduce object.  Replace with a Reduce object if you don't
+ * need the result on all ranks.
+ */
 template<typename T>
-inline T MPIReduce(T f, MPI_Op O)
+inline T MPIReduce_once(T f, MPI_Op O)
 {
     AllReduce<T> reduction;
     reduction.val = f;
     reduction.StartReduce(O);
     // Wait on results
-    while (reduction.CheckReduce() == TaskStatus::incomplete);
-    return reduction.val;
-}
-
-template<typename T>
-inline AllReduce<T> MPIStartReduce(T f, MPI_Op O)
-{
-    AllReduce<T> reduction;
-    reduction.val = f;
-    reduction.StartReduce(O);
-    return reduction;
-}
-
-template<typename T>
-inline T MPIGetReduce(AllReduce<T> reduction)
-{
     while (reduction.CheckReduce() == TaskStatus::incomplete);
     return reduction.val;
 }
@@ -62,25 +57,5 @@ inline T MPIGetReduce(AllReduce<T> reduction)
 inline void MPIBarrier() {}
 inline bool MPIRank() { return 0; }
 inline bool MPIRank0() { return true; }
-
-template<typename T>
-inline T MPIReduce(T f, MPI_Op O)
-{
-    return f;
-}
-
-template<typename T>
-inline AllReduce<T> MPIStartReduce(T f, MPI_Op O)
-{
-    AllReduce<T> reduction;
-    reduction.val = f;
-    return reduction;
-}
-
-template<typename T>
-inline T MPIGetReduce(AllReduce<T> reduction)
-{
-    return reduction.val;
-}
 
 #endif // MPI_PARALLEL

--- a/kharma/prob/b_field_tools.cpp
+++ b/kharma/prob/b_field_tools.cpp
@@ -41,7 +41,7 @@
 TaskStatus NormalizeBField(MeshBlockData<Real> *rc, Real norm)
 {
     auto pmb = rc->GetBlockPointer();
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);

--- a/kharma/prob/blob.hpp
+++ b/kharma/prob/blob.hpp
@@ -69,9 +69,10 @@ void InsertBlob(MeshBlockData<Real> *rc, ParameterInput *pin)
     GReal blob_th = pin->GetOrAddReal("blob", "th", M_PI/8);
     GReal blob_phi = pin->GetOrAddReal("blob", "phi", 0.0);
 
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+    IndexDomain domain = IndexDomain::interior;
+    IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
+    IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
+    IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("insert_blob", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA_3D {
             Real X[GR_DIM];

--- a/kharma/prob/bondi.hpp
+++ b/kharma/prob/bondi.hpp
@@ -55,7 +55,7 @@ TaskStatus InitializeBondi(MeshBlockData<Real> *rc, ParameterInput *pin);
  * 
  * Used for initialization and boundary conditions
  */
-TaskStatus SetBondi(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::entire, bool coarse=false);
+TaskStatus SetBondi(MeshBlockData<Real> *rc, IndexDomain domain=IndexDomain::interior, bool coarse=false);
 
 /**
  * Supporting functions for Bondi flow calculations

--- a/kharma/prob/bz_monopole.cpp
+++ b/kharma/prob/bz_monopole.cpp
@@ -55,7 +55,7 @@ TaskStatus InitializeBZMonopole(MeshBlockData<Real> *rc, ParameterInput *pin)
     Real rho_min_limit = pin->GetOrAddReal("floors", "rho_min_geom", 1.e-6);
     Real u_min_limit = pin->GetOrAddReal("floors", "u_min_geom", 1.e-8);
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);

--- a/kharma/prob/emhdmodes.hpp
+++ b/kharma/prob/emhdmodes.hpp
@@ -92,9 +92,10 @@ TaskStatus InitializeEMHDModes(MeshBlockData<Real> *rc, ParameterInput *pin)
     const Real k2 = 4. * M_PI;
     // END POSSIBLE ARGS
 
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+    IndexDomain domain = IndexDomain::interior;
+    IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
+    IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
+    IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("emhdmodes_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA_3D {
             Real X[GR_DIM];

--- a/kharma/prob/emhdshock.hpp
+++ b/kharma/prob/emhdshock.hpp
@@ -81,9 +81,10 @@ TaskStatus InitializeEMHDShock(MeshBlockData<Real> *rc, ParameterInput *pin)
 
     const std::string input = pin->GetOrAddString("emhd", "input" "BVP");
 
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+    IndexDomain domain = IndexDomain::interior;
+    IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
+    IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
+    IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
 
     // Need the EMHD package if higher order terms are considered
     const bool use_emhd = pkgs.count("EMHD");

--- a/kharma/prob/explosion.hpp
+++ b/kharma/prob/explosion.hpp
@@ -77,9 +77,10 @@ TaskStatus InitializeExplosion(MeshBlockData<Real> *rc, ParameterInput *pin)
     const Real xoff = pin->GetOrAddReal("explosion", "xoff", 0.0);
     const Real yoff = pin->GetOrAddReal("explosion", "yoff", 0.0);
 
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+    IndexDomain domain = IndexDomain::interior;
+    IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
+    IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
+    IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("explosion_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA_3D {
             Real X[GR_DIM];

--- a/kharma/prob/fm_torus.cpp
+++ b/kharma/prob/fm_torus.cpp
@@ -58,7 +58,7 @@ TaskStatus InitializeFMTorus(MeshBlockData<Real> *rc, ParameterInput *pin)
     const GReal tilt = tilt_deg / 180. * M_PI;
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     const int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     const int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     const int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);

--- a/kharma/prob/kelvin_helmholtz.hpp
+++ b/kharma/prob/kelvin_helmholtz.hpp
@@ -66,7 +66,7 @@ TaskStatus InitializeKelvinHelmholtz(MeshBlockData<Real> *rc, ParameterInput *pi
     const auto& G = pmb->coords;
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);

--- a/kharma/prob/mhdmodes.hpp
+++ b/kharma/prob/mhdmodes.hpp
@@ -245,9 +245,10 @@ TaskStatus InitializeMHDModes(MeshBlockData<Real> *rc, ParameterInput *pin)
         }
     }
 
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+    IndexDomain domain = IndexDomain::interior;
+    IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
+    IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
+    IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("mhdmodes_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA_3D {
             Real X[GR_DIM];

--- a/kharma/prob/noh.hpp
+++ b/kharma/prob/noh.hpp
@@ -65,7 +65,7 @@ TaskStatus InitializeNoh(MeshBlockData<Real> *rc, ParameterInput *pin)
 
     const auto& G = pmb->coords;
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);

--- a/kharma/prob/orszag_tang.hpp
+++ b/kharma/prob/orszag_tang.hpp
@@ -35,7 +35,7 @@ TaskStatus InitializeOrszagTang(MeshBlockData<Real> *rc, ParameterInput *pin)
     // Default phase puts the current sheet in the middle of the domain
     const Real phase = pin->GetOrAddReal("orszag_tang", "phase", M_PI);
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);

--- a/kharma/prob/post_initialize.cpp
+++ b/kharma/prob/post_initialize.cpp
@@ -44,6 +44,7 @@
 #include "gr_coordinates.hpp"
 #include "grmhd.hpp"
 #include "kharma.hpp"
+#include "mpi.hpp"
 #include "types.hpp"
 
 #include "seed_B_ct.hpp"

--- a/kharma/prob/post_initialize.cpp
+++ b/kharma/prob/post_initialize.cpp
@@ -113,11 +113,11 @@ void KHARMA::SeedAndNormalizeB(ParameterInput *pin, Mesh *pmesh)
 
             // Calculate current beta_min value
             if (beta_calc_legacy) {
-                bsq_max = MPIReduce(bsq_max, MPI_MAX);
-                p_max = MPIReduce(p_max, MPI_MAX);
+                bsq_max = MPIReduce_once(bsq_max, MPI_MAX);
+                p_max = MPIReduce_once(p_max, MPI_MAX);
                 beta_min = p_max / (0.5 * bsq_max);
             } else {
-                beta_min = MPIReduce(beta_min, MPI_MIN);
+                beta_min = MPIReduce_once(beta_min, MPI_MIN);
             }
 
             if (pin->GetInteger("debug", "verbose") > 0) {
@@ -153,11 +153,11 @@ void KHARMA::SeedAndNormalizeB(ParameterInput *pin, Mesh *pmesh)
                 }
             }
             if (beta_calc_legacy) {
-                bsq_max = MPIReduce(bsq_max, MPI_MAX);
-                p_max = MPIReduce(p_max, MPI_MAX);
+                bsq_max = MPIReduce_once(bsq_max, MPI_MAX);
+                p_max = MPIReduce_once(p_max, MPI_MAX);
                 beta_min = p_max / (0.5 * bsq_max);
             } else {
-                beta_min = MPIReduce(beta_min, MPI_MIN);
+                beta_min = MPIReduce_once(beta_min, MPI_MIN);
             }
             if (MPIRank0()) {
                 cerr << "Beta min post-norm: " << beta_min << endl;
@@ -177,7 +177,7 @@ void KHARMA::SeedAndNormalizeB(ParameterInput *pin, Mesh *pmesh)
         } else if (use_b_cd) {
             divb_max = B_CD::MaxDivB(md);
         }
-        divb_max = MPIReduce(divb_max, MPI_MAX);
+        divb_max = MPIReduce_once(divb_max, MPI_MAX);
         if (MPIRank0()) {
             cerr << "Starting max divB: " << divb_max << endl;
         }

--- a/kharma/prob/resize_restart.cpp
+++ b/kharma/prob/resize_restart.cpp
@@ -180,7 +180,7 @@ TaskStatus ReadIharmRestart(MeshBlockData<Real> *rc, ParameterInput *pin)
     hsize_t n3tot = pin->GetInteger("parthenon/mesh", "restart_nx3");
 
     // Size/domain of the MeshBlock we're reading to
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);

--- a/kharma/prob/shock_tube.hpp
+++ b/kharma/prob/shock_tube.hpp
@@ -42,7 +42,7 @@ TaskStatus InitializeShockTube(MeshBlockData<Real> *rc, ParameterInput *pin)
     const Real B3L = pin->GetOrAddReal("shock", "B3L", 0.0);
     const Real B3R = pin->GetOrAddReal("shock", "B3R", 0.0);
 
-    IndexDomain domain = IndexDomain::entire;
+    IndexDomain domain = IndexDomain::interior;
     IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);

--- a/kharma/reductions/reductions.hpp
+++ b/kharma/reductions/reductions.hpp
@@ -124,25 +124,26 @@ Real DomainSum(MeshData<Real> *md, const Real& radius);
 // plus packing & passing
 enum class Mdot : int;
 MAKE_SUM2D_FN(Mdot,
-    // TODO document values here. e.g.:
     // \dot{M} == \int rho * u^1 * gdet * dx2 * dx3
     local_result += -P(m_p.RHO, k, j, i) * Dtmp.ucon[1] * gdA;
 )
 enum class Edot : int;
 MAKE_SUM2D_FN(Edot,
-    // Edot == \int - T^1_0 * gdet * dx2 * dx3
+    // \dot{E} == \int - T^1_0 * gdet * dx2 * dx3
     local_result += -T[X1DIR][X0DIR] * gdA;
 )
 enum class Ldot : int;
 MAKE_SUM2D_FN(Ldot,
-    // Ldot == \int T^1_3 * gdet * dx2 * dx3
+    // \dot{L} == \int T^1_3 * gdet * dx2 * dx3
     local_result += T[X1DIR][X3DIR] * gdA;
 )
 enum class Phi : int;
 MAKE_SUM2D_FN(Phi,
-    // phi == \int |*F^1^0| * gdet * dx2 * dx3 == \int |B1| * gdet * dx2 * dx3
+    // \Phi == \int |*F^1^0| * gdet * dx2 * dx3 == \int |B1| * gdet * dx2 * dx3
     // Can also sum the hemispheres independently to be fancy (TODO?)
-    local_result += 0.5 * fabs(U(m_u.B1, k, j, i)) * dA; // gdet is included in cons.B
+    if (m_u.B1 >= 0) {
+        local_result += 0.5 * fabs(U(m_u.B1, k, j, i)) * dA; // gdet is included in cons.B
+    }
 )
 
 // Then we can define the same with fluxes.
@@ -287,7 +288,7 @@ inline Real TotalL(MeshData<Real> *md) {return DomainSum<Ltot>(md, 50.);}
 inline Real TotalEHTLum(MeshData<Real> *md) {return DomainSum<EHTLum>(md, 50.);}
 inline Real JetLum_50(MeshData<Real> *md) {return DomainSum<JetLum>(md, 50.);} // Recall this is *at* not *within*
 
-inline int NPFlags(MeshData<Real> *md) {return CountPFlags(md, IndexDomain::entire, 0);}
+inline int NPFlags(MeshData<Real> *md) {return CountPFlags(md, IndexDomain::interior, 0);}
 inline int NFFlags(MeshData<Real> *md) {return CountFFlags(md, IndexDomain::interior, 0);}
 
 } // namespace Reductions

--- a/machines/bp.sh
+++ b/machines/bp.sh
@@ -50,23 +50,27 @@ if [[ $METAL_HOSTNAME == "fermium" ]]; then
 fi
 
 if [[ $METAL_HOSTNAME == "ferrum" ]]; then
+  HOST_ARCH="HSW"
+  DEVICE_ARCH="INTEL_GEN"
+  NPROC=6
+
   if [[ "$ARGS" == *"gcc"* ]]; then
     module load mpi/mpich-x86_64
     C_NATIVE="gcc"
     CXX_NATIVE="g++"
+  elif [[ "$ARGS" == *"icc"* ]]; then
+    # Intel compiler
+    module purge
+    module load compiler mpi
+    PREFIX_PATH="$HOME/libs/hdf5-oneapi"
   else
     # Intel SYCL implementation "DPC++"
     module purge
     module load compiler mpi
     PREFIX_PATH="$HOME/libs/hdf5-oneapi"
+    C_NATIVE="icx"
+    CXX_NATIVE="icpx"
   fi
-
-  NPROC=6 # My kingdom for a RAM!
-
-  HOST_ARCH="HSW"
-  DEVICE_ARCH="INTEL_GEN"
-
-  EXTRA_FLAGS="-DFUSE_FLUX_KERNELS=OFF -DFUSE_EMF_KERNELS=OFF -DFUSE_FLOOR_KERNELS=OFF $EXTRA_FLAGS"
 fi
 
 if [[ $HOST == "cinnabar"* ]]; then

--- a/pars/sane2d.par
+++ b/pars/sane2d.par
@@ -20,7 +20,7 @@ nx3 = 1
 
 <coordinates>
 base = spherical_ks
-transform = mks
+transform = fmks
 r_out = 50
 a = 0.9375
 hslope = 0.3
@@ -30,6 +30,7 @@ poly_alpha = 14.0
 
 <parthenon/time>
 tlim = 3000.0
+nlim = -1
 
 <debug>
 verbose = 1

--- a/tests/restart/run.sh
+++ b/tests/restart/run.sh
@@ -12,6 +12,8 @@ $KHARMADIR/run.sh -i $KHARMADIR/pars/sane.par parthenon/time/nlim=5
 
 mv torus.out0.final.phdf torus.out0.final.init.phdf
 
+sleep 1
+
 $KHARMADIR/run.sh -r torus.out1.00000.rhdf parthenon/time/nlim=5
 
 mv torus.out0.final.phdf torus.out0.final.restart.phdf


### PR DESCRIPTION
This branch fixes a couple of things:
1. Remaining MPI crashes due to allocating communicators.
2. Implicit stepping now exits when *max* L1 is less than the converged value.  We may want per-zone...
3. Reductions when no B field is present will no longer attempt access & crash

And makes a couple of changes, which I *think* are fixes:
1. All problems are initialized over the "interior" domain only, relying on the initial boundary sync to fill ghost zones
2. pflags are recorded if *either* the initial UtoP inversion fails *or* the inversion after (normal-observer frame) floors fails.  This prevents adding floors based on bad primitive state, which nevertheless produce a physical (but very unstable) state once applied.