### PR TITLE
Feature/device side buffers

### DIFF
--- a/external/kokkos-kernels/KokkosBatched_Util.hpp
+++ b/external/kokkos-kernels/KokkosBatched_Util.hpp
@@ -772,8 +772,8 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
 }
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
-                                            Kokkos::ALL_t i2,
-                                            Kokkos::ALL_t i3,
+                                            Kokkos::Impl::ALL_t i2,
+                                            Kokkos::Impl::ALL_t i3,
                                             const BatchLayout::Left &layout_tag,
                                             const Trans::Transpose) {
   auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
@@ -805,7 +805,7 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
 }
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
-    ViewType v, IdxType1 i1, Kokkos::ALL_t i2, Kokkos::ALL_t i3,
+    ViewType v, IdxType1 i1, Kokkos::Impl::ALL_t i2, Kokkos::Impl::ALL_t i3,
     const BatchLayout::Right &layout_tag, const Trans::Transpose &) {
   auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
 

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -538,8 +538,11 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
                                 solve_norm()        = m::sqrt(solve_norm()); // TODO faster to scratch cache & copy?
 
                                 // Did we converge to required tolerance? If not, update solve_fail accordingly
-                                if (solve_norm() > rootfind_tol) {
-                                    solve_fail() = SolverStatus::beyond_tol; // TODO was changed from +=. Valid?
+                                if (isnan(solve_norm())) {
+                                    // Unrecoverable
+                                    solve_fail() = SolverStatus::fail;
+                                } else if (solve_norm() > rootfind_tol) {
+                                    solve_fail() = SolverStatus::beyond_tol;
                                 }
                             }
                         }

--- a/machines/delta.sh
+++ b/machines/delta.sh
@@ -25,24 +25,26 @@ then
     MPI_EXTRA_ARGS="--map-by ppr:4:node:pe=16"
     MPI_NUM_PROCS=4
 
-    # Device-side buffers are broken on some Nvidia machines
-    EXTRA_FLAGS="-DPARTHENON_ENABLE_HOST_COMM_BUFFERS=ON $EXTRA_FLAGS"
+    if [[ "$ARGS" == *"hostside"* ]]; then
+      # Device-side buffers are broken on some Nvidia machines
+      EXTRA_FLAGS="-DPARTHENON_ENABLE_HOST_COMM_BUFFERS=ON $EXTRA_FLAGS"
+    fi
 
-    # Load common GPU modules
-    module load gcc/11.4.0 cuda/11.8.0  openmpi/4.1.5+cuda
-
-    if [[ $ARGS == *"latest"* ]]; then
-      # nvhpc only on request, MPI crashes
-      module load nvhpc_latest openmpi-5.0_beta
-      C_NATIVE=nvc
-      CXX_NATIVE=nvc++
-    elif [[ $ARGS == *"gcc"* ]]; then
+    if [[ $ARGS == *"gcc"* ]]; then
+      module load gcc/11.4.0 cuda/11.8.0 openmpi/4.1.5+cuda
       C_NATIVE=gcc
       CXX_NATIVE=g++
+    elif [[ $ARGS == *"cray"* ]]; then
+      module load PrgEnv-gnu cuda craype-x86-milan craype-accel-ncsa
+      export MPICH_GPU_SUPPORT_ENABLED=1
+      export MPICH_GPU_MANAGED_MEMORY_SUPPORT_ENABLED=1
+      C_NATIVE=cc
+      CXX_NATIVE=CC
     else
-      module load nvhpc_latest/22.11 openmpi
-      C_NATIVE=nvc
-      CXX_NATIVE=nvc++
+      # Default to gcc since we know that works
+      module load gcc/11.4.0 cuda/11.8.0 openmpi/4.1.5+cuda
+      C_NATIVE=gcc
+      CXX_NATIVE=g++
     fi
   else
     # CPU Compile

--- a/make.sh
+++ b/make.sh
@@ -308,8 +308,13 @@ if [[ "$ARGS" == *"clean"* ]]; then
       git apply ../patches/variant-hip.patch
     fi
     cd -
-  fi
 
+    # HIP also prefers new Kokkos.
+    # TODO work something out if on HIP machines w/o internet
+    cd external/parthenon
+    git submodule update --remote external/Kokkos
+    cd -
+  fi
 
   rm -rf build
 fi


### PR DESCRIPTION
In order to get device side buffers working on Delta, I pulled this [PR (72)](https://github.com/AFD-Illinois/kharma/pull/72). However, I messed up pushing my changes upstream and ended up creating a new branch. With the changes in `delta.sh` here, I am able to get device-side buffers working on Delta's A100s and recover most of the speed I lost when they upgraded to Slingshot 11. For single GPU jobs, it's more than just "recover", I see speed gains :)

The device-side compilation works with the `gcc` flag, but the Cray environment still gives issues. However, seeing that there is significant speed gains i.e. we can save on node-hours on Delta, I vote to merge this to stable so other users on Delta can work off this. Note that this is based on [72](https://github.com/AFD-Illinois/kharma/pull/72), which means that can be closed too once this is merged; apologies for my git-related ineptitude.