### PR TITLE
WIP: Warning fixes

### DIFF
--- a/kharma/b_ct/b_ct_functions.hpp
+++ b/kharma/b_ct/b_ct_functions.hpp
@@ -101,7 +101,7 @@ KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& 
 }
 
 template<TE el, int NDIM>
-KOKKOS_INLINE_FUNCTION void EdgeCurl(MeshBlockData<Real> *rc, const GridVector& A,
+inline void EdgeCurl(MeshBlockData<Real> *rc, const GridVector& A,
                                      const VariablePack<Real>& B_U, IndexDomain domain)
 {
     auto pmb = rc->GetBlockPointer();


### PR DESCRIPTION
KHARMA's gotten a little wordy to compile.  Going to try to cut down on that as I get time here.

TODO:
- [x] `warning #20011-D: calling a __host__ function("parthenon::MeshBlockData<double> ::GetBlockPointer() const") from a __host__ __device__ function("B_CT::EdgeCurl<( ::parthenon::TopologicalElement)3, (int)3> ") is not allowed`
- [x] `NVC++-W-0277-Cannot inline function _Z6FaceOfIiEN9parthenon18TopologicalElementERKT_ - data type mismatch`
- [ ] There's a fix in Parthenon for the `statement is unreachable` warning iirc, maybe backport?
- [x] Others?