### PR TITLE
Fix transmitting polar boundary conditions

### DIFF
--- a/kharma/b_ct/b_ct.hpp
+++ b/kharma/b_ct/b_ct.hpp
@@ -1,5 +1,5 @@
 /* 
- *  File: b_flux_ct.hpp
+ *  File: b_ct.hpp
  *  
  *  BSD 3-Clause License
  *  
@@ -33,17 +33,13 @@
  */
 #pragma once
 
+#include "b_ct_functions.hpp"
 #include "decs.hpp"
-#include "grmhd_functions.hpp"
-#include "matrix.hpp"
+#include "kharma_driver.hpp"
 #include "reductions.hpp"
 #include "types.hpp"
 
-#include "kharma_driver.hpp"
-
 #include <parthenon/parthenon.hpp>
-
-#include <memory>
 
 /**
  * This physics package implements Constrained Transport of a split face-centered B field.
@@ -78,8 +74,6 @@ TaskStatus CalculateEMF(MeshData<Real> *md);
  * from the EMFs at edges.
  */
 TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
-
-// TODO UNIFY ALL THE FOLLOWING
 
 /**
  * Calculate maximum corner-centered divergence of magnetic field,
@@ -119,222 +113,26 @@ void FillOutput(MeshBlock *pmb, ParameterInput *pin);
  */
 void CalcDivB(MeshData<Real> *md, std::string divb_field_name="divB");
 
-// Device functions
-template<typename Global>
-KOKKOS_INLINE_FUNCTION Real face_div(const GRCoordinates &G, Global &v, const int &ndim, const int &k, const int &j, const int &i)
-{
-    Real du = (v(F1, 0, k, j, i + 1) * G.Volume<F1>(k, j, i + 1) - v(F1, 0, k, j, i) * G.Volume<F1>(k, j, i));
-    if (ndim > 1)
-        du += (v(F2, 0, k, j + 1, i) * G.Volume<F2>(k, j + 1, i) - v(F2, 0, k, j, i) * G.Volume<F2>(k, j, i));
-    if (ndim > 2)
-        du += (v(F3, 0, k + 1, j, i) * G.Volume<F3>(k + 1, j, i) - v(F3, 0, k, j, i) * G.Volume<F3>(k, j, i));
-    return du / G.Volume<CC>(k, j, i);
-}
+// BOUNDARY FUNCTIONS
+// Maintaining zero divergence for face fields on boundaries takes some extra work
 
-template<TE el, int NDIM>
-KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& A, const VariablePack<Real>& B_U,
-                                    const int& k, const int& j, const int& i)
-{
-    if constexpr (NDIM == 2) {
-        if constexpr (el == TE::F1) {
-            // A3,2 derivative
-            B_U(F1, 0, k, j, i) =   (A(V3, k, j + 1, i) - A(V3, k, j, i)) / G.Dxc<2>(j);
-        } else if constexpr (el == TE::F2) {
-            // A3,1 derivative;
-            B_U(F2, 0, k, j, i) = - (A(V3, k, j, i + 1) - A(V3, k, j, i)) / G.Dxc<1>(i);
-        } else if constexpr (el == TE::F3) {
-            B_U(F3, 0, k, j, i) = 0.;
-        }
-    } else if constexpr (NDIM == 3) {
-        // This version is only needed for tilted disks, i.e. where |A| != A_phi
-        // TODO TODO test a tilted disk using this code
-        if constexpr (el == TE::F1) {
-            // A3,2 derivative
-            const Real A3c2f = (A(V3, k, j + 1, i) + A(V3, k + 1, j + 1, i)) / 2;
-            const Real A3c2b = (A(V3, k, j, i)     + A(V3, k + 1, j, i)) / 2;
-            // A2,3 derivative
-            const Real A2c3f = (A(V2, k + 1, j, i) + A(V2, k + 1, j + 1, i)) / 2;
-            const Real A2c3b = (A(V2, k, j, i)     + A(V2, k, j + 1, i)) / 2;
-            B_U(F1, 0, k, j, i) = (A3c2f - A3c2b) / G.Dxc<2>(j) - (A2c3f - A2c3b) / G.Dxc<3>(k);
-        } else if constexpr (el == TE::F2) {
-            // A1,3 derivative
-            const Real A1c3f = (A(V1, k + 1, j, i) + A(V1, k + 1, j, i + 1)) / 2;
-            const Real A1c3b = (A(V1, k, j, i)     + A(V1, k, j, i + 1)) / 2;
-            // A3,1 derivative
-            const Real A3c1f = (A(V3, k, j, i + 1) + A(V3, k + 1, j, i + 1)) / 2;
-            const Real A3c1b = (A(V3, k, j, i)     + A(V3, k + 1, j, i)) / 2;
-            B_U(F2, 0, k, j, i) = (A1c3f - A1c3b) / G.Dxc<3>(k) - (A3c1f - A3c1b) / G.Dxc<1>(i);
-        } else if constexpr (el == TE::F3) {
-            // A2,1 derivative
-            const Real A2c1f = (A(V2, k, j, i + 1) + A(V2, k, j + 1, i + 1)) / 2;
-            const Real A2c1b = (A(V2, k, j, i)     + A(V2, k, j + 1, i)) / 2;
-            // A1,2 derivative
-            const Real A1c2f = (A(V1, k, j + 1, i) + A(V1, k, j + 1, i + 1)) / 2;
-            const Real A1c2b = (A(V1, k, j, i)     + A(V1, k, j, i + 1)) / 2;
-            B_U(F3, 0, k, j, i) = (A2c1f - A2c1b) / G.Dxc<1>(i) - (A1c2f - A1c2b) / G.Dxc<2>(j);
-        }
-    }
-}
+/**
+ * Don't allow EMF inside of a boundary, effectively making it a superconducting surface*
+ * Used for Dirichlet and reflecting conditions.
+ * 
+ * *mostly. I think
+ */
+void ZeroEMF(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse);
 
-template<TE el, int NDIM>
-KOKKOS_INLINE_FUNCTION void EdgeCurl(MeshBlockData<Real> *rc, const GridVector& A,
-                                     const VariablePack<Real>& B_U, IndexDomain domain)
-{
-    auto pmb = rc->GetBlockPointer();
-    const auto &G = pmb->coords;
-    IndexRange3 bB = KDomain::GetRange(rc, domain, el);
-    pmb->par_for(
-        "EdgeCurl", bB.ks, bB.ke, bB.js, bB.je, bB.is, bB.ie,
-        KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
-            B_CT::edge_curl<el, NDIM>(G, A, B_U, k, j, i);
-        }
-    );
-}
+/**
+ * Average all EMFs corresponding to the coordinate pole location, e.g. usually all E1 on X2 faces
+ */
+void AverageEMF(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse);
 
-KOKKOS_INLINE_FUNCTION Real upwind_diff(const VariableFluxPack<Real>& B_U, const VariablePack<Real>& emfc, const VariablePack<Real>& uvec,
-                                        const int& comp, const int& dir, const int& vdir,
-                                        const int& k, const int& j, const int& i, const bool& left_deriv)
-{
-    // See SG09 eq 23
-    // Upwind based on vel(vdir) at the left face in vdir (contact mode)
-    TopologicalElement face = FaceOf(vdir);
-    const Real contact_vel = uvec(face, vdir-1, k, j, i);
-    // Upwind by one zone in dir
-    const int i_up = (vdir == 1) ? i - 1 : i;
-    const int j_up = (vdir == 2) ? j - 1 : j;
-    const int k_up = (vdir == 3) ? k - 1 : k;
-    // Sign for transforming the flux to EMF, based on directions
-    const int emf_sign = antisym(comp-1, dir-1, vdir-1);
-
-    // If we're actually taking the derivative at -3/4, back up which center we use,
-    // and reverse the overall sign
-    const int i_cent = (left_deriv && dir == 1) ? i - 1 : i;
-    const int j_cent = (left_deriv && dir == 2) ? j - 1 : j;
-    const int k_cent = (left_deriv && dir == 3) ? k - 1 : k;
-    const int i_cent_up = (left_deriv && dir == 1) ? i_up - 1 : i_up;
-    const int j_cent_up = (left_deriv && dir == 2) ? j_up - 1 : j_up;
-    const int k_cent_up = (left_deriv && dir == 3) ? k_up - 1 : k_up;
-    const int return_sign = (left_deriv) ? -1 : 1;
-
-
-    // TODO calculate offsets once somehow?
-
-    if (contact_vel > 0) {
-        // Forward: difference at i
-        return return_sign * (emfc(comp-1, k_cent, j_cent, i_cent) + emf_sign * B_U.flux(dir, vdir-1, k, j, i));
-    } else if (contact_vel < 0) {
-        // Back: difference at i-1
-        return return_sign * (emfc(comp-1, k_cent_up, j_cent_up, i_cent_up) + emf_sign * B_U.flux(dir, vdir-1, k_up, j_up, i_up));
-    } else {
-        // Half and half
-        return return_sign*0.5*(emfc(comp-1, k_cent, j_cent, i_cent) + emf_sign * B_U.flux(dir, vdir-1, k, j, i) +
-                    emfc(comp-1, k_cent_up, j_cent_up, i_cent_up) + emf_sign * B_U.flux(dir, vdir-1, k_up, j_up, i_up));
-    }
-}
-
-// Only through formatting has the following been made even a little comprehensible.
-
-template<int diff_face, int diff_side, int offset, int DIM>
-KOKKOS_FORCEINLINE_FUNCTION Real F(const ParArrayND<Real, VariableState> &fine, const Coordinates_t &coords, int l, int m, int n, int fk, int fj, int fi)
-{
-    // Trivial directions
-    if constexpr (diff_face+1 > DIM)
-        return 0.;
-    // TODO compile-time error on misuse? (diff_face == diff_side etc)
-    constexpr int df_is_k = 2*(diff_face == V3 && DIM > 2);
-    constexpr int df_is_j = 2*(diff_face == V2 && DIM > 1);
-    constexpr int df_is_i = 2*(diff_face == V1 && DIM > 0);
-    constexpr int ds_is_k = (diff_side == V3 && DIM > 2);
-    constexpr int ds_is_j = (diff_side == V2 && DIM > 1);
-    constexpr int ds_is_i = (diff_side == V1 && DIM > 0);
-    constexpr int of_is_k = (offset == V3 && DIM > 2);
-    constexpr int of_is_j = (offset == V2 && DIM > 1);
-    constexpr int of_is_i = (offset == V1 && DIM > 0);
-    return fine(diff_face, l, m, n,  fk+df_is_k+ds_is_k+of_is_k, fj+df_is_j+ds_is_j+of_is_j, fi+df_is_i+ds_is_i+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+df_is_k+ds_is_k+of_is_k, fj+df_is_j+ds_is_j+of_is_j, fi+df_is_i+ds_is_i+of_is_i)
-         - fine(diff_face, l, m, n,  fk+ds_is_k+of_is_k        , fj+ds_is_j+of_is_j        , fi+ds_is_i+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+ds_is_k+of_is_k        , fj+ds_is_j+of_is_j        , fi+ds_is_i+of_is_i)
-         - fine(diff_face, l, m, n,  fk+df_is_k+of_is_k        , fj+df_is_j+of_is_j        , fi+df_is_i+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+df_is_k+of_is_k        , fj+df_is_j+of_is_j        , fi+df_is_i+of_is_i)
-         + fine(diff_face, l, m, n,  fk+of_is_k                , fj+of_is_j                , fi+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+of_is_k                , fj+of_is_j                , fi+of_is_i);
-}
-
-struct ProlongateInternalOlivares {
-  static constexpr bool OperationRequired(TopologicalElement fel,
-                                          TopologicalElement cel) {
-    // We will always be filling some locations of fine element fel with others of the same element.
-    // However, the chosen coarse element cel defines our *domain*
-    return IsSubmanifold(fel, cel);
-  }
-
-  template <int DIM, TopologicalElement fel = TopologicalElement::CC,
-            TopologicalElement cel = TopologicalElement::CC>
-  KOKKOS_FORCEINLINE_FUNCTION static void
-  Do(const int l, const int m, const int n, const int k, const int j, const int i,
-     const IndexRange &ckb, const IndexRange &cjb, const IndexRange &cib,
-     const IndexRange &kb, const IndexRange &jb, const IndexRange &ib,
-     const Coordinates_t &coords, const Coordinates_t &coarse_coords,
-     const ParArrayND<Real, VariableState> *,
-     const ParArrayND<Real, VariableState> *pfine) {
-
-        // Definitely exit on what we can't handle
-        // This is never hit as currently compiled in KHARMA
-        if constexpr (fel != TE::F1 && fel != TE::F2 && fel != TE::F3)
-            return;
-
-        // Handle permutations "naturally."
-        // Olivares et al. is fond of listing x1 versions which permute,
-        // this makes translating/checking those easier
-        constexpr int me = static_cast<int>(fel) % 3;
-        constexpr int next = (me+1) % 3;
-        constexpr int third = (me+2) % 3;
-
-        // Fine array, indices
-        // Note the boundaries are *always the interior*
-        auto &fine = *pfine;
-        const int fi = (DIM > 0) ? (i - cib.s) * 2 + ib.s : ib.s;
-        const int fj = (DIM > 1) ? (j - cjb.s) * 2 + jb.s : jb.s;
-        const int fk = (DIM > 2) ? (k - ckb.s) * 2 + kb.s : kb.s;
-
-        // Coefficients selecting a particular formula (see Olivares et al. 2019)
-        // TODO options here. There are 3 presented:
-        // 1. Zeros (Cunningham)
-        // 2. differences of squares of zone dimesnions (Toth)
-        // 3. heuristic based on flux difference of top vs bottom halves (Olivares)
-        // constexpr Real a[3] = {0., 0., 0.};
-        const Real a[3] = {(SQR(coords.Dxc<2>(fj)) - SQR(coords.Dxc<3>(fk))) / (SQR(coords.Dxc<2>(fj)) + SQR(coords.Dxc<3>(fk))),
-                           (SQR(coords.Dxc<3>(fk)) - SQR(coords.Dxc<1>(fi))) / (SQR(coords.Dxc<3>(fk)) + SQR(coords.Dxc<1>(fi))),
-                           (SQR(coords.Dxc<1>(fi)) - SQR(coords.Dxc<2>(fj))) / (SQR(coords.Dxc<1>(fi)) + SQR(coords.Dxc<2>(fj)))};
-
-        // Coefficients for each term evaluating the four sub-faces
-        const Real coeff[4][4] = {{3 + a[next], 1 - a[next], 3 - a[third], 1 + a[third]},
-                                  {3 + a[next], 1 - a[next], 1 + a[third], 3 - a[third]},
-                                  {1 - a[next], 3 + a[next], 3 - a[third], 1 + a[third]},
-                                  {1 - a[next], 3 + a[next], 1 + a[third], 3 - a[third]}};
-
-        constexpr int diff_k = (me == V3 && DIM > 2), diff_j = (me == V2 && DIM > 1), diff_i = (me == V1 && DIM > 0);
-
-        // Iterate through the 4 sub-faces
-        for (int elem=0; elem < 4; elem++) {
-            // Make sure we can offset in other directions before doing so, though
-            const int off_i = (DIM > 0) ? (elem%2)*(me == V2) + (elem/2)*(me == V3) + (me == V1) : 0;
-            const int off_j = (DIM > 1) ? (elem%2)*(me == V3) + (elem/2)*(me == V1) + (me == V2) : 0;
-            const int off_k = (DIM > 2) ? (elem%2)*(me == V1) + (elem/2)*(me == V2) + (me == V3) : 0;
-
-            fine(me, l, m, n, fk+off_k, fj+off_j, fi+off_i) = (
-                // Average faces on either side of us in selected direction (diff), on each of the 4 sub-faces (off)
-                0.5*(fine(me, l, m, n, fk+off_k-diff_k, fj+off_j-diff_j, fi+off_i-diff_i)
-                   * coords.Volume<fel>(fk+off_k-diff_k, fj+off_j-diff_j, fi+off_i-diff_i)
-                   + fine(me, l, m, n, fk+off_k+diff_k, fj+off_j+diff_j, fi+off_i+diff_i)
-                   * coords.Volume<fel>(fk+off_k+diff_k, fj+off_j+diff_j, fi+off_i+diff_i)) +
-                1./16*(coeff[elem][0]*F<next, me,   -1,DIM>(fine, coords, l, m, n, fk, fj, fi)
-                     + coeff[elem][1]*F<next, me,third,DIM>(fine, coords, l, m, n, fk, fj, fi)
-                     + coeff[elem][2]*F<third,me,  -1,DIM>(fine, coords, l, m, n, fk, fj, fi)
-                     + coeff[elem][3]*F<third,me,next,DIM>(fine, coords, l, m, n, fk, fj, fi))
-                ) / coords.Volume<fel>(fk+off_k, fj+off_j, fi+off_i);
-        }
-    }
-};
+/**
+ * Reset an outflow condition to have no divergence, even if a field line exits the domain.
+ * Could maybe be used on other boundaries, but resets the perpendicular face so use with caution.
+ */
+void DestructiveBoundaryClean(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &fpack, bool coarse);
 
 }

--- a/kharma/b_ct/b_ct_functions.hpp
+++ b/kharma/b_ct/b_ct_functions.hpp
@@ -1,0 +1,264 @@
+/* 
+ *  File: b_ct_functions.hpp
+ *  
+ *  BSD 3-Clause License
+ *  
+ *  Copyright (c) 2020, AFD Group at UIUC
+ *  All rights reserved.
+ *  
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *  
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *  
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "decs.hpp"
+#include "domain.hpp"
+#include "grmhd_functions.hpp"
+#include "matrix.hpp"
+#include "types.hpp"
+
+#include <parthenon/parthenon.hpp>
+
+// Device functions for B_CT package
+namespace B_CT {
+
+template<typename Global>
+KOKKOS_INLINE_FUNCTION Real face_div(const GRCoordinates &G, Global &v, const int &ndim, const int &k, const int &j, const int &i)
+{
+    Real du = (v(F1, 0, k, j, i + 1) * G.Volume<F1>(k, j, i + 1) - v(F1, 0, k, j, i) * G.Volume<F1>(k, j, i));
+    if (ndim > 1)
+        du += (v(F2, 0, k, j + 1, i) * G.Volume<F2>(k, j + 1, i) - v(F2, 0, k, j, i) * G.Volume<F2>(k, j, i));
+    if (ndim > 2)
+        du += (v(F3, 0, k + 1, j, i) * G.Volume<F3>(k + 1, j, i) - v(F3, 0, k, j, i) * G.Volume<F3>(k, j, i));
+    return du / G.Volume<CC>(k, j, i);
+}
+
+template<TE el, int NDIM>
+KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& A, const VariablePack<Real>& B_U,
+                                    const int& k, const int& j, const int& i)
+{
+    if constexpr (NDIM == 2) {
+        if constexpr (el == TE::F1) {
+            // A3,2 derivative
+            B_U(F1, 0, k, j, i) =   (A(V3, k, j + 1, i) - A(V3, k, j, i)) / G.Dxc<2>(j);
+        } else if constexpr (el == TE::F2) {
+            // A3,1 derivative;
+            B_U(F2, 0, k, j, i) = - (A(V3, k, j, i + 1) - A(V3, k, j, i)) / G.Dxc<1>(i);
+        } else if constexpr (el == TE::F3) {
+            B_U(F3, 0, k, j, i) = 0.;
+        }
+    } else if constexpr (NDIM == 3) {
+        // This version is only needed for tilted disks, i.e. where |A| != A_phi
+        // TODO TODO test a tilted disk using this code
+        if constexpr (el == TE::F1) {
+            // A3,2 derivative
+            const Real A3c2f = (A(V3, k, j + 1, i) + A(V3, k + 1, j + 1, i)) / 2;
+            const Real A3c2b = (A(V3, k, j, i)     + A(V3, k + 1, j, i)) / 2;
+            // A2,3 derivative
+            const Real A2c3f = (A(V2, k + 1, j, i) + A(V2, k + 1, j + 1, i)) / 2;
+            const Real A2c3b = (A(V2, k, j, i)     + A(V2, k, j + 1, i)) / 2;
+            B_U(F1, 0, k, j, i) = (A3c2f - A3c2b) / G.Dxc<2>(j) - (A2c3f - A2c3b) / G.Dxc<3>(k);
+        } else if constexpr (el == TE::F2) {
+            // A1,3 derivative
+            const Real A1c3f = (A(V1, k + 1, j, i) + A(V1, k + 1, j, i + 1)) / 2;
+            const Real A1c3b = (A(V1, k, j, i)     + A(V1, k, j, i + 1)) / 2;
+            // A3,1 derivative
+            const Real A3c1f = (A(V3, k, j, i + 1) + A(V3, k + 1, j, i + 1)) / 2;
+            const Real A3c1b = (A(V3, k, j, i)     + A(V3, k + 1, j, i)) / 2;
+            B_U(F2, 0, k, j, i) = (A1c3f - A1c3b) / G.Dxc<3>(k) - (A3c1f - A3c1b) / G.Dxc<1>(i);
+        } else if constexpr (el == TE::F3) {
+            // A2,1 derivative
+            const Real A2c1f = (A(V2, k, j, i + 1) + A(V2, k, j + 1, i + 1)) / 2;
+            const Real A2c1b = (A(V2, k, j, i)     + A(V2, k, j + 1, i)) / 2;
+            // A1,2 derivative
+            const Real A1c2f = (A(V1, k, j + 1, i) + A(V1, k, j + 1, i + 1)) / 2;
+            const Real A1c2b = (A(V1, k, j, i)     + A(V1, k, j, i + 1)) / 2;
+            B_U(F3, 0, k, j, i) = (A2c1f - A2c1b) / G.Dxc<1>(i) - (A1c2f - A1c2b) / G.Dxc<2>(j);
+        }
+    }
+}
+
+template<TE el, int NDIM>
+KOKKOS_INLINE_FUNCTION void EdgeCurl(MeshBlockData<Real> *rc, const GridVector& A,
+                                     const VariablePack<Real>& B_U, IndexDomain domain)
+{
+    auto pmb = rc->GetBlockPointer();
+    const auto &G = pmb->coords;
+    IndexRange3 bB = KDomain::GetRange(rc, domain, el);
+    pmb->par_for(
+        "EdgeCurl", bB.ks, bB.ke, bB.js, bB.je, bB.is, bB.ie,
+        KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+            B_CT::edge_curl<el, NDIM>(G, A, B_U, k, j, i);
+        }
+    );
+}
+
+KOKKOS_INLINE_FUNCTION Real upwind_diff(const VariableFluxPack<Real>& B_U, const VariablePack<Real>& emfc, const VariablePack<Real>& uvec,
+                                        const int& comp, const int& dir, const int& vdir,
+                                        const int& k, const int& j, const int& i, const bool& left_deriv)
+{
+    // See SG09 eq 23
+    // Upwind based on vel(vdir) at the left face in vdir (contact mode)
+    TopologicalElement face = FaceOf(vdir);
+    const Real contact_vel = uvec(face, vdir-1, k, j, i);
+    // Upwind by one zone in dir
+    const int i_up = (vdir == 1) ? i - 1 : i;
+    const int j_up = (vdir == 2) ? j - 1 : j;
+    const int k_up = (vdir == 3) ? k - 1 : k;
+    // Sign for transforming the flux to EMF, based on directions
+    const int emf_sign = antisym(comp-1, dir-1, vdir-1);
+
+    // If we're actually taking the derivative at -3/4, back up which center we use,
+    // and reverse the overall sign
+    const int i_cent = (left_deriv && dir == 1) ? i - 1 : i;
+    const int j_cent = (left_deriv && dir == 2) ? j - 1 : j;
+    const int k_cent = (left_deriv && dir == 3) ? k - 1 : k;
+    const int i_cent_up = (left_deriv && dir == 1) ? i_up - 1 : i_up;
+    const int j_cent_up = (left_deriv && dir == 2) ? j_up - 1 : j_up;
+    const int k_cent_up = (left_deriv && dir == 3) ? k_up - 1 : k_up;
+    const int return_sign = (left_deriv) ? -1 : 1;
+
+
+    // TODO calculate offsets once somehow?
+
+    if (contact_vel > 0) {
+        // Forward: difference at i
+        return return_sign * (emfc(comp-1, k_cent, j_cent, i_cent) + emf_sign * B_U.flux(dir, vdir-1, k, j, i));
+    } else if (contact_vel < 0) {
+        // Back: difference at i-1
+        return return_sign * (emfc(comp-1, k_cent_up, j_cent_up, i_cent_up) + emf_sign * B_U.flux(dir, vdir-1, k_up, j_up, i_up));
+    } else {
+        // Half and half
+        return return_sign*0.5*(emfc(comp-1, k_cent, j_cent, i_cent) + emf_sign * B_U.flux(dir, vdir-1, k, j, i) +
+                    emfc(comp-1, k_cent_up, j_cent_up, i_cent_up) + emf_sign * B_U.flux(dir, vdir-1, k_up, j_up, i_up));
+    }
+}
+
+// Only through formatting has the following been made even a little comprehensible.
+
+template<int diff_face, int diff_side, int offset, int DIM>
+KOKKOS_FORCEINLINE_FUNCTION Real F(const ParArrayND<Real, VariableState> &fine, const Coordinates_t &coords, int l, int m, int n, int fk, int fj, int fi)
+{
+    // Trivial directions
+    if constexpr (diff_face+1 > DIM)
+        return 0.;
+    // TODO compile-time error on misuse? (diff_face == diff_side etc)
+    constexpr int df_is_k = 2*(diff_face == V3 && DIM > 2);
+    constexpr int df_is_j = 2*(diff_face == V2 && DIM > 1);
+    constexpr int df_is_i = 2*(diff_face == V1 && DIM > 0);
+    constexpr int ds_is_k = (diff_side == V3 && DIM > 2);
+    constexpr int ds_is_j = (diff_side == V2 && DIM > 1);
+    constexpr int ds_is_i = (diff_side == V1 && DIM > 0);
+    constexpr int of_is_k = (offset == V3 && DIM > 2);
+    constexpr int of_is_j = (offset == V2 && DIM > 1);
+    constexpr int of_is_i = (offset == V1 && DIM > 0);
+    return fine(diff_face, l, m, n,  fk+df_is_k+ds_is_k+of_is_k, fj+df_is_j+ds_is_j+of_is_j, fi+df_is_i+ds_is_i+of_is_i)
+      * coords.FaceArea<diff_face+1>(fk+df_is_k+ds_is_k+of_is_k, fj+df_is_j+ds_is_j+of_is_j, fi+df_is_i+ds_is_i+of_is_i)
+         - fine(diff_face, l, m, n,  fk+ds_is_k+of_is_k        , fj+ds_is_j+of_is_j        , fi+ds_is_i+of_is_i)
+      * coords.FaceArea<diff_face+1>(fk+ds_is_k+of_is_k        , fj+ds_is_j+of_is_j        , fi+ds_is_i+of_is_i)
+         - fine(diff_face, l, m, n,  fk+df_is_k+of_is_k        , fj+df_is_j+of_is_j        , fi+df_is_i+of_is_i)
+      * coords.FaceArea<diff_face+1>(fk+df_is_k+of_is_k        , fj+df_is_j+of_is_j        , fi+df_is_i+of_is_i)
+         + fine(diff_face, l, m, n,  fk+of_is_k                , fj+of_is_j                , fi+of_is_i)
+      * coords.FaceArea<diff_face+1>(fk+of_is_k                , fj+of_is_j                , fi+of_is_i);
+}
+
+struct ProlongateInternalOlivares {
+  static constexpr bool OperationRequired(TopologicalElement fel,
+                                          TopologicalElement cel) {
+    // We will always be filling some locations of fine element fel with others of the same element.
+    // However, the chosen coarse element cel defines our *domain*
+    return IsSubmanifold(fel, cel);
+  }
+
+  template <int DIM, TopologicalElement fel = TopologicalElement::CC,
+            TopologicalElement cel = TopologicalElement::CC>
+  KOKKOS_FORCEINLINE_FUNCTION static void
+  Do(const int l, const int m, const int n, const int k, const int j, const int i,
+     const IndexRange &ckb, const IndexRange &cjb, const IndexRange &cib,
+     const IndexRange &kb, const IndexRange &jb, const IndexRange &ib,
+     const Coordinates_t &coords, const Coordinates_t &coarse_coords,
+     const ParArrayND<Real, VariableState> *,
+     const ParArrayND<Real, VariableState> *pfine) {
+
+        // Definitely exit on what we can't handle
+        // This is never hit as currently compiled in KHARMA
+        if constexpr (fel != TE::F1 && fel != TE::F2 && fel != TE::F3)
+            return;
+
+        // Handle permutations "naturally."
+        // Olivares et al. is fond of listing x1 versions which permute,
+        // this makes translating/checking those easier
+        constexpr int me = static_cast<int>(fel) % 3;
+        constexpr int next = (me+1) % 3;
+        constexpr int third = (me+2) % 3;
+
+        // Fine array, indices
+        // Note the boundaries are *always the interior*
+        auto &fine = *pfine;
+        const int fi = (DIM > 0) ? (i - cib.s) * 2 + ib.s : ib.s;
+        const int fj = (DIM > 1) ? (j - cjb.s) * 2 + jb.s : jb.s;
+        const int fk = (DIM > 2) ? (k - ckb.s) * 2 + kb.s : kb.s;
+
+        // Coefficients selecting a particular formula (see Olivares et al. 2019)
+        // TODO options here. There are 3 presented:
+        // 1. Zeros (Cunningham)
+        // 2. differences of squares of zone dimesnions (Toth)
+        // 3. heuristic based on flux difference of top vs bottom halves (Olivares)
+        // constexpr Real a[3] = {0., 0., 0.};
+        const Real a[3] = {(SQR(coords.Dxc<2>(fj)) - SQR(coords.Dxc<3>(fk))) / (SQR(coords.Dxc<2>(fj)) + SQR(coords.Dxc<3>(fk))),
+                           (SQR(coords.Dxc<3>(fk)) - SQR(coords.Dxc<1>(fi))) / (SQR(coords.Dxc<3>(fk)) + SQR(coords.Dxc<1>(fi))),
+                           (SQR(coords.Dxc<1>(fi)) - SQR(coords.Dxc<2>(fj))) / (SQR(coords.Dxc<1>(fi)) + SQR(coords.Dxc<2>(fj)))};
+
+        // Coefficients for each term evaluating the four sub-faces
+        const Real coeff[4][4] = {{3 + a[next], 1 - a[next], 3 - a[third], 1 + a[third]},
+                                  {3 + a[next], 1 - a[next], 1 + a[third], 3 - a[third]},
+                                  {1 - a[next], 3 + a[next], 3 - a[third], 1 + a[third]},
+                                  {1 - a[next], 3 + a[next], 1 + a[third], 3 - a[third]}};
+
+        constexpr int diff_k = (me == V3 && DIM > 2), diff_j = (me == V2 && DIM > 1), diff_i = (me == V1 && DIM > 0);
+
+        // Iterate through the 4 sub-faces
+        for (int elem=0; elem < 4; elem++) {
+            // Make sure we can offset in other directions before doing so, though
+            const int off_i = (DIM > 0) ? (elem%2)*(me == V2) + (elem/2)*(me == V3) + (me == V1) : 0;
+            const int off_j = (DIM > 1) ? (elem%2)*(me == V3) + (elem/2)*(me == V1) + (me == V2) : 0;
+            const int off_k = (DIM > 2) ? (elem%2)*(me == V1) + (elem/2)*(me == V2) + (me == V3) : 0;
+
+            fine(me, l, m, n, fk+off_k, fj+off_j, fi+off_i) = (
+                // Average faces on either side of us in selected direction (diff), on each of the 4 sub-faces (off)
+                0.5*(fine(me, l, m, n, fk+off_k-diff_k, fj+off_j-diff_j, fi+off_i-diff_i)
+                   * coords.Volume<fel>(fk+off_k-diff_k, fj+off_j-diff_j, fi+off_i-diff_i)
+                   + fine(me, l, m, n, fk+off_k+diff_k, fj+off_j+diff_j, fi+off_i+diff_i)
+                   * coords.Volume<fel>(fk+off_k+diff_k, fj+off_j+diff_j, fi+off_i+diff_i)) +
+                1./16*(coeff[elem][0]*F<next, me,   -1,DIM>(fine, coords, l, m, n, fk, fj, fi)
+                     + coeff[elem][1]*F<next, me,third,DIM>(fine, coords, l, m, n, fk, fj, fi)
+                     + coeff[elem][2]*F<third,me,  -1,DIM>(fine, coords, l, m, n, fk, fj, fi)
+                     + coeff[elem][3]*F<third,me,next,DIM>(fine, coords, l, m, n, fk, fj, fi))
+                ) / coords.Volume<fel>(fk+off_k, fj+off_j, fi+off_i);
+        }
+    }
+};
+
+}

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -176,10 +176,10 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
         bool clean_face_B = pin->GetOrAddBoolean("boundaries", "clean_face_B_" + bname, (btype == "outflow"));
         params.Add("clean_face_B_"+bname, clean_face_B);
 
-        // Special EMF averaging, slow, manual only
-        bool average_EMF = pin->GetOrAddBoolean("boundaries", "average_EMF_" + bname, false);
+        // Special EMF averaging.  Probably slow but beneficial for transmitting boundaries
+        bool average_EMF = pin->GetOrAddBoolean("boundaries", "average_EMF_" + bname, (btype == "transmitting"));
         params.Add("average_EMF_"+bname, average_EMF);
-        // Otherwise, zero EMFs to prevent B field escaping the domain in polar/dirichlet bounds
+        // Otherwise, always zero EMFs to prevent B field escaping the domain in polar/dirichlet bounds
         bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname, ((bdir == X2DIR && spherical)
                                                                              || (btype == "dirichlet"))
                                                                              && !average_EMF);
@@ -276,6 +276,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                     throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
                 if (pin->GetString("coordinates", "transform") == "fmks" || pin->GetString("coordinates", "transform") == "funky")
                     throw std::runtime_error("Transmitting polar boundary conditions require coordinates symmetric about theta=0!");
+                // TODO also check for wedge simulations x3<2pi
             } else if (btype == "outflow") {
                 switch (bface) {
                 case BoundaryFace::inner_x1:
@@ -336,116 +337,44 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     const auto bdir = BoundaryDirection(bface);
     const bool binner = BoundaryIsInner(bface);
 
+    // Delegate EMF boundaries to the B_CT package
+    // Only until per-variable boundaries available in Parthenon
+    auto& emfpack = rc->PackVariables(std::vector<std::string>{"B_CT.emf"});
+    if (emfpack.GetDim(4) > 0) {
+        if (params.Get<bool>("zero_EMF_" + bname)) {
+            Flag("ZeroEMF_"+bname);
+            B_CT::ZeroEMF(rc.get(), domain, emfpack, coarse);
+            EndFlag();
+        }
+        if (params.Get<bool>("average_EMF_" + bname)) {
+            Flag("AverageEMF_"+bname);
+            B_CT::AverageEMF(rc.get(), domain, emfpack, coarse);
+            EndFlag();
+        }
+        // No traditional boundaries needed for EMFs
+        return;
+    }
+
+    // Otherwise, call through to the registered boundary function
     Flag("Apply "+bname+" boundary: "+btype_name);
     pkg->KBoundaries[bface](rc, coarse);
     EndFlag();
 
+    // Then a bunch of common boundary "touchups"
     // Nothing below is designed, nor necessary, for coarse buffers
     if (coarse) {
         EndFlag();
         return;
     }
 
-    // If we're syncing EMFs and in spherical, explicitly zero polar faces
-    // Since we manipulate the j coord, we'd overstep coarse bufs
-    auto& emfpack = rc->PackVariables(std::vector<std::string>{"B_CT.emf"});
-    if (params.Get<bool>("zero_EMF_" + bname) && emfpack.GetDim(4) > 0) {
-        Flag("BoundaryEdge_"+bname);
-        std::vector<TE> te_list;
-        if (bdir == 1) {
-            te_list = {TE::E2, TE::E3};
-        } else if (bdir == 2) {
-            te_list = {TE::E1, TE::E3};
-        } else {
-            te_list = {TE::E1, TE::E2};
-        }
-
-        for (TE el : te_list) {
-            // Augment the domain -- EMF must be zero *on* domain faces, not just beyond
-            auto b = KDomain::GetRange(rc, domain, el, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
-            pmb->par_for(
-                "zero_EMF_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    emfpack(el, 0, k, j, i) = 0;
-                }
-            );
-        }
-        // Remaining edge zero'd only *within* domain
-        TE el = EdgeOf(bdir);
-        auto b = KDomain::GetRange(rc, domain, el, coarse);
-        pmb->par_for(
-            "zero_EMF_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                emfpack(el, 0, k, j, i) = 0;
-            }
-        );
-        EndFlag();
-    }
-    if (params.Get<bool>("average_EMF_" + bname) && emfpack.GetDim(4) > 0) {
-        Flag("BoundaryEdge_"+bname);
-        if (bdir != 2) {
-            throw std::runtime_error("Polar average EMF implemented only in X2!");
-        }
-
-        // Augment the domain -- X3 EMF must be zero *on* polar face, since edge size is 0
-        auto b = KDomain::GetRange(rc, domain, E3, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
-        pmb->par_for(
-            "zero_EMF_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                emfpack(E3, 0, k, j, i) = 0;
-            }
-        );
-
-        // X1 EMF is *averaged* on the face
-        // TODO error if this is called in 2D...
-        // TODO should maybe only be physical zones...
-        b = KDomain::GetRange(rc, domain, E1, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
-        IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, E1, coarse);
-        const int jf = (binner) ? b.je : b.js; // j index of polar face
-        parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_EMF", pmb->exec_space,
-            0, 1, b.is, b.ie,
-            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i) {
-                // Sum the (non-ghost) X1 direction fluxes along the pole at zone i
-                double emf_sum;
-                Kokkos::Sum<double> sum_reducer(emf_sum);
-                parthenon::par_reduce_inner(member, bi.ks, bi.ke,
-                    [&](const int& k, double& local_result) {
-                        local_result += emfpack(E1, 0, k, jf, i);
-                    }
-                , sum_reducer);
-
-                // Calculate the average and set all EMFs identically (even ghosts, to keep divB)
-                const double emf_av = emf_sum / (bi.ke - bi.ks + 1);
-                parthenon::par_for_inner(member, b.ks, b.ke,
-                    [&](const int& k) {
-                        emfpack(E1, 0, k, jf, i) = emf_av;
-                    }
-                );
-            }
-        );
-
-        // Remaining X1/X2 EMF zero'd only *within* boundary domain
-        for (auto el : {E1, E2}) {
-            b = KDomain::GetRange(rc, domain, el, coarse);
-            pmb->par_for(
-                "zero_EMF_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    emfpack(el, 0, k, j, i) = 0;
-                }
-            );
-        }
-        EndFlag();
-    }
-
-    // Zero/invert XN faces at a reflecting XN boundary (nearly always X2)
-    // Replaces reflecting face values at reflecting boundaries, Parthenon messes them up
+    // Correct Parthenon's reflecting conditions on the corresponding face
+    // TODO currently expects only cons.fB.  Make more general
+    // TODO just put it in Parthenon
     auto fpack = rc->PackVariables({Metadata::Face, Metadata::FillGhost});
     if (params.Get<bool>("reflect_face_vector_" + bname) && fpack.GetDim(4) > 0) {
-        Flag("BoundaryFace_"+bname);
+        Flag("ReflectFace_"+bname);
         const TopologicalElement face = FaceOf(bdir);
-        // This is the domain of the boundary/ghost zones
-        // Augment the domain since we're always modifying e.g. F2 in X2 boundary
-        auto b = KDomain::GetRange(rc, domain, face, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
+        auto b = KDomain::GetBoundaryRange(rc, domain, face, coarse);
         // Zero the last physical face, otherwise invert.
         auto i_f = (binner) ? b.ie : b.is;
         auto j_f = (binner) ? b.je : b.js;
@@ -464,43 +393,11 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
         EndFlag();
     }
 
-    // Zero/invert XN faces at a reflecting XN boundary (nearly always X2)
-    // Replaces reflecting face values at reflecting boundaries, Parthenon messes them up
+    // Correct orthogonal B field component to eliminate divergence in last rank
+    // and ghosts. Used for outflow conditions when field lines will exit domain
     if (params.Get<bool>("clean_face_B_" + bname) && fpack.GetDim(4) > 0) {
-        Flag("BoundaryFace_"+bname);
-        const TopologicalElement face = FaceOf(bdir);
-        // Correct last domain face, too
-        auto b = KDomain::GetRange(rc, domain, face, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
-        // Need the coordinates for this boundary, uniquely
-        auto G = pmb->coords;
-        const int ndim = pmb->pmy_mesh->ndim;
-        if (domain == IndexDomain::inner_x1 || domain == IndexDomain::outer_x1) {
-            const int i_face = (binner) ? b.ie : b.is;
-            for (int iadd = 0; iadd <= (b.ie - b.is); iadd++) {
-                const int i = (binner) ? i_face - iadd : i_face + iadd;
-                const int last_rank_f  = (binner) ? i + 1 : i - 1;
-                const int last_rank_c  = (binner) ? i     : i - 1;
-                const int outward_sign = (binner) ? -1.   : 1.;
-                pmb->par_for(
-                    "correct_face_vector_" + bname, b.ks, b.ke, b.js, b.je, i, i,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                        // Other faces have been updated, just need to clean divergence
-                        // Subtract off their contributions to find ours. Note our partner face contributes differently,
-                        // depending on whether we're the i+1 "outward" face, or the i "innward" face
-                        Real new_face = - (-outward_sign) * fpack(F1, 0, k, j, last_rank_f) * G.Volume<F1>(k, j, last_rank_f)
-                                        - (fpack(F2, 0, k, j + 1, last_rank_c) * G.Volume<F2>(k, j + 1, last_rank_c)
-                                            - fpack(F2, 0, k, j, last_rank_c) * G.Volume<F2>(k, j, last_rank_c));
-                        if (ndim > 2)
-                            new_face -= fpack(F3, 0, k + 1, j, last_rank_c) * G.Volume<F3>(k + 1, j, last_rank_c)
-                                        - fpack(F3, 0, k, j, last_rank_c) * G.Volume<F3>(k, j, last_rank_c);
-
-                        fpack(F1, 0, k, j, i) = outward_sign * new_face / G.Volume<F1>(k, j, i);
-                    }
-                );
-            }
-        } else {
-            throw std::runtime_error("Divergence-free outflow replacement only implemented in X1!");
-        }
+        Flag("CleanFaceB_"+bname);
+        B_CT::DestructiveBoundaryClean(rc.get(), domain, fpack, coarse);
         EndFlag();
     }
 
@@ -556,6 +453,8 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     * with outflow conditions based on the updated ghost cells.
     */
     if (bdir == X2DIR) {
+        // TODO test more carefully whether this is still needed for face-centered B...
+
         // If we're on the interior edge, re-apply that edge for our block by calling
         // exactly the same function that Parthenon does.  This ensures we're applying
         // the same thing, just emulating calling it after X2.
@@ -575,7 +474,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
         }
     }
 
-    bool sync_prims = rc->GetBlockPointer()->packages.Get("Driver")->Param<bool>("sync_prims");
+    bool sync_prims = pmb->packages.Get("Driver")->Param<bool>("sync_prims");
     // There are two modes of operation here:
     if (sync_prims) {
         // 1. Exchange/prolongate/restrict PRIMITIVE variables: (ImEx driver)
@@ -590,7 +489,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
         }
         Flux::BlockPtoU(rc.get(), domain, coarse);
     } else {
-        // 2. Exchange/prolongate/restrict CONSERVED variables: (KHARMA driver, maybe ImEx+AMR)
+        // 2. Exchange/prolongate/restrict CONSERVED variables: (KHARMA driver)
         //    Conserved variables are marked FillGhost, plus FLUID PRIMITIVES.
         if (!params.Get<bool>("domain_bounds_on_conserved")) {
             // To apply primitive boundaries to GRMHD, we run PtoU on that ONLY,

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -368,8 +368,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     }
 
     // Correct Parthenon's reflecting conditions on the corresponding face
-    // TODO currently expects only cons.fB.  Make more general
-    // TODO just put it in Parthenon
+    // TODO honor SplitVector here, then move it all to Parthenon
     auto fpack = rc->PackVariables({Metadata::Face, Metadata::FillGhost});
     if (params.Get<bool>("reflect_face_vector_" + bname) && fpack.GetDim(4) > 0) {
         Flag("ReflectFace_"+bname);

--- a/kharma/boundaries/one_block_transmit.cpp
+++ b/kharma/boundaries/one_block_transmit.cpp
@@ -102,7 +102,7 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q,
         const int jpivot = (binner) ? (corresponding_face ? b.je + 1 : b.je)
                                     : (corresponding_face ? b.js - 1 : b.js);
         // B3 component on X3 face should be inverted even if not marked "vector"
-        // TODO currently this inverts everything on F3, probably not desirable
+        // TODO honor SplitVector here rather than always inverting
         const bool do_face_invert = (el == F3);
 
         pmb->par_for(

--- a/kharma/boundaries/one_block_transmit.cpp
+++ b/kharma/boundaries/one_block_transmit.cpp
@@ -62,13 +62,20 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q,
 {
     // We're sometimes called without any variables to sync (e.g. syncing flags, EMFs), just return
     if (q.GetDim(4) == 0) return;
+    // We're also sometimes called on coarse buffers with or without AMR.
+    // Use of transmitting polar conditions when coarse buffers matter (e.g., refinement
+    // boundary touching the pole) is UNSUPPORTED
+    if (coarse) return;
 
-    // Indices
+    // Pull boundary properties
     auto pmb = rc->GetBlockPointer();
     const bool binner = BoundaryIsInner(bface);
-    const int dir = BoundaryDirection(bface);
+    const int bdir = BoundaryDirection(bface);
     const auto domain = BoundaryDomain(bface);
     const auto bname = BoundaryName(bface);
+
+    if (bdir != 2)
+        throw std::runtime_error("Transmitting polar conditions only defined for X2!");
 
     std::vector<TopologicalElement> el_list;
     if (do_face) {
@@ -76,41 +83,37 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q,
     } else {
         el_list = {CC};
     }
-    int el_tot = el_list.size();
-    for (auto el : el_list) {
-        // Set boundary/ghost zones *only*, not zones on faces
-        const IndexRange3 b = KDomain::GetRange(rc, domain, el, coarse);
-        const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, CC);
+    for (TopologicalElement &el : el_list) {
+        // This automatically includes zones on domain faces, which we set to 0 below
+        const IndexRange3 b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
+        const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, CC, coarse);
+        // Whether we're on e.g. X2 face for X2 boundary
+        const bool corresponding_face = (el == FaceOf(bdir));
+        const int reflect_offset = corresponding_face ? 0 : (binner ? 1 : -1);
 
-        if (domain == IndexDomain::inner_x2 || domain == IndexDomain::outer_x2) {
-            const int Nk3p = (bi.ke - bi.ks + 1); // Physical/interior *zones* in dir 3
-            const int Nk3p2 = Nk3p/2;             // pi/2 of those (boundary incompatible with slice sims TODO check+error)
-            const int ksp = bi.ks;                // Offset of first physical zone or face (same number)
-            // Pivot element for faces is first domain face (==0), pivot for cells is between b.js/e, b.js/e+/-1
-            const int jpivot = (domain == IndexDomain::inner_x2) ? ((el == FaceOf(dir)) ? b.je + 1 : b.je)
-                                                                 : ((el == FaceOf(dir)) ? b.js - 1 : b.js);
-            const bool do_face_invert = (el == F3);
-            pmb->par_for(
-                "transmitting_polar_boundary_" + bname, 0, q.GetDim(4)/el_tot-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
-                    const int ki = ((k - ksp + Nk3p2) % Nk3p) + ksp;
-                    const int ji = m::abs(jpivot - j);
-                    const int ii = i;
-                    const Real invert = (do_face_invert || q(el, v).vector_component == X3DIR) ? -1. : 1.;
-                    q(el, v, k, j, i) = invert * q(el, v, ki, ji, ii);
-                }
-            );
-            // Explicitly zero B2 face for some reason
-            if (el == FaceOf(dir)) {
-                pmb->par_for(
-                    "transmitting_polar_boundary_" + bname, 0, q.GetDim(4)/el_tot-1, b.ks, b.ke, jpivot, jpivot, b.is, b.ie,
-                    KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
-                        q(el, v, k, j, i) = 0.;
-                    }
-                );
+        // TODO SPECIFIC TO X2
+        // Total physical/interior *zones* in dir 3.  Note first/last face will share an opposite,
+        // i.e. both F3(0,x,x) and F3(N3,x,x) -> F3(N3/2,x,x), but in reverse only the former
+        const int Nk3p = (bi.ke - bi.ks + 1);
+        const int Nk3p2 = Nk3p/2;
+        const int ksp = bi.ks;
+        // Pivot element for corresponding face is one more than pivot for cells/other-faces
+        // X2 dir should be calculated exactly as if reflecting
+        const int jpivot = (binner) ? (corresponding_face ? b.je + 1 : b.je)
+                                    : (corresponding_face ? b.js - 1 : b.js);
+        // B3 component on X3 face should be inverted even if not marked "vector"
+        // TODO currently this inverts everything on F3, probably not desirable
+        const bool do_face_invert = (el == F3);
+
+        pmb->par_for(
+            "transmitting_polar_boundary_" + bname, 0, q.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+            KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+                const int ki = ((k - ksp + Nk3p2) % Nk3p) + ksp;
+                const int ji = jpivot + reflect_offset + (jpivot - j);
+                const int ii = i;
+                const Real invert = (do_face_invert || q(el, v).vector_component == X3DIR) ? -1. : 1.;
+                q(el, v, k, j, i) = (corresponding_face && j == jpivot) ? 0. : invert * q(el, v, ki, ji, ii);
             }
-        } else {
-            throw std::runtime_error("Transmitting polar conditions only defined for X2!");
-        }
+        );
     }
 }

--- a/kharma/boundaries/one_block_transmit.cpp
+++ b/kharma/boundaries/one_block_transmit.cpp
@@ -97,10 +97,8 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q,
         const int Nk3p = (bi.ke - bi.ks + 1);
         const int Nk3p2 = Nk3p/2;
         const int ksp = bi.ks;
-        // Pivot element for corresponding face is one more than pivot for cells/other-faces
-        // X2 dir should be calculated exactly as if reflecting
-        const int jpivot = (binner) ? (corresponding_face ? b.je + 1 : b.je)
-                                    : (corresponding_face ? b.js - 1 : b.js);
+        // Calculate j just like for reflecting conditions
+        const int jpivot = (binner) ? b.je : b.js;
         // B3 component on X3 face should be inverted even if not marked "vector"
         // TODO honor SplitVector here rather than always inverting
         const bool do_face_invert = (el == F3);

--- a/kharma/domain.hpp
+++ b/kharma/domain.hpp
@@ -132,6 +132,28 @@ inline IndexRange3 GetRange(T data, IndexDomain domain, bool coarse)
 {
     return GetRange(data, domain, CC, 0, 0, coarse);
 }
+
+/**
+ * Special range to include domain faces when computing boundaries,
+ * as KHARMA's physical boundary conditions set these
+ */
+template<typename T>
+inline IndexRange3 GetBoundaryRange(T data, IndexDomain domain, TopologicalElement el=CC, bool coarse=false)
+{
+    using KBoundaries::BoundaryDirection;
+    using KBoundaries::BoundaryIsInner;
+    const int bdir = BoundaryDirection(domain);
+    if (el == FaceOf(bdir) ||
+        (el == E1 && (bdir == X2DIR || bdir == X3DIR)) ||
+        (el == E2 && (bdir == X1DIR || bdir == X3DIR)) ||
+        (el == E3 && (bdir == X1DIR || bdir == X2DIR))) {
+        const int binner = BoundaryIsInner(domain);
+        return GetRange(data, domain, el, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
+    } else {
+        return GetRange(data, domain, el, 0, 0, coarse);
+    }
+}
+
 /**
  * Get zones which are inside the physical domain, i.e. set by computation or MPI halo sync,
  * not by problem boundary conditions.

--- a/kharma/driver/kharma_driver.cpp
+++ b/kharma/driver/kharma_driver.cpp
@@ -91,6 +91,10 @@ std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(ParameterInput *pin, std
     // but which should not be evolved (or more importantly, sync'd) during main stepping
     Metadata::AddUserFlag("StartupOnly");
 
+    // This is a flag Parthenon should have eventually, but we'll prototype in KHARMA
+    // Indicate a 1-element face-centered field is split components of a vector
+    Metadata::AddUserFlag("SplitVector");
+
     // Synchronize primitive variables unless we're using the KHARMA driver that specifically doesn't
     // This includes for AMR w/ImEx driver
     // Note the "conserved" B field is always sync'd.  The "primitive" version only differs by sqrt(-g)


### PR DESCRIPTION
Needlessly thorough fix for a bad index problem in the one-block transmitting conditions.  Refactors boundary EMF stuff back into the B_CT package where it belongs, and sets EMF averaging to default with transmitting conditions now it's decently fast and probably useful with them.  Mostly, the boundaries code just needs a good clean, but I'm waiting on Parthenon to get more flexible boundaries so I can lean on it again.

Testing now, will merge when (if) the CI and some tori on Darwin come back clean.