### PR TITLE
Add embedding-coordinate geometry functions & output

### DIFF
--- a/kharma/coordinates/coordinate_embedding.hpp
+++ b/kharma/coordinates/coordinate_embedding.hpp
@@ -271,15 +271,32 @@ class CoordinateEmbedding {
             return mpark::holds_alternative<CartMinkowskiCoords>(base) && mpark::holds_alternative<NullTransform>(transform);
         }
 
-        // Spell out the interface we take from BaseCoords
-        // TODO add a gcon_embed, gdet_embed
+        // Note this is the one thing we need from BaseCoords
         KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
         {
             mpark::visit( [&Xembed, &gcov](const auto& self) {
                 self.gcov_embed(Xembed, gcov);
             }, base);
         }
-        // and from the Transform
+        // All the quantities we can derive from that
+        KOKKOS_INLINE_FUNCTION Real gcon_from_gcov(const Real gcov[GR_DIM][GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
+        {
+            Real gdet = invert(&gcov[0][0], &gcon[0][0]);
+            return m::sqrt(m::abs(gdet));
+        }
+        KOKKOS_INLINE_FUNCTION Real gcon_embed(const GReal Xembed[GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
+        {
+            GReal gcov[GR_DIM][GR_DIM];
+            gcov_embed(Xembed, gcov);
+            return gcon_from_gcov(gcov, gcon);
+        }
+        KOKKOS_INLINE_FUNCTION Real gdet_embed(const GReal Xembed[GR_DIM]) const
+        {
+            GReal gcon[GR_DIM][GR_DIM];
+            return gcon_embed(Xembed, gcon);
+        }
+
+        // Now, everything we take from CoordinateTransform
         KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
         {
             mpark::visit( [&Xnative, &Xembed](const auto& self) {
@@ -484,18 +501,12 @@ class CoordinateEmbedding {
         {
             Real gcov[GR_DIM][GR_DIM];
             gcov_native(X, gcov);
-            return gcon_native(gcov, gcon);
-        }
-        KOKKOS_INLINE_FUNCTION Real gcon_native(const Real gcov[GR_DIM][GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
-        {
-            Real gdet = invert(&gcov[0][0], &gcon[0][0]);
-            return m::sqrt(m::abs(gdet));
+            return gcon_from_gcov(gcov, gcon);
         }
         KOKKOS_INLINE_FUNCTION Real gdet_native(const GReal X[GR_DIM]) const
         {
-            Real gcov[GR_DIM][GR_DIM], gcon[GR_DIM][GR_DIM];
-            gcov_native(X, gcov);
-            return gcon_native(gcov, gcon);
+            Real gcon[GR_DIM][GR_DIM];
+            return gcon_native(X, gcon);
         }
 
         KOKKOS_INLINE_FUNCTION void conn_native(const GReal X[GR_DIM], const GReal delta, Real conn[GR_DIM][GR_DIM][GR_DIM]) const

--- a/kharma/coordinates/gr_coordinates.cpp
+++ b/kharma/coordinates/gr_coordinates.cpp
@@ -145,7 +145,7 @@ void init_GRCoordinates(GRCoordinates& G) {
                             // Get geometry at points
                             GReal gcov_loc[GR_DIM][GR_DIM], gcon_loc[GR_DIM][GR_DIM];
                             G.coords.gcov_native(X, gcov_loc);
-                            const GReal gdet = G.coords.gcon_native(gcov_loc, gcon_loc);
+                            const GReal gdet = G.coords.gcon_from_gcov(gcov_loc, gcon_loc);
                             // Add to running averages
                             gdet_local(loc, j, i) += gdet / square;
                             DLOOP2 {
@@ -177,7 +177,7 @@ void init_GRCoordinates(GRCoordinates& G) {
                         // Get geometry at the point
                         GReal gcov_loc[GR_DIM][GR_DIM], gcon_loc[GR_DIM][GR_DIM];
                         G.coords.gcov_native(X, gcov_loc);
-                        const GReal gdet = G.coords.gcon_native(gcov_loc, gcon_loc);
+                        const GReal gdet = G.coords.gcon_from_gcov(gcov_loc, gcon_loc);
                         // Add to running averages
                         gdet_local(loc, j, i) += gdet / diameter;
                         DLOOP2 {
@@ -192,7 +192,7 @@ void init_GRCoordinates(GRCoordinates& G) {
                     // Get geometry
                     GReal gcov_loc[GR_DIM][GR_DIM], gcon_loc[GR_DIM][GR_DIM];
                     G.coords.gcov_native(X, gcov_loc);
-                    const GReal gdet = G.coords.gcon_native(gcov_loc, gcon_loc);
+                    const GReal gdet = G.coords.gcon_from_gcov(gcov_loc, gcon_loc);
                     // Set geometry
                     gdet_local(loc, j, i) = gdet;
                     DLOOP2 {

--- a/pars/tori_2d/sane2d.par
+++ b/pars/tori_2d/sane2d.par
@@ -98,10 +98,11 @@ dt = 0.1
 # a bunch of other contexts.
 <parthenon/output3>
 file_type = hdf5
+analysis_output = true
 dt = 1e20
 single_precision_output = false
 # If you want the convenience and hate disk space, you can add these
 # variables to "normal" dump files like output0 too.
 variables = coords.Xnative, coords.Xsph, &
-            coords.gcon, coords.gcov, coords.gdet, coords.lapse, &
-            coords.conn
+            coords.gcon, coords.gcov, coords.gdet, coords.lapse, coords.conn, &
+            coords.gcon_embed, coords.gcov_embed, coords.gdet_embed


### PR DESCRIPTION
This PR adds functions for the metric in whatever the embedding coordinate system is. `gcov_embed` was already present, but we add `gcon_embed` and `gdet_embed` for completeness.  Note we don't *cache* these, just add the functions for user/package code.

Also added the option to output the `_embed` versions when creating coordinate/geometry outputs, which might be useful for new/complex metrics which may be a pain to re-create in code reading the files.