### PR TITLE
Fix some B field indices

### DIFF
--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -292,7 +292,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
         EndFlag();
     }
 
-    // Zero/invert X2 faces at polar X2 boundary
+    // Replace reflecting face values at reflecting boundaries, Parthenon messes them up
     auto fpack = rc->PackVariables({Metadata::Face, Metadata::FillGhost});
     if (bdir == X2DIR &&
         pmb->coords.coords.is_spherical() &&
@@ -311,7 +311,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
         pmb->par_for_bndry(
             "invert_F2_" + bname, IndexRange{0, fpack.GetDim(4)-1}, domain, F2, coarse,
             KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
-                fpack(F2, v, k, j, i) *= -1;
+                fpack(F2, v, k, j, i) = -fpack(F2, v, k, jf - (j-jf), i);
             }
         );
         EndFlag();

--- a/kharma/domain.hpp
+++ b/kharma/domain.hpp
@@ -60,7 +60,6 @@ KOKKOS_INLINE_FUNCTION bool inside(const int& k, const int& j, const int& i,
 }
 KOKKOS_INLINE_FUNCTION bool inside(const int& k, const int& j, const int& i, const IndexRange3& b)
 {
-    // This is faster in the case that the point is outside
     return !outside(k, j, i, b);
 }
 

--- a/kharma/prob/bondi.cpp
+++ b/kharma/prob/bondi.cpp
@@ -126,6 +126,9 @@ TaskStatus SetBondiImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain do
     auto U = GRMHD::PackMHDCons(rc.get(), cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
+    // Sometimes called when syncing EMFs, etc
+    if (P.GetDim(4) == 0) return TaskStatus::complete;
+
     const Real mdot = pmb->packages.Get("GRMHD")->Param<Real>("mdot");
     const Real rs = pmb->packages.Get("GRMHD")->Param<Real>("rs");
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
@@ -135,7 +138,6 @@ TaskStatus SetBondiImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain do
 
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
-    // Just the X1 right boundary
     GRCoordinates G = pmb->coords;
 
     // Set the Bondi conditions wherever we're asked

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -127,7 +127,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
             auto B_Uf = rc->PackVariables(std::vector<std::string>{"cons.fB"});
             // Fill at 3 different locations
             pmb->par_for(
-                "B_field_B", b.ks, b.ke, b.js, b.je, b.is, b.ie,
+                "B_field_B", be.ks, be.ke, be.js, be.je, be.is, be.ie,
                 KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
                     GReal Xembed[GR_DIM];
                     double null1, null2;

--- a/pars/bondi/bondi_b_vertical.par
+++ b/pars/bondi/bondi_b_vertical.par
@@ -47,9 +47,11 @@ disable_floors = true
 check_inflow_outer_x1 = false
 
 <b_field>
+solver = face_ct
 # Constant pure-vertical field
 type = vertical
-bz = 0.1
+A0 = 0.1
+norm = false
 
 <debug>
 verbose = 1
@@ -65,7 +67,8 @@ file_type = hdf5
 dt = 5.0
 single_precision_output = false
 # Fields not present are silently ignored
-variables = prims.rho, prims.u, prims.uvec, prims.B, pflag, divB
+variables = prims, pflag, divB, cons.fB
+ghost_zones = true
 
 <parthenon/output1>
 file_type = hst


### PR DESCRIPTION
Parthenon's reflecting conditions on face fields do not account for the odd indexing on the matching face, e.g. F2 for an X2 reflecting condition.  I will eventually also fix it in their absurdly general single boundary function, but for now I just fix it downstream.

I also try to address an issue where not all ghost zones' B fields are initialized when we compute and take the curl of the vector potential.  I think I fix all the trivial indexing issues here, but something about the last zone is being initialized incorrectly (#76).

This will have some conflicts in `dev` which I'll handle offline and force-push once we know it works in `stable`.