### PR TITLE
WIP: Fix Dirichlet boundaries on faces

### DIFF
--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -129,8 +129,6 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
             const int nx3 = pin->GetInteger("parthenon/meshblock", "nx3");
             const int n3_f = (nx3 == 1) ? nx3 : nx3 + 2 * ng + 1;
 
-            std::cerr << "Face fluid vars: " << nvar_f << std::endl;
-
             // These are declared *backward* from how they will be indexed
             std::vector<int> s_x1_f({ng_f, n2_f, n3_f, nvar_f});
             std::vector<int> s_x2_f({n1_f, ng_f, n3_f, nvar_f});

--- a/kharma/boundaries/dirichlet.hpp
+++ b/kharma/boundaries/dirichlet.hpp
@@ -37,8 +37,9 @@
 
 namespace KBoundaries {
 
+// TODO(BSP) privatize probably
 void DirichletImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse, bool set);
-void DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> q, std::string prefix,
+void DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> &q, VariablePack<Real> &bound,
                                         BoundaryFace bface, bool coarse, bool set, bool do_face);
 
 template <BoundaryFace bface>

--- a/kharma/domain.hpp
+++ b/kharma/domain.hpp
@@ -101,32 +101,37 @@ inline const IndexShape& GetCellbounds(std::shared_ptr<MeshData<T>> md, bool coa
  * This seemed more natural for people coming from for loops.
  */
 template<typename T>
-inline IndexRange3 GetRange(T data, IndexDomain domain, int left_halo=0, int right_halo=0, bool coarse=false)
+inline IndexRange3 GetRange(T data, IndexDomain domain, TopologicalElement el=CC, int left_halo=0, int right_halo=0, bool coarse=false)
 {
     // TODO also offsets for e.g. PtoU_Send?
     // Get sizes
     const auto& cellbounds = GetCellbounds(data, coarse);
-    const IndexRange ib = cellbounds.GetBoundsI(domain);
-    const IndexRange jb = cellbounds.GetBoundsJ(domain);
-    const IndexRange kb = cellbounds.GetBoundsK(domain);
+    const IndexRange ib = cellbounds.GetBoundsI(domain, el);
+    const IndexRange jb = cellbounds.GetBoundsJ(domain, el);
+    const IndexRange kb = cellbounds.GetBoundsK(domain, el);
     // Compute sizes with specified halo zones included in non-trivial dimensions
-    // TODO notion of activated x1+x3 with nx2==0?
+    // TODO support arbitrary trivial directions
     const int& ndim = GetNDim(data);
     const IndexRange il = IndexRange{ib.s + left_halo, ib.e + right_halo};
     const IndexRange jl = (ndim > 1) ? IndexRange{jb.s + left_halo, jb.e + right_halo} : jb;
     const IndexRange kl = (ndim > 2) ? IndexRange{kb.s + left_halo, kb.e + right_halo} : kb;
     // Bounds of entire domain, we never mean to go beyond these
-    const IndexRange ibe = cellbounds.GetBoundsI(IndexDomain::entire);
-    const IndexRange jbe = cellbounds.GetBoundsJ(IndexDomain::entire);
-    const IndexRange kbe = cellbounds.GetBoundsK(IndexDomain::entire);
+    const IndexRange ibe = cellbounds.GetBoundsI(IndexDomain::entire, el);
+    const IndexRange jbe = cellbounds.GetBoundsJ(IndexDomain::entire, el);
+    const IndexRange kbe = cellbounds.GetBoundsK(IndexDomain::entire, el);
     return IndexRange3{(uint) m::max(il.s, ibe.s), (uint) m::min(il.e, ibe.e),
                        (uint) m::max(jl.s, jbe.s), (uint) m::min(jl.e, jbe.e),
                        (uint) m::max(kl.s, kbe.s), (uint) m::min(kl.e, kbe.e)};
 }
 template<typename T>
+inline IndexRange3 GetRange(T data, IndexDomain domain, int left_halo, int right_halo, bool coarse=false)
+{
+    return GetRange(data, domain, CC, left_halo, right_halo, coarse);
+}
+template<typename T>
 inline IndexRange3 GetRange(T data, IndexDomain domain, bool coarse)
 {
-    return GetRange(data, domain, 0, 0, coarse);
+    return GetRange(data, domain, CC, 0, 0, coarse);
 }
 /**
  * Get zones which are inside the physical domain, i.e. set by computation or MPI halo sync,

--- a/tests/bondi/run.sh
+++ b/tests/bondi/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+\#!/bin/bash
 set -euo pipefail
 
 BASE=../..
@@ -56,7 +56,7 @@ conv_2d b_flux_ct "b_field/type=monopole_cube b_field/B10=1 b_field/solver=flux_
 conv_2d b_face_ct "b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered"
 
 ALL_RES="24,32,48,64" # TODO idk why this doesn't work at 16^2
-conv_2d b_face_ct "boundaries/inner_x1=dirichlet boundaries/outer_x1=dirichlet b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered+Dirichlet"
+conv_2d b_face_ct_dirichlet "boundaries/inner_x1=dirichlet boundaries/outer_x1=dirichlet b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered+Dirichlet"
 
 # TODO 3D?
 


### PR DESCRIPTION
This properly iterates through face-centered fields when applying Dirichlet boundaries.

It also switches most loops over to `par_for` from `par_for_bndry` as this is easier to understand and more flexible.  To accommodate this, I also added a TopologicalElement argument to `GetRange`, which allows asking for e.g. the boundary range for faces, vs for cells.

However, this potentially disrupts boundary conditions everywhere, so I'm going to let it sit here and give it some testing before merging.