### PR TITLE
WIP: Attempt to fix a "rare" polar B/divB issue

### DIFF
--- a/kharma/b_ct/b_ct.cpp
+++ b/kharma/b_ct/b_ct.cpp
@@ -84,9 +84,6 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
     if (lazy_prolongation && pin->GetString("parthenon/mesh", "refinement") == "adaptive")
         throw std::runtime_error("Cannot use non-divergence-preserving prolongation in AMR!");
 
-    bool consistent_face_b = pin->GetOrAddBoolean("b_field", "consistent_face_b", true);
-    params.Add("consistent_face_b", consistent_face_b);
-
     // FIELDS
 
     // Flags for B fields on faces.

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -334,6 +334,14 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
                 }
             );
         }
+        // Remaining edge zero'd only *within* domain
+        auto b = KDomain::GetRange(rc, domain, EdgeOf(bdir), coarse);
+        pmb->par_for(
+            "zero_EMF_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                emfpack(el, 0, k, j, i) = 0;
+            }
+        );
         EndFlag();
     }
 

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -335,7 +335,8 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
             );
         }
         // Remaining edge zero'd only *within* domain
-        auto b = KDomain::GetRange(rc, domain, EdgeOf(bdir), coarse);
+        TE el = EdgeOf(bdir);
+        auto b = KDomain::GetRange(rc, domain, el, coarse);
         pmb->par_for(
             "zero_EMF_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
             KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -135,6 +135,19 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     bool reconstruction_fallback = pin->GetOrAddBoolean("flux", "reconstruction_fallback", false);
     params.Add("reconstruction_fallback", reconstruction_fallback);
 
+    // When calculating the fluxes, replace perpendicular fields (e.g. B2 at F2) with
+    // the value already present at the face
+    // Schemes universally do this, and it is very inadvisable to disable this
+    bool consistent_face_b = false;
+    if (packages->AllPackages().count("B_CT")) {
+        bool default_consistent_b = true;
+        if (pin->DoesParameterExist("b_field", "consistent_face_b")) {
+            default_consistent_b = pin->GetBoolean("b_field", "consistent_face_b");
+        }
+        consistent_face_b = pin->GetOrAddBoolean("flux", "consistent_face_b", default_consistent_b);
+        params.Add("consistent_face_b", consistent_face_b);
+    }
+
     // We can't just use GetVariables or something since there's no mesh yet.
     // That's what this function is for.
     int nvar = KHARMA::PackDimension(packages.get(), Metadata::WithFluxes);
@@ -183,6 +196,13 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
 
         bool use_source_term = pin->GetOrAddBoolean("fofc", "use_source_term", false);
         params.Add("fofc_use_source_term", use_source_term);
+
+        if (packages->AllPackages().count("B_CT")) {
+            // Use consistent B for FOFC (see above)
+            // It is mildly inadvisable to disable this
+            bool fofc_consistent_face_b = pin->GetOrAddBoolean("fofc", "consistent_face_b", consistent_face_b);
+            params.Add("fofc_consistent_face_b", fofc_consistent_face_b);
+        }
 
         // Use a custom block for fofc floors.  We now do the same for Kastaun, where we can *also* have floors
         // TODO even post-reconstruction/reconstruction fallback?

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -116,7 +116,7 @@ TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
     // With B_CT this will load the preference, without it will set face_b false and never access (empty) Bf
     // Weird but it works
     const bool face_b = (packages.AllPackages().count("B_CT") &&
-                        packages.Get("B_CT")->Param<bool>("consistent_face_b"));
+                        packages.Get("Flux")->Param<bool>("fofc_consistent_face_b"));
     const auto& Bf = md->PackVariables(std::vector<std::string>{"cons.fB"});
 
     for (int dir=1; dir <= ndim; dir++) { // TODO if(trivial_direction) etc

--- a/kharma/flux/get_flux.hpp
+++ b/kharma/flux/get_flux.hpp
@@ -212,7 +212,7 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
 
     // If we have B field on faces, we "must" replace reconstructed version with that
     // Override at user option due to unreasonable effectiveness (https://github.com/AFD-Illinois/kharma/issues/79)
-    if (pmb0->packages.AllPackages().count("B_CT") && packages.Get("B_CT")->Param<bool>("consistent_face_b")) {
+    if (pmb0->packages.AllPackages().count("B_CT") && packages.Get("Flux")->Param<bool>("consistent_face_b")) {
         const auto& Bf  = md->PackVariables(std::vector<std::string>{"cons.fB"});
         const TopologicalElement face = FaceOf(dir); // TODO probably can be constexpr, somehow
         IndexRange3 bi = KDomain::GetRange(md, IndexDomain::interior, face);

--- a/kharma/types.hpp
+++ b/kharma/types.hpp
@@ -75,6 +75,10 @@ template<typename T>
 KOKKOS_FORCEINLINE_FUNCTION TopologicalElement FaceOf(const T& dir) {
     return (dir == X1DIR) ? F1 : ((dir == X2DIR) ? F2 : F3);
 }
+template<typename T>
+KOKKOS_FORCEINLINE_FUNCTION TopologicalElement EdgeOf(const T& dir) {
+    return (dir == X1DIR) ? E1 : ((dir == X2DIR) ? E2 : E3);
+}
 
 // Struct for derived 4-vectors at a point, usually calculated and needed together
 typedef struct {


### PR DESCRIPTION
A phantom still stalks KHARMA.  In certain simulations -- so far, multi-zone, counter-rotating, and alternate metrics -- KHARMA allows an unacceptably large magnetic field divergence to accumulate at the pole.

In at least the counter-rotating case, the divergence appears not to be a transport issue, but a side effect of an unphysically large magnetic field strength -- a magnetic-only positive feedback loop that blows up next to the polar boundary, with an "checkerboarded" B1 component in the zones next to the pole.  I'd appreciate confirmation of this for the other cases.  It appears to be independent of the CT scheme used (at least among B&S '99 and S&G '07), so we can at least rule that out.  Higher floors seem to trigger it, but as a magnetic field issue it must be in the field transport, not fluid evolution.

This PR has a potential fix, but because the issue is so rare I can't exactly verify it easily.  Basically, I wasn't setting all EMF values in polar & Dirichlet boundaries to zero, only certain ones.  I'm not sure how the issue would have stemmed from what I fixed here, though, so it's likely not the full fix.  Magnetic field behavior in the very first zone in theta doesn't appear natural; but if there's an index error, it's not obvious.

Mostly this is just a place to centralize discussion and figure out what fixes it, so we can make the release and go back to not worrying about divB...