### PR TITLE
Delta compile with Slingshot 11 and new module stack

### DIFF
--- a/machines/delta.sh
+++ b/machines/delta.sh
@@ -29,7 +29,7 @@ then
     EXTRA_FLAGS="-DPARTHENON_ENABLE_HOST_COMM_BUFFERS=ON $EXTRA_FLAGS"
 
     # Load common GPU modules
-    module load modtree/gpu cmake
+    module load gcc/11.4.0 cuda/11.8.0  openmpi/4.1.5+cuda
 
     if [[ $ARGS == *"latest"* ]]; then
       # nvhpc only on request, MPI crashes


### PR DESCRIPTION
NCSA Delta recently upgraded their network to Slingshot 11 and also the accompanying software/module stack. They have done away with preloaded module environments `modtree/cpu`/`modtree/gpu` for CPU/GPUs and instead require manually loading compilers, MPI and cuda modules. This PR reflects these changes.

There are alternate versions of `GCC`, `cuda` and `openmpi` available in the software stack that MAY provide a performance improvement (if those versions get along well), but I haven't played with that yet. This PR is more need-of-the-hour for others who are running KHARMA on Delta.