### PR TITLE
Fix/quash solver nans

### DIFF
--- a/kharma/boundaries/dirichlet.hpp
+++ b/kharma/boundaries/dirichlet.hpp
@@ -37,8 +37,9 @@
 
 namespace KBoundaries {
 
+// TODO(BSP) privatize probably
 void DirichletImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse, bool set);
-void DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> q, std::string prefix,
+void DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> &q, VariablePack<Real> &bound,
                                         BoundaryFace bface, bool coarse, bool set, bool do_face);
 
 template <BoundaryFace bface>

--- a/kharma/domain.hpp
+++ b/kharma/domain.hpp
@@ -101,32 +101,37 @@ inline const IndexShape& GetCellbounds(std::shared_ptr<MeshData<T>> md, bool coa
  * This seemed more natural for people coming from for loops.
  */
 template<typename T>
-inline IndexRange3 GetRange(T data, IndexDomain domain, int left_halo=0, int right_halo=0, bool coarse=false)
+inline IndexRange3 GetRange(T data, IndexDomain domain, TopologicalElement el=CC, int left_halo=0, int right_halo=0, bool coarse=false)
 {
     // TODO also offsets for e.g. PtoU_Send?
     // Get sizes
     const auto& cellbounds = GetCellbounds(data, coarse);
-    const IndexRange ib = cellbounds.GetBoundsI(domain);
-    const IndexRange jb = cellbounds.GetBoundsJ(domain);
-    const IndexRange kb = cellbounds.GetBoundsK(domain);
+    const IndexRange ib = cellbounds.GetBoundsI(domain, el);
+    const IndexRange jb = cellbounds.GetBoundsJ(domain, el);
+    const IndexRange kb = cellbounds.GetBoundsK(domain, el);
     // Compute sizes with specified halo zones included in non-trivial dimensions
-    // TODO notion of activated x1+x3 with nx2==0?
+    // TODO support arbitrary trivial directions
     const int& ndim = GetNDim(data);
     const IndexRange il = IndexRange{ib.s + left_halo, ib.e + right_halo};
     const IndexRange jl = (ndim > 1) ? IndexRange{jb.s + left_halo, jb.e + right_halo} : jb;
     const IndexRange kl = (ndim > 2) ? IndexRange{kb.s + left_halo, kb.e + right_halo} : kb;
     // Bounds of entire domain, we never mean to go beyond these
-    const IndexRange ibe = cellbounds.GetBoundsI(IndexDomain::entire);
-    const IndexRange jbe = cellbounds.GetBoundsJ(IndexDomain::entire);
-    const IndexRange kbe = cellbounds.GetBoundsK(IndexDomain::entire);
+    const IndexRange ibe = cellbounds.GetBoundsI(IndexDomain::entire, el);
+    const IndexRange jbe = cellbounds.GetBoundsJ(IndexDomain::entire, el);
+    const IndexRange kbe = cellbounds.GetBoundsK(IndexDomain::entire, el);
     return IndexRange3{(uint) m::max(il.s, ibe.s), (uint) m::min(il.e, ibe.e),
                        (uint) m::max(jl.s, jbe.s), (uint) m::min(jl.e, jbe.e),
                        (uint) m::max(kl.s, kbe.s), (uint) m::min(kl.e, kbe.e)};
 }
 template<typename T>
+inline IndexRange3 GetRange(T data, IndexDomain domain, int left_halo, int right_halo, bool coarse=false)
+{
+    return GetRange(data, domain, CC, left_halo, right_halo, coarse);
+}
+template<typename T>
 inline IndexRange3 GetRange(T data, IndexDomain domain, bool coarse)
 {
-    return GetRange(data, domain, 0, 0, coarse);
+    return GetRange(data, domain, CC, 0, 0, coarse);
 }
 /**
  * Get zones which are inside the physical domain, i.e. set by computation or MPI halo sync,

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -538,7 +538,11 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
                                 solve_norm()        = m::sqrt(solve_norm()); // TODO faster to scratch cache & copy?
 
                                 // Did we converge to required tolerance? If not, update solve_fail accordingly
-                                if (solve_norm() > rootfind_tol) {
+                                if (isnan(solve_norm())) {
+                                    // Unrecoverable
+                                    solve_fail() = SolverStatus::fail;
+                                    FLOOP P_solver(ip) = P_sub_step_init(ip);
+                                } else if (solve_norm() > rootfind_tol) {
                                     solve_fail() = SolverStatus::beyond_tol; // TODO was changed from +=. Valid?
                                 }
                             }

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -64,8 +64,8 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
 
     const auto& pars = pmb->packages.Get("GRMHD")->AllParams();
     const Real gam = pars.Get<Real>("gamma");
+
     // Only yell about neighbors on extreme verbosity.
-    // 
     const int flag_verbose = pmb->packages.Get("Globals")->Param<int>("flag_verbose");
 
     // UtoP is applied and fixed over all "Physical" zones -- anything in the domain,
@@ -112,7 +112,6 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
                     if (flag_verbose >= 3)
                         printf("No neighbors were available at %d %d %d!\n", i, j, k);
 #endif
-                    // TODO is there a situation in which this shadow is useful, or do we ditch it?
                     PRIMLOOP P(p, k, j, i) = sum_x[p]/wsum_x;
                 } else {
                     PRIMLOOP P(p, k, j, i) = sum[p]/wsum;

--- a/tests/bondi/run.sh
+++ b/tests/bondi/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+\#!/bin/bash
 set -euo pipefail
 
 BASE=../..
@@ -56,7 +56,7 @@ conv_2d b_flux_ct "b_field/type=monopole_cube b_field/B10=1 b_field/solver=flux_
 conv_2d b_face_ct "b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered"
 
 ALL_RES="24,32,48,64" # TODO idk why this doesn't work at 16^2
-conv_2d b_face_ct "boundaries/inner_x1=dirichlet boundaries/outer_x1=dirichlet b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered+Dirichlet"
+conv_2d b_face_ct_dirichlet "boundaries/inner_x1=dirichlet boundaries/outer_x1=dirichlet b_field/type=monopole_cube b_field/B10=1 b_field/solver=face_ct" "in 2D, monopole B, face-centered+Dirichlet"
 
 # TODO 3D?
 


### PR DESCRIPTION
This prevents at least one reproducible catastrophic event wherein a NaN returned from the solver would not be marked for cleanup, and would proceed to destroy the whole simulation.

The ideal would obviously be to just... not return NaN from the solver.  But this was faster than diving into the Kokkos kernels again, and I think this is acceptable for initial runs, as any zone which would return NaN from the solver is probably going to need to be fixed/replaced with the average of neighbors in any case.  The fixup rate is already high, because solving for primitive variables like this is just hard, so making a potentially preventable fixup every 1e9+ zone updates doesn't seem like a top priority.

This can go in as soon as #63 does, probably next few days since that one's passed tests and seems to be working at scale so far.