### PR TITLE
Revert Kokkos by default

### DIFF
--- a/external/kokkos-kernels/KokkosBatched_Util.hpp
+++ b/external/kokkos-kernels/KokkosBatched_Util.hpp
@@ -772,8 +772,8 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
 }
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
-                                            Kokkos::ALL_t i2,
-                                            Kokkos::ALL_t i3,
+                                            Kokkos::Impl::ALL_t i2,
+                                            Kokkos::Impl::ALL_t i3,
                                             const BatchLayout::Left &layout_tag,
                                             const Trans::Transpose) {
   auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
@@ -805,7 +805,7 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
 }
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
-    ViewType v, IdxType1 i1, Kokkos::ALL_t i2, Kokkos::ALL_t i3,
+    ViewType v, IdxType1 i1, Kokkos::Impl::ALL_t i2, Kokkos::Impl::ALL_t i3,
     const BatchLayout::Right &layout_tag, const Trans::Transpose &) {
   auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
 

--- a/make.sh
+++ b/make.sh
@@ -308,8 +308,13 @@ if [[ "$ARGS" == *"clean"* ]]; then
       git apply ../patches/variant-hip.patch
     fi
     cd -
-  fi
 
+    # HIP also prefers new Kokkos.
+    # TODO work something out if on HIP machines w/o internet
+    cd external/parthenon
+    git submodule update --remote external/Kokkos
+    cd -
+  fi
 
   rm -rf build
 fi


### PR DESCRIPTION
The device-side MPI buffer issue #46 turned out to be a Kokkos issue in version 4.2+.  Rather than be a good citizen and chase it down to try to report coherently, I am for now simply reverting to 4.0.01.

I would use 4.1, but there's an unrelated issue in that version which causes a crash (something about freeing scratch space).  That issue is fixed in 4.2, but...

The untested part of this PR is a facility to update to 4.2/develop when using HIP, as it doesn't suffer from this issue and benefits from latest Kokkos.  Going to at least test/play with that before merging.