### PR TITLE
Fix face_ct with Bondi initialization/boundaries

### DIFF
--- a/kharma/boundaries/dirichlet.hpp
+++ b/kharma/boundaries/dirichlet.hpp
@@ -37,12 +37,14 @@
 
 namespace KBoundaries {
 
-void DirichletImpl(std::shared_ptr<MeshBlockData<Real>> &rc, BoundaryFace bface, bool coarse);
+void DirichletImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse, bool set);
+void DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> q, std::string prefix,
+                                        BoundaryFace bface, bool coarse, bool set, bool do_face);
 
 template <BoundaryFace bface>
-void Dirichlet(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
+inline void Dirichlet(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
 {
-    DirichletImpl(rc, bface, coarse);
+    DirichletImpl(rc.get(), bface, coarse, false);
 }
 
 /**
@@ -51,6 +53,10 @@ void Dirichlet(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
 void FreezeDirichlet(std::shared_ptr<MeshData<Real>> &md);
 void FreezeDirichletBlock(MeshBlockData<Real> *rc);
 
-void SetDomainDirichlet(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+inline void SetDomainDirichlet(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+{
+    auto bface = KBoundaries::BoundaryFaceOf(domain);
+    DirichletImpl(rc, bface, coarse, true);
+}
 
 }

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -107,6 +107,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
     // Indices
     // TODO handle filling faces with domain < entire more gracefully
     IndexRange3 b = KDomain::GetRange(rc, domain);
+    IndexRange3 bf = KDomain::GetRange(rc, domain, 0, 1);
     int ndim = pmb->pmy_mesh->ndim;
 
     // Shortcut to field values for easy fields
@@ -138,7 +139,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
             auto B_Uf = rc->PackVariables(std::vector<std::string>{"cons.fB"});
             // Fill at 3 different locations
             pmb->par_for(
-                "B_field_B", b.ks, b.ke, b.js, b.je, b.is, b.ie,
+                "B_field_B", bf.ks, bf.ke, bf.js, bf.je, bf.is, bf.ie,
                 KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
                     GReal Xembed[GR_DIM];
                     double null1, null2;
@@ -243,7 +244,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
         IndexSize3 sz = KDomain::GetBlockSize(rc);
         ParArrayND<double> A("A", NVEC, sz.n3+1, sz.n2+1, sz.n1+1);
         pmb->par_for(
-            "B_field_A", b.ks, b.ke+1, b.js, b.je+1, b.is, b.ie+1,
+            "B_field_A", bf.ks, bf.ke, bf.js, bf.je, bf.is, bf.ie,
             KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
                 GReal Xnative[GR_DIM];
                 GReal Xembed[GR_DIM], Xmidplane[GR_DIM];

--- a/pars/bondi/bondi.par
+++ b/pars/bondi/bondi.par
@@ -71,7 +71,7 @@ file_type = hdf5
 dt = 5.0
 single_precision_output = true
 # Fields not present are silently ignored
-variables = prims.rho, prims.u, prims.uvec, pflag
+variables = prims, pflag
 
 <parthenon/output1>
 file_type = hst

--- a/pars/bondi/bondi_1d.par
+++ b/pars/bondi/bondi_1d.par
@@ -67,7 +67,7 @@ check_inflow_outer_x1 = false
 type = none
 solver = none
 # To add magnetic field
-#type = monopole
+#type = monopole_cube
 #B10 = 1
 # Or
 #type = vertical

--- a/pars/bondi/bondi_b.par
+++ b/pars/bondi/bondi_b.par
@@ -33,7 +33,7 @@ gamma = 1.666667
 reconstruction = weno5
 
 <b_field>
-type = monopole
+type = monopole_cube
 B10 = 1
 
 <bondi>

--- a/pars/bondi/bondi_b.par
+++ b/pars/bondi/bondi_b.par
@@ -19,7 +19,7 @@ nx3 = 1
 
 <coordinates>
 base = ks
-transform = fmks
+transform = mks
 a = 0.0
 hslope = 0.3
 r_out = 30

--- a/pars/bondi/bondi_b_face.par
+++ b/pars/bondi/bondi_b_face.par
@@ -34,7 +34,7 @@ reconstruction = weno5
 
 <b_field>
 solver = face_ct
-type = monopole
+type = monopole_cube
 B10 = 1
 
 <bondi>

--- a/pars/bondi/bondi_b_face.par
+++ b/pars/bondi/bondi_b_face.par
@@ -19,7 +19,7 @@ nx3 = 1
 
 <coordinates>
 base = ks
-transform = fmks
+transform = mks
 a = 0.0
 hslope = 0.3
 r_out = 30

--- a/pars/bondi/bondi_b_face.par
+++ b/pars/bondi/bondi_b_face.par
@@ -33,6 +33,7 @@ gamma = 1.666667
 reconstruction = weno5
 
 <b_field>
+solver = face_ct
 type = monopole
 B10 = 1
 

--- a/pars/electrons/driven_turbulence.par
+++ b/pars/electrons/driven_turbulence.par
@@ -43,7 +43,7 @@ add_jcon = false
 
 <b_field>
 type = constant
-b10 = 1
+B10 = 1
 norm = true
 beta_min = 10
 

--- a/pars/tests/explosion.par
+++ b/pars/tests/explosion.par
@@ -57,7 +57,7 @@ gamma_max = 10
 
 <b_field>
 type = constant
-b10 = 1.0
+B10 = 1.0
 
 <parthenon/output0>
 file_type = hdf5

--- a/pars/tests/kelvin_helmholtz.par
+++ b/pars/tests/kelvin_helmholtz.par
@@ -81,8 +81,8 @@ reconstruction = linear_mc
 
 <b_field>
 type = constant
-b10 = 1
-b20 = 1
+B10 = 1
+B20 = 1
 solver = face_ct
 kill_on_large_divb = true
 ct_scheme = bs99

--- a/tests/bondi/run.sh
+++ b/tests/bondi/run.sh
@@ -51,8 +51,12 @@ conv_2d linear_mc GRMHD/reconstruction=linear_mc "in 2D, linear recon with MC li
 conv_2d imex driver/type=imex "in 2D, with Imex driver"
 conv_2d imex_im "driver/type=imex GRMHD/implicit=true" "in 2D, semi-implicit stepping"
 
-conv_2d b_flux_ct "b_field/type=monopole b_field/B10=1" "in 2D, monopole B field"
-conv_2d b_face_ct "b_field/type=monopole b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered"
+ALL_RES="16,24,32,48,64"
+conv_2d b_flux_ct "b_field/type=monopole_cube b_field/B10=1 b_field/solver=flux_ct" "in 2D, monopole B field"
+conv_2d b_face_ct "b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered"
+
+ALL_RES="24,32,48,64" # TODO idk why this doesn't work at 16^2
+conv_2d b_face_ct "boundaries/inner_x1=dirichlet boundaries/outer_x1=dirichlet b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered+Dirichlet"
 
 # TODO 3D?
 

--- a/tests/bondi/run.sh
+++ b/tests/bondi/run.sh
@@ -51,6 +51,9 @@ conv_2d linear_mc GRMHD/reconstruction=linear_mc "in 2D, linear recon with MC li
 conv_2d imex driver/type=imex "in 2D, with Imex driver"
 conv_2d imex_im "driver/type=imex GRMHD/implicit=true" "in 2D, semi-implicit stepping"
 
-# TODO 3D, esp magnetized w/flux, face CT
+conv_2d b_flux_ct "b_field/type=monopole b_field/B10=1" "in 2D, monopole B field"
+conv_2d b_face_ct "b_field/type=monopole b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered"
+
+# TODO 3D?
 
 exit $exit_code


### PR DESCRIPTION
There was a segfault previously when running magnetized Bondi problems with face_ct fields, as the function to set Bondi conditions didn't expect to be called during e.g. the EMF synchronization.

This PR as-is fixes the segfault and introduces magnetized Bondi flow regression tests.  However, they fail because there are still 2 issues with the Bondi/Face-CT combination:
1. The Bondi problem boundary function implementation does not set magnetic fields except for the very special case of the viscous_bondi test problem.
2. The Dirichlet boundaries do not handle face-centered fields at all

These will take a bit to fix, hence posting a PR.