### PR TITLE
Mark zones at the pole for FOFC

### DIFF
--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -197,8 +197,8 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         bool use_source_term = pin->GetOrAddBoolean("fofc", "use_source_term", false);
         params.Add("fofc_use_source_term", use_source_term);
 
-        bool do_last_polar = pin->GetOrAddBoolean("fofc", "last_polar_cell", false);
-        params.Add("fofc_at_pole", do_last_polar);
+        int fofc_polar_cells = pin->GetOrAddInteger("fofc", "polar_cells", 0);
+        params.Add("fofc_polar_cells", fofc_polar_cells);
         const GReal eh_buffer = pin->GetOrAddReal("fofc", "eh_buffer", 0.1);
         params.Add("fofc_eh_buffer", eh_buffer);
 

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -197,6 +197,11 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         bool use_source_term = pin->GetOrAddBoolean("fofc", "use_source_term", false);
         params.Add("fofc_use_source_term", use_source_term);
 
+        bool do_last_polar = pin->GetOrAddBoolean("fofc", "last_polar_cell", false);
+        params.Add("fofc_at_pole", do_last_polar);
+        const GReal eh_buffer = pin->GetOrAddReal("fofc", "eh_buffer", 0.1);
+        params.Add("fofc_eh_buffer", eh_buffer);
+
         if (packages->AllPackages().count("B_CT")) {
             // Use consistent B for FOFC (see above)
             // It is mildly inadvisable to disable this

--- a/kharma/flux/flux.hpp
+++ b/kharma/flux/flux.hpp
@@ -91,6 +91,8 @@ TaskStatus MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
 /**
  * As above, except that IndexDomains of ghost cells are taken to cover
  * cells *sent* (that is, part of the domain) rather than received
+ * 
+ * UNUSED
  */
 TaskStatus BlockPtoU_Send(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
 

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -54,8 +54,11 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
     auto fofcflag = guess->PackVariables(std::vector<std::string>{"fofcflag"});
 
     // Parameters
+    const auto& pars = pmb0->packages.Get("Flux")->AllParams();
     const bool spherical = pmb0->coords.coords.is_spherical();
     const GReal r_eh = pmb0->coords.coords.get_horizon();
+    const bool do_last_polar = pars.Get<bool>("fofc_at_pole");
+    const GReal eh_buffer = pars.Get<GReal>("fofc_eh_buffer");
 
     // Pre-mark cells which will need fluxes reduced.
     // This avoids a race condition marking them multiple times when iterating faces,
@@ -68,13 +71,44 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
             // if cell failed to invert or would call floors...
             // TODO preserve cause in the fofcflag
             if (static_cast<int>(fflag(b, 0, k, j, i)) || //Inverter::failed(pflag(b, 0, k, j, i)) ||
-                (spherical && G.r(k, j, i) < r_eh + 0.1)) { // TODO customizable FOFC radius
+                (spherical && G.r(k, j, i) < r_eh + eh_buffer)) {
                 fofcflag(b, 0, k, j, i) = 1;
             } else {
                 fofcflag(b, 0, k, j, i) = 0;
             }
         }
     );
+
+    if (spherical && do_last_polar) {
+        for (int i_block = 0; i_block < guess->NumBlocks(); i_block++) {
+            auto &rc = guess->GetBlockData(i_block);
+            auto pmb = rc->GetBlockPointer();
+            const bool is_inner_x2 = pmb->boundary_flag[BoundaryFace::inner_x2] == BoundaryFlag::user;
+            const bool is_outer_x2 = pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::user;
+            if (is_inner_x2 || is_outer_x2) {
+                auto lfofcflag = rc->PackVariables(std::vector<std::string>{"fofcflag"});
+                if (is_inner_x2) {
+                    const IndexRange3 b = KDomain::GetRange(guess, IndexDomain::inner_x2);
+                    int jpivot = b.je + 1;
+                    pmb0->par_for("fofc_mark_inner_x2", b.ks, b.ke, b.is, b.ie,
+                        KOKKOS_LAMBDA (const int &k, const int &i) {
+                            lfofcflag(0, k, jpivot, i) = 1;
+                        }
+                    );
+                }
+                if (is_outer_x2) {
+                    const IndexRange3 b = KDomain::GetRange(guess, IndexDomain::outer_x2);
+                    int jpivot = b.js - 1;
+                    pmb0->par_for("fofc_mark_outer_x2", b.ks, b.ke, b.is, b.ie,
+                        KOKKOS_LAMBDA (const int &k, const int &i) {
+                            lfofcflag(0, k, jpivot, i) = 1;
+                        }
+                    );
+                }
+            }
+        }
+    }
+
     return TaskStatus::complete;
 }
 
@@ -108,16 +142,16 @@ TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
     const auto& U_all = md->PackVariablesAndFluxes(cons_flags, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
     const int nvar = U_all.GetDim(4);
+    // Okay if this is empty since we won't access it then
+    const auto& Bf = md->PackVariables(std::vector<std::string>{"cons.fB"});
 
     // Parameters
-    const Real gam = pmb0->packages.Get("GRMHD")->Param<Real>("gamma");
-    const bool use_global = pmb0->packages.Get("Flux")->Param<bool>("fofc_use_glf");
+    const auto& pars = packages.Get("Flux")->AllParams();
+    const Real gam = packages.Get("GRMHD")->Param<Real>("gamma");
+    const bool use_global = pars.Get<bool>("fofc_use_glf");
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(packages);
-    // With B_CT this will load the preference, without it will set face_b false and never access (empty) Bf
-    // Weird but it works
-    const bool face_b = (packages.AllPackages().count("B_CT") &&
-                        packages.Get("Flux")->Param<bool>("fofc_consistent_face_b"));
-    const auto& Bf = md->PackVariables(std::vector<std::string>{"cons.fB"});
+    // Only fix faces if they exist
+    const bool face_b = (Bf.GetDim(4) > 0 && pars.Get<bool>("fofc_consistent_face_b"));
 
     for (int dir=1; dir <= ndim; dir++) { // TODO if(trivial_direction) etc
         const TE el = FaceOf(dir);


### PR DESCRIPTION
This adds an option `fofc/polar_cells` which automatically marks a certain number of rows next to the pole as first-order corrected, regardless of other considerations.  A similar trick is used for the event horizon already, which I also make configurable here.

This seems to help significantly to reduce issues at the pole in early testing, while basically just causing a little extra drag around the pole.  Tests of 90-degree tilts look almost indistinguishable at `polar_cells=0` and `polar_cells=1`, with the latter beginning to accrete just a few t_g earlier.  `polar_cells=2` looks slightly qualitatively different and begins to accrete significantly earlier.  Recall none of the 90-degree simulations are accurate, though -- the goal is more to treat the pole in a stable and consistent way, vs accurately modeling things moving across it.
