### PR TITLE
Coordinate system output

### DIFF
--- a/kharma/coordinates/coordinate_embedding.hpp
+++ b/kharma/coordinates/coordinate_embedding.hpp
@@ -231,6 +231,10 @@ class CoordinateEmbedding {
                 return self.spherical;
             }, base);
         }
+        KOKKOS_INLINE_FUNCTION bool is_transformed() const
+        {
+            return !mpark::holds_alternative<NullTransform>(transform);
+        }
         KOKKOS_INLINE_FUNCTION GReal get_horizon() const
         {
             if (mpark::holds_alternative<SphKSCoords>(base) ||

--- a/kharma/coordinates/gr_coordinates.hpp
+++ b/kharma/coordinates/gr_coordinates.hpp
@@ -135,6 +135,18 @@ public:
         return *this;
     };
 
+    // Correct the coordinate system name for outputs.
+    // So far the only override we need.
+    const char *Name() const {
+        if (coords.is_spherical()) {
+            return "TransformedSpherical";
+        } else if (coords.is_transformed()) {
+            return "TransformedCartesian";
+        } else {
+            return "UniformCartesian";
+        }
+    }
+
     // TODO Test these vs going all-in on full-matrix versions and computing on the fly
     KOKKOS_INLINE_FUNCTION Real gcon(const Loci loc, const int& j, const int& i, const int mu, const int nu) const;
     KOKKOS_INLINE_FUNCTION Real gcov(const Loci loc, const int& j, const int& i, const int mu, const int nu) const;


### PR DESCRIPTION
Previously, when calling `Name()` GRCoordinates would report `"UniformCartesian"` rather than its own name or a descriptive one.  This has never been a problem before, as specifics were recorded with the ParameterInput contents -- however, to help in distinguishing KHARMA and its coordinate systems in e.g. a generic Parthenon parser, the recorded coordinate system name should reflect what's really being used.

Thus KHARMA will now report `TransformedSpherical` for any spherical systems (even if no transform is applied, this naming will help to avoid collisions with AthenaPK's spherical coordinates, which are implemented very differently).  The specific transform can always be read from the input, since a parser can now assume the file is from KHARMA or follows its conventions.

If we implement snake coordinates in future they will be `TransformedCartesian` automatically, and normal Cartesian coordinates can continue reporting as `UniformCartesian`and be treated correctly.