### PR TITLE
Feature/ideal mhd guess

### DIFF
--- a/kharma/driver/imex_step.cpp
+++ b/kharma/driver/imex_step.cpp
@@ -218,8 +218,13 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
 
             // Copy the current state of any implicitly-evolved vars (at least the prims) in as a guess.
             // If we aren't using the ideal solution as the guess, set md_solver = md_sub_step_init
-            auto t_copy_guess = t_explicit;
+            auto t_copy_guess       = t_explicit;
+            auto t_copy_emhd_vars   = t_explicit;
             if (use_ideal_guess) {
+                t_copy_emhd_vars = tl.AddTask(t_sources, Copy<MeshData<Real>>, std::vector<MetadataFlag>({Metadata::GetUserFlag("EMHDVar")}),
+                                        md_sub_step_init.get(), md_solver.get());
+                t_copy_guess = t_copy_emhd_vars;
+            } else {
                 t_copy_guess = tl.AddTask(t_sources, Copy<MeshData<Real>>, std::vector<MetadataFlag>({Metadata::GetUserFlag("Implicit")}),
                                         md_sub_step_init.get(), md_solver.get());
             }

--- a/kharma/driver/imex_step.cpp
+++ b/kharma/driver/imex_step.cpp
@@ -219,7 +219,6 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
                                                 md_solver.get(), md_linesearch.get());
             }
 
-
             // Time-step implicit variables by root-finding the residual.
             // This calculates the primitive values after the substep for all "isImplicit" variables --
             // no need for separately adding the flux divergence or calling UtoP

--- a/kharma/driver/imex_step.cpp
+++ b/kharma/driver/imex_step.cpp
@@ -73,6 +73,8 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
     const bool use_implicit = pkgs.count("Implicit");
     const bool use_jcon = pkgs.count("Current");
     const bool use_linesearch = (use_implicit) ? pkgs.at("Implicit")->Param<bool>("linesearch") : false;
+    const bool emhd_enabled = pkgs.count("EMHD");
+    const bool use_ideal_guess = (emhd_enabled) ? pkgs.at("GRMHD")->Param<bool>("ideal_guess") : false;
 
     // Allocate/copy the things we need
     // TODO these can now be reduced by including the var lists/flags which actually need to be allocated
@@ -190,6 +192,13 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
                                                      md_flux_src.get(), md_solver.get(),
                                                      std::vector<MetadataFlag>{Metadata::GetUserFlag("Explicit"), Metadata::Independent},
                                                      use_b_ct, stage);
+
+        // Update ideal MHD variables so that they can be used as a guess for the solver.
+        // Only used if emhd/ideal_guess is enabled.
+        // An additional `AddStateUpdate` task just for variables marked with the `IdealGuess` flag
+        if (use_ideal_guess) {
+            
+        }
 
         // Make sure the primitive values of *explicitly-evolved* variables are updated.
         // Packages with implicitly-evolved vars should only register BoundaryUtoP or BoundaryPtoU

--- a/kharma/driver/kharma_driver.cpp
+++ b/kharma/driver/kharma_driver.cpp
@@ -286,7 +286,8 @@ TaskID KHARMADriver::AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real> *md,
     auto pmb0  = md->GetBlockData(0)->GetBlockPointer();
     auto& pkgs = pmb0->packages.AllPackages();
 
-    const Floors::Prescription fofc_floors = pmb0->packages.Get("Flux")->Param<Floors::Prescription>("fofc_prescription");
+    const Floors::Prescription fofc_floors       = pmb0->packages.Get("Flux")->Param<Floors::Prescription>("fofc_prescription");
+    const Floors::Prescription fofc_floors_inner = pmb0->packages.Get("Flux")->Param<Floors::Prescription>("fofc_prescription_inner");
 
     // Populate guess source term with divergence of the existing fluxes
     // NOTE this does not include source terms!  Though, could call them here tbh
@@ -309,7 +310,7 @@ TaskID KHARMADriver::AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real> *md,
     auto t_guess_Bp = tl.AddTask(t_guess_update, B_FluxCT::MeshUtoP, guess, IndexDomain::entire, false);
     auto t_guess_prims = tl.AddTask(t_guess_Bp, Inverter::MeshUtoP, guess, IndexDomain::entire, false);
     // Check and mark floors
-    auto t_mark_floors = tl.AddTask(t_guess_prims, Floors::DetermineGRMHDFloors, guess, IndexDomain::entire, fofc_floors, fofc_floors);
+    auto t_mark_floors = tl.AddTask(t_guess_prims, Floors::DetermineGRMHDFloors, guess, IndexDomain::entire, fofc_floors, fofc_floors_inner);
     // Determine which cells are FOFC in our block
     auto t_mark_fofc = tl.AddTask(t_mark_floors, Flux::MarkFOFC, guess);
     // Sync with neighbor blocks.  This seems to ameliorate an increasing divB on X1 boundaries in GR,

--- a/kharma/driver/kharma_driver.cpp
+++ b/kharma/driver/kharma_driver.cpp
@@ -309,7 +309,7 @@ TaskID KHARMADriver::AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real> *md,
     auto t_guess_Bp = tl.AddTask(t_guess_update, B_FluxCT::MeshUtoP, guess, IndexDomain::entire, false);
     auto t_guess_prims = tl.AddTask(t_guess_Bp, Inverter::MeshUtoP, guess, IndexDomain::entire, false);
     // Check and mark floors
-    auto t_mark_floors = tl.AddTask(t_guess_prims, Floors::DetermineGRMHDFloors, guess, IndexDomain::entire, fofc_floors);
+    auto t_mark_floors = tl.AddTask(t_guess_prims, Floors::DetermineGRMHDFloors, guess, IndexDomain::entire, fofc_floors, fofc_floors);
     // Determine which cells are FOFC in our block
     auto t_mark_fofc = tl.AddTask(t_mark_floors, Flux::MarkFOFC, guess);
     // Sync with neighbor blocks.  This seems to ameliorate an increasing divB on X1 boundaries in GR,

--- a/kharma/driver/kharma_driver.cpp
+++ b/kharma/driver/kharma_driver.cpp
@@ -82,6 +82,14 @@ std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(ParameterInput *pin, std
     // so we define the flags here to avoid loading order issues
     Metadata::AddUserFlag("Implicit");
     Metadata::AddUserFlag("Explicit");
+    // Add a flag if we wish to use ideal variables explicitly evolved as guess for implicit update.
+    // GRIM uses the fluid state of the previous (sub-)step.
+    // The logic here is that the non-ideal variables do not significantly contribute to the
+    // stress-energy tensor. Hence, we can explicitly update the ideal MHD variables and hope
+    // that this takes us to a region in the parameter space of state variables that 
+    // is close to the true solution. The corrections obtained from the implicit update would then
+    // be small corrections.
+    Metadata::AddUserFlag("IdealGuess");
 
     // 1. One flag to mark the primitive variables specifically
     // (Parthenon has Metadata::Conserved already)

--- a/kharma/driver/kharma_driver.hpp
+++ b/kharma/driver/kharma_driver.hpp
@@ -134,6 +134,15 @@ class KHARMADriver : public MultiStageDriver {
                                 bool update_face, int stage);
 
         /**
+         * This function updates a state md_update with the results of an explicit source term calculation
+         * placed in md_flux_src. It is similar to `AddStateUpdate` but applies only to variables marked
+         * with the `IdealGuess` flag.
+         */
+        TaskID AddStateUpdateIdealGuess(TaskID& t_start, TaskList& tl, MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init,
+                                MeshData<Real> *md_flux_src, MeshData<Real> *md_update, std::vector<MetadataFlag> flags,
+                                bool update_face, int stage);
+
+        /**
          * Add a synchronization retion to an existing TaskCollection tc.
          * Since the region is self-contained, does not return a TaskID
          */

--- a/kharma/electrons/electrons.cpp
+++ b/kharma/electrons/electrons.cpp
@@ -573,17 +573,17 @@ void ApplyFloors(MeshBlockData<Real> *mbd, IndexDomain domain)
             // Also apply the ceiling to the advected entropy KTOT, if we're keeping track of that
             // (either for electrons, or robust primitive inversions in future)
             Real ktot_max;
-            if (floors.radius_dependent_floors && G.coords.is_spherical()) {
-                GReal r = G.r(k, j, i);
-                (r < floors.floors_switch_r) ? ktot_max = floors_inner.ktot_max : floors.ktot_max;
-            }
-            else {
-                ktot_max = floors.ktot_max;
-            }
-
-            if (m_p.KTOT >= 0 && (P(m_p.KTOT, k, j, i) > ktot_max)) {
-                fflag(0, k, j, i) = Floors::FFlag::KTOT | (int) fflag(0, k, j, i);
-                P(m_p.KTOT, k, j, i) = ktot_max;
+            if (m_p.KTOT >= 0) {
+                if (floors.radius_dependent_floors && G.coords.is_spherical()) {
+                    GReal r = G.r(k, j, i);
+                    (r < floors.floors_switch_r) ? ktot_max = floors_inner.ktot_max : floors.ktot_max;
+                }
+                else ktot_max = floors.ktot_max;
+                
+                if (P(m_p.KTOT, k, j, i) > ktot_max) {
+                    fflag(0, k, j, i) = Floors::FFlag::KTOT | (int) fflag(0, k, j, i);
+                    P(m_p.KTOT, k, j, i) = ktot_max;
+                }
             }
 
             // TODO(BSP) restore Ressler adjustment option

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -89,6 +89,15 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
         params.Add("frame_switch_beta", frame_switch_beta);
     }
 
+    // Radius-dependent floors and ceiling in a given frame
+    // Default presciption struct refers to outer domain, i.e., beyond 'floor_switch_r'
+    // Make an additional prescription struct for inner domain.
+    // There are two Floors::Prescription objects even if there is no radius-dependence,
+    // the values will simply if the same in both objects.
+    // Avoids a bunch of if (radius_dependent_floors) else while determining floors.
+    // TODO(VKD): Combine this functionality with frame switching
+    params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
+
     // Disable all floors.  It is obviously tremendously inadvisable to do this
     // Note this will only be recorded if false, otherwise we're not loaded at all!
     bool disable_floors = pin->GetOrAddBoolean("floors", "disable_floors", false);
@@ -170,10 +179,11 @@ TaskStatus Floors::ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *
     pmb->par_for("apply_initial_floors", b.ks, b.ke, b.js, b.je, b.is, b.ie,
         KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
             Real rhoflr_max, uflr_max;
-            int fflag = determine_floors(G, P, m_p, gam, k, j, i, floors, rhoflr_max, uflr_max);
+            // Initial floors, so the radius-dependence of floors don't matter that much. 
+            int fflag = determine_floors(G, P, m_p, gam, k, j, i, floors, floors, rhoflr_max, uflr_max);
             if (fflag) {
                 apply_floors<InjectionFrame::fluid>(G, P, m_p, gam, k, j, i, rhoflr_max, uflr_max, U, m_u);
-                apply_ceilings(G, P, m_p, gam, k, j, i, floors, U, m_u);
+                apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors, U, m_u);
                 // P->U for any modified zones
                 Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, j, i, U, m_u, Loci::center);
             }
@@ -184,7 +194,8 @@ TaskStatus Floors::ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *
     return TaskStatus::complete;
 }
 
-TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain, const Floors::Prescription& floors)
+TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
+    const Floors::Prescription& floors, const Floors::Prescription& floors_inner)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -208,7 +219,7 @@ TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain, 
         KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
             const auto& G = P.GetCoords(b);
             fflag(b, 0, k, j, i) = static_cast<int>(fflag(b, 0, k, j, i)) |
-                                    determine_floors(G, P(b), m_p, gam, k, j, i, floors,
+                                    determine_floors(G, P(b), m_p, gam, k, j, i, floors, floors_inner,
                                                      floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i));
         }
     );

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -93,9 +93,8 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // Default presciption struct refers to outer domain, i.e., beyond 'floor_switch_r'
     // Make an additional prescription struct for inner domain.
     // There are two Floors::Prescription objects even if there is no radius-dependence,
-    // the values will simply if the same in both objects.
+    // the values will simply be the same if radius-dependent floors are not enabled.
     // Avoids a bunch of if (radius_dependent_floors) else while determining floors.
-    // TODO(VKD): Combine this functionality with frame switching
     params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
 
     // Disable all floors.  It is obviously tremendously inadvisable to do this

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -97,7 +97,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // Avoids a bunch of if (radius_dependent_floors) else while determining floors.
     if (pin->DoesBlockExist("floors_inner"))
         params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
-    else:
+    else
         params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)), "floors");
 
     // Disable all floors.  It is obviously tremendously inadvisable to do this

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -95,7 +95,10 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // There are two Floors::Prescription objects even if there is no radius-dependence,
     // the values will simply be the same if radius-dependent floors are not enabled.
     // Avoids a bunch of if (radius_dependent_floors) else while determining floors.
-    params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
+    if (pin->DoesBlockExist("floors_inner"))
+        params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
+    else:
+        params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)), "floors");
 
     // Disable all floors.  It is obviously tremendously inadvisable to do this
     // Note this will only be recorded if false, otherwise we're not loaded at all!

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -113,7 +113,7 @@ class Prescription {
         bool use_r_char, temp_adjust_u, adjust_k;
         // Radius dependent floors?
         bool radius_dependent_floors;
-        GReal floors_switch_r;
+        Real floors_switch_r;
 };
 
 inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string block="floors")

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -168,10 +168,10 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
 
 /**
  * Set prescription struct for inner domain (r < floor_switch_r) if 'radius_dependent_floors' is enabled.
- * Sets values provided in the 'floors/inner' block in input par file if provided,
+ * Sets values provided in the 'floors_inner' block in input par file if provided,
  * else sets it equal to the values in the whole/outer domain.
  */
-inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescription p_outer, std::string block="floors/inner"){
+inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescription p_outer, std::string block="floors_inner"){
     
     Prescription p_inner;
 

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -111,6 +111,9 @@ class Prescription {
         Real gamma_max;
         // Floor options (frame was MOVED to templating)
         bool use_r_char, temp_adjust_u, adjust_k;
+        // Radius dependent floors?
+        bool radius_dependent_floors;
+        GReal floors_switch_r;
 };
 
 inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string block="floors")
@@ -157,7 +160,56 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
     // Limit the fluid Lorentz factor gamma
     p.gamma_max = pin->GetOrAddReal(block, "gamma_max", 50.);
 
+    p.radius_dependent_floors = pin->GetOrAddBoolean("floors", "radius_dependent_floors", false); 
+    p.floors_switch_r = pin->GetOrAddReal("floors", "floors_switch_r", 50.);
+
     return p;
+}
+
+/**
+ * Set prescription struct for inner domain (r < floor_switch_r) if 'radius_dependent_floors' is enabled.
+ * Sets values provided in the 'floors/inner' block in input par file if provided,
+ * else sets it equal to the values in the whole/outer domain.
+ */
+inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescription p_outer, std::string block="floors/inner"){
+    
+    Prescription p_inner;
+
+    // Floor parameters
+    if (pin->GetBoolean("coordinates", "spherical")) {
+        // In spherical systems, floors drop as r^2, so set them higher by default
+        p_inner.rho_min_geom = pin->GetOrAddReal(block, "rho_min_geom", p_outer.rho_min_geom);
+        p_inner.u_min_geom   = pin->GetOrAddReal(block, "u_min_geom", p_outer.u_min_geom);
+        // Some constant for large distances. New, out of the way by default
+        p_inner.rho_min_const = pin->GetOrAddReal(block, "rho_min_const", p_outer.rho_min_const);
+        p_inner.u_min_const   = pin->GetOrAddReal(block, "u_min_const", p_outer.u_min_const);
+    } else { // TODO spherical cart will also have both
+        // Accept old names
+        Real rho_min_const_default = pin->DoesParameterExist(block, "rho_min_geom") ?
+                                        pin->GetReal(block, "rho_min_geom") : p_outer.rho_min_geom;
+        Real u_min_const_default   = pin->DoesParameterExist(block, "u_min_geom") ?
+                                        pin->GetReal(block, "u_min_geom") : p_outer.u_min_geom;
+        p_inner.rho_min_const = pin->GetOrAddReal(block, "rho_min_const", rho_min_const_default);
+        p_inner.u_min_const   = pin->GetOrAddReal(block, "u_min_const", u_min_const_default);
+    }
+
+    p_inner.use_r_char = pin->GetOrAddBoolean(block, "use_r_char", p_outer.use_r_char);
+    p_inner.r_char     = pin->GetOrAddReal(block, "r_char", p_outer.r_char);
+
+    p_inner.bsq_over_rho_max = pin->GetOrAddReal(block, "bsq_over_rho_max", p_outer.bsq_over_rho_max);
+    p_inner.bsq_over_u_max = pin->GetOrAddReal(block, "bsq_over_u_max", p_outer.bsq_over_u_max);
+
+    p_inner.u_over_rho_max = pin->GetOrAddReal(block, "u_over_rho_max", p_outer.u_over_rho_max);
+    p_inner.ktot_max = pin->GetOrAddReal(block, "ktot_max", p_outer.ktot_max);
+    p_inner.temp_adjust_u = pin->GetOrAddBoolean(block, "temp_adjust_u", p_outer.temp_adjust_u);
+    p_inner.adjust_k = pin->GetOrAddBoolean(block, "adjust_k", p_outer.adjust_k);
+
+    p_inner.gamma_max = pin->GetOrAddReal(block, "gamma_max", p_outer.gamma_max);
+
+    p_inner.radius_dependent_floors = pin->GetOrAddBoolean("floors", "radius_dependent_floors", p_outer.radius_dependent_floors); 
+    p_inner.floors_switch_r = pin->GetOrAddReal("floors", "floors_switch_r", p_outer.floors_switch_r);
+
+    return p_inner;
 }
 
 /**
@@ -181,7 +233,8 @@ TaskStatus ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain);
  * 2. fflag, which floors were hit by the current state
  * This is what ApplyFloors uses to determine the floor values/locations
  */
-TaskStatus DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain, const Floors::Prescription& floors);
+TaskStatus DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
+    const Floors::Prescription& floors, const Floors::Prescription& floors_inner);
 
 /**
  * Apply the same floors as above, in the same way, except:

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -322,7 +322,7 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal>(FLOOR_ONE_ARGS)
     // Kastaun would need real vals here...
     const Floors::Prescription floor_tmp = {0}; 
     return Inverter::u_to_p<Inverter::Type::onedw>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                     floor_tmp, 8, 1e-8);
+                                                     floor_tmp, floor_tmp, 8, 1e-8);
 }
 
 template<>
@@ -371,7 +371,6 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Local& P, co
         GReal Xembed[GR_DIM];
         G.coord_embed(0, j, i, loc, Xembed);
         GReal r = Xembed[1];
-        const GReal r = G.r(k, j, i);
         // r_char sets more aggressive floor close to EH but backs off
         Real rhoscal = (floors.use_r_char) ? (r < floors.floors_switch_r) ? 1. / ((r*r) * (1 + r / floors_inner.r_char)) 
                         : 1. / ((r*r) * (1 + r / floors.r_char)) : 1. / m::sqrt(r*r*r);
@@ -407,7 +406,6 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, c
         GReal Xembed[GR_DIM];
         G.coord_embed(0, j, i, loc, Xembed);
         GReal r = Xembed[1];
-        const GReal r = G.r(k, j, i);
         // r_char sets more aggressive floor close to EH but backs off
         Real rhoscal = (floors.use_r_char) ? (r < floors.floors_switch_r) ? 1. / ((r*r) * (1 + r / floors_inner.r_char)) 
                         : 1. / ((r*r) * (1 + r / floors.r_char)) : 1. / m::sqrt(r*r*r);
@@ -419,7 +417,7 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, c
         rhoflr_geom = floors.rho_min_geom;
         uflr_geom   = floors.u_min_geom;
     }
-    
+
     int fflag = 0;
     // Record all the floors that were hit, using bitflags
     // Record Geometric floor hits

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -47,14 +47,26 @@ namespace Floors {
  * LOCKSTEP: this function respects P and returns consistent P<->U
  */
 KOKKOS_INLINE_FUNCTION void apply_ceilings(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                          const Real& gam, const int& k, const int& j, const int& i, const Floors::Prescription& floors,
+                                          const Real& gam, const int& k, const int& j, const int& i,
+                                          const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
                                           const VariablePack<Real>& U, const VarMap& m_u, const Loci loc=Loci::center)
 {
-    // First apply ceilings:
+    // Compute max values for ceilings
+    Real gamma      = GRMHD::lorentz_calc(G, P, m_p, k, j, i, loc);
+    Real ktot       = (gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam);
+    Real u_over_rho = P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
+    Real gamma_max, ktot_max, u_over_rho_max;
+    if (floors.radius_dependent_floors && G.coords.is_spherical()) {
+        // Obtain radius value
+        GReal r = G.r(k, j, i);
+        (r < floors.floors_switch_r) ? gamma_max      = floors_inner.gamma_max : floors.gamma_max;
+        (r < floors.floors_switch_r) ? ktot_max       = floors_inner.ktot_max : floors.ktot_max;
+        (r < floors.floors_switch_r) ? u_over_rho_max = floors_inner.u_over_rho_max : floors.u_over_rho_max;
+    }
+
     // 1. Limit gamma with respect to normal observer
-    Real gamma = GRMHD::lorentz_calc(G, P, m_p, k, j, i, loc);
-    if (gamma > floors.gamma_max) {
-        Real f = m::sqrt((SQR(floors.gamma_max) - 1.) / (SQR(gamma) - 1.));
+    if (gamma > gamma_max) {
+        Real f = m::sqrt((SQR(gamma_max) - 1.) / (SQR(gamma) - 1.));
         VLOOP P(m_p.U1+v, k, j, i) *= f;
     }
 
@@ -62,20 +74,19 @@ KOKKOS_INLINE_FUNCTION void apply_ceilings(const GRCoordinates& G, const Variabl
     // Note this technically applies the condition *one step sooner* than legacy, since it operates on
     // the entropy as calculated from current conditions, rather than the value kept from the previous
     // step for calculating dissipation.
-    Real ktot = (gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam);
-    if (ktot > floors.ktot_max) {
-        P(m_p.UU, k, j, i) = floors.ktot_max / ktot * P(m_p.UU, k, j, i);
+    if (ktot > ktot_max) {
+        P(m_p.UU, k, j, i) = ktot_max / ktot * P(m_p.UU, k, j, i);
     }
 
     // 3. Limit the temperature by controlling u.  Can optionally add density instead, implemented in apply_floors
-    if (floors.temp_adjust_u && P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > floors.u_over_rho_max) {
-        P(m_p.UU, k, j, i) = floors.u_over_rho_max * P(m_p.RHO, k, j, i);
+    if (floors.temp_adjust_u && P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > u_over_rho_max) {
+        P(m_p.UU, k, j, i) = u_over_rho_max * P(m_p.RHO, k, j, i);
     }
 }
 
 KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
                                         const Real& gam, const int& k, const int& j, const int& i, const Floors::Prescription& floors,
-                                        Real& rhoflr_max, Real& uflr_max)
+                                        const Floors::Prescription& floors_inner, Real& rhoflr_max, Real& uflr_max)
 {
     // Calculate the different floor values in play:
     // 1. Geometric hard floors, not based on fluid relationships
@@ -84,9 +95,12 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
     if(G.coords.is_spherical()) {
         const GReal r = G.r(k, j, i);
         // r_char sets more aggressive floor close to EH but backs off
-        Real rhoscal = (floors.use_r_char) ? 1. / ((r*r) * (1 + r / floors.r_char)) : 1. / m::sqrt(r*r*r);
-        rhoflr_geom = m::max(floors.rho_min_geom * rhoscal, floors.rho_min_const);
-        uflr_geom   = m::max(floors.u_min_geom * m::pow(rhoscal, gam), floors.u_min_const);
+        Real rhoscal = (floors.use_r_char) ? (r < floors.floors_switch_r) ? 1. / ((r*r) * (1 + r / floors_inner.r_char)) 
+                        : 1. / ((r*r) * (1 + r / floors.r_char)) : 1. / m::sqrt(r*r*r);
+        rhoflr_geom = (r < floors.floors_switch_r) ? m::max(floors_inner.rho_min_geom * rhoscal, floors_inner.rho_min_const)
+                        : m::max(floors.rho_min_geom * rhoscal, floors.rho_min_const);
+        uflr_geom   = (r < floors.floors_switch_r) ? m::max(floors_inner.u_min_geom * m::pow(rhoscal, gam), floors_inner.u_min_const)
+                        : m::max(floors.u_min_geom * m::pow(rhoscal, gam), floors.u_min_const);
     } else {
         rhoflr_geom = floors.rho_min_const;
         uflr_geom   = floors.u_min_const;
@@ -95,9 +109,20 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
     // 2. Magnetization ceilings: impose maximum magnetization sigma = bsq/rho, and inverse beta prop. to bsq/U
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
-    Real bsq      = dot(Dtmp.bcon, Dtmp.bcov);
-    Real rhoflr_b = bsq / floors.bsq_over_rho_max;
-    Real uflr_b   = bsq / floors.bsq_over_u_max;
+    Real rhoflr_b, uflr_b;
+    // Radius-dependent floors.
+    // Used with spherical coordinate system, i.e., G.r(k,j,i) exist
+    if (floors.radius_dependent_floors && G.coords.is_spherical()) {
+        // Obtain radius value
+        GReal r = G.r(k, j, i);
+        Real bsq = dot(Dtmp.bcon, Dtmp.bcov);
+        rhoflr_b = (r < floors.floors_switch_r) ? (bsq / floors_inner.bsq_over_rho_max) : (bsq / floors.bsq_over_rho_max);
+        uflr_b   = (r < floors.floors_switch_r) ? (bsq / floors_inner.bsq_over_u_max) : (bsq / floors.bsq_over_u_max);
+    } else {
+        Real bsq = dot(Dtmp.bcon, Dtmp.bcov);
+        rhoflr_b = bsq / floors.bsq_over_rho_max;
+        uflr_b   = bsq / floors.bsq_over_u_max;
+    }
 
     // Evaluate max U floor, needed for temp ceiling below
     uflr_max = m::max(uflr_geom, uflr_b);
@@ -109,7 +134,16 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
     if (!floors.temp_adjust_u) {
         // 3. Temperature ceiling: impose maximum temperature u/rho
         // Take floors on U into account
-        double rhoflr_temp = m::max(u, uflr_max) / floors.u_over_rho_max;
+        double rhoflr_temp;
+        if (floors.radius_dependent_floors && G.coords.is_spherical()) {
+            // Obtain radius value
+            GReal r = G.r(k, j, i);
+            rhoflr_temp = (r < floors.floors_switch_r) ? (m::max(u, uflr_max) / floors_inner.u_over_rho_max)
+                : (m::max(u, uflr_max) / floors.u_over_rho_max);
+        } else {
+            rhoflr_temp = m::max(u, uflr_max) / floors.u_over_rho_max;
+        }
+
         // Record hitting temperature ceiling
         fflag |= (rhoflr_temp > rho) * FFlag::TEMP;
 
@@ -131,14 +165,32 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
     }
 
     // Then ceilings, need to record these for FOFC. See real implementation.
-    if (GRMHD::lorentz_calc(G, P, m_p, k, j, i, Loci::center) > floors.gamma_max)
-        fflag |= FFlag::GAMMA;
+    if (floors.radius_dependent_floors && G.coords.is_spherical()) {
+        GReal lorentz_factor, ktot, temperature;
+        // Obtain radius value
+        GReal r = G.r(k, j, i);
 
-    if ((gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam) > floors.ktot_max)
-        fflag |= FFlag::KTOT;
+        lorentz_factor = GRMHD::lorentz_calc(G, P, m_p, k, j, i, Loci::center);
+        ktot           = (gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam);
+        temperature    = P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
 
-    if (floors.temp_adjust_u && (P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > floors.u_over_rho_max))
-        fflag |= FFlag::TEMP;
+        // Record hits
+        if ((r < floors.floors_switch_r) ? lorentz_factor > floors_inner.gamma_max : lorentz_factor > floors.gamma_max)
+            fflag |= FFlag::GAMMA;
+        if ((r < floors.floors_switch_r) ? ktot > floors_inner.ktot_max : ktot > floors.ktot_max)
+            fflag |= FFlag::KTOT;
+        if ((r < floors.floors_switch_r) ? temperature > floors_inner.u_over_rho_max : temperature > floors.u_over_rho_max)
+            fflag |= FFlag::TEMP;
+    } else {
+        if (GRMHD::lorentz_calc(G, P, m_p, k, j, i, Loci::center) > floors.gamma_max)
+            fflag |= FFlag::GAMMA;
+
+        if ((gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam) > floors.ktot_max)
+            fflag |= FFlag::KTOT;
+
+        if (floors.temp_adjust_u && (P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > floors.u_over_rho_max))
+            fflag |= FFlag::TEMP;
+    }
 
     return fflag;
 }

--- a/kharma/floors/floors_impl.hpp
+++ b/kharma/floors/floors_impl.hpp
@@ -63,9 +63,10 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb0->packages);
     // Still needed for ceilings and determining floors
     const Floors::Prescription floors = pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+    const Floors::Prescription floors_inner = pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
 
     // Determine floors
-    DetermineGRMHDFloors(md, domain, floors);
+    DetermineGRMHDFloors(md, domain, floors, floors_inner);
 
     const IndexRange3 b = KDomain::GetRange(md, domain);
     const IndexRange block = IndexRange{0, P.GetDim(5) - 1};
@@ -83,7 +84,7 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                 if (pflag_l) pflag(b, 0, k, j, i) = pflag_l;
 
                 // Apply ceilings *after* floors, to make the temperature ceiling better-behaved
-                apply_ceilings(G, P(b), m_p, gam, k, j, i, floors, U(b), m_u);
+                apply_ceilings(G, P(b), m_p, gam, k, j, i, floors, floors_inner, U(b), m_u);
 
                 // P->U for any modified zones
                 Flux::p_to_u_mhd(G, P(b), m_p, emhd_params, gam, k, j, i, U(b), m_u, Loci::center);

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -188,7 +188,10 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         // TODO even post-reconstruction/reconstruction fallback?
         if (!pin->DoesBlockExist("fofc_floors")) {
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "floors"));
-            params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+            if (pin->DoesBlockExist("floors_inner"))
+                params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+            else:
+                params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
         } else {
             // Override inner and outer floors with `fofc_floors` block
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "fofc_floors"));

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -188,8 +188,11 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         // TODO even post-reconstruction/reconstruction fallback?
         if (!pin->DoesBlockExist("fofc_floors")) {
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "floors"));
+            params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
         } else {
+            // Override inner and outer floors with `fofc_floors` block
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "fofc_floors"));
+            params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "fofc_floors"), "fofc_floors"));
         }
 
         // Flag for whether FOFC was applied, for diagnostics

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -190,7 +190,7 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "floors"));
             if (pin->DoesBlockExist("floors_inner"))
                 params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
-            else:
+            else
                 params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
         } else {
             // Override inner and outer floors with `fofc_floors` block

--- a/kharma/flux/get_flux.hpp
+++ b/kharma/flux/get_flux.hpp
@@ -79,13 +79,16 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
 
     const bool reconstruction_floors = pars.Get<bool>("reconstruction_floors");
     Floors::Prescription floors_temp;
+    Floors::Prescription floors_inner_temp;
     if (reconstruction_floors) {
         // Apply post-reconstruction floors.
         // Only enabled for WENO since it is not TVD, and only when other
         // floors are enabled.
-        floors_temp = packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+        floors_temp       = packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+        floors_inner_temp = packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
     }
     const Floors::Prescription& floors = floors_temp;
+    const Floors::Prescription& floors_inner = floors_inner_temp;
 
     const bool reconstruction_fallback = pars.Get<bool>("reconstruction_fallback");
 
@@ -172,8 +175,8 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
                     // we have no guarantee they remotely resemble the *centered* primitives
                     // If we selected to fall back to TVD, the floors are at zero (as intended)
                     if (reconstruction_floors || reconstruction_fallback) {
-                        fallback_tvd(i)  = Floors::apply_geo_floors(G, Pl, m_p, gam, j, i, floors, loc);
-                        fallback_tvd(i) |= Floors::apply_geo_floors(G, Pr, m_p, gam, j, i, floors, loc);
+                        fallback_tvd(i)  = Floors::apply_geo_floors(G, Pl, m_p, gam, j, i, floors, floors_inner, loc);
+                        fallback_tvd(i) |= Floors::apply_geo_floors(G, Pr, m_p, gam, j, i, floors, floors_inner, loc);
                     }
                 }
             );

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -110,6 +110,9 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     auto implicit_grmhd = (driver.Get<DriverType>("type") == DriverType::imex) &&
                           (pin->GetBoolean("emhd", "on") || pin->GetOrAddBoolean("GRMHD", "implicit", false));
     params.Add("implicit", implicit_grmhd);
+    // Explicitly-evolved ideal MHD variables as guess for Extended MHD runs
+    const bool ideal_guess = pin->GetOrAddBoolean("emhd", "ideal_guess", false);
+    params.Add("ideal_guess", ideal_guess);
 
     // AMR PARAMETERS
     // Adaptive mesh refinement options

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -144,6 +144,10 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     auto flags_cons = driver.Get<std::vector<MetadataFlag>>("cons_flags");
     flags_cons.insert(flags_cons.end(), flags_grmhd.begin(), flags_grmhd.end());
 
+    // Mark whether the ideal MHD variables are to be updated explicitly for the guess to the solver
+    flags_prim.push_back(Metadata::GetUserFlag("IdealGuess"));
+    flags_cons.push_back(Metadata::GetUserFlag("IdealGuess"));
+
     // We must additionally save the primtive variables as the "seed" for the next U->P solve
     flags_prim.push_back(Metadata::Restart);
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     params.Add("max_dt_increase", max_dt_increase);
 
     // Alternatively, you can start with (or just always use) the light (phase) speed crossing time
-    // of the smallest zone.  Useful when you're not sure of/modeling the characteristic velocities
+    // of the smallest zone. Useful when you're not sure of/modeling the characteristic velocities
     bool start_dt_light = pin->GetOrAddBoolean("parthenon/time", "start_dt_light", false);
     params.Add("start_dt_light", start_dt_light);
     bool use_dt_light = pin->GetOrAddBoolean("parthenon/time", "use_dt_light", false);
@@ -145,8 +145,10 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     flags_cons.insert(flags_cons.end(), flags_grmhd.begin(), flags_grmhd.end());
 
     // Mark whether the ideal MHD variables are to be updated explicitly for the guess to the solver
-    flags_prim.push_back(Metadata::GetUserFlag("IdealGuess"));
-    flags_cons.push_back(Metadata::GetUserFlag("IdealGuess"));
+    if (ideal_guess) {
+        flags_prim.push_back(Metadata::GetUserFlag("IdealGuess"));
+        flags_cons.push_back(Metadata::GetUserFlag("IdealGuess"));
+    }
 
     // We must additionally save the primtive variables as the "seed" for the next U->P solve
     flags_prim.push_back(Metadata::Restart);

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -121,6 +121,9 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     const Floors::Prescription floors = pmb->packages.AllPackages().count("Floors") ?
                                         pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription") :
                                         pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
+    const Floors::Prescription floors_inner = pmb->packages.AllPackages().count("Floors") ?
+                                        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner") :
+                                        pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
 
     // We need the full packs of prims/cons for p_to_u
     // Pack new variables
@@ -139,7 +142,7 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
             if (failed(pflag(k, j, i))) {
                 // Make sure all fixed values still abide by floors
                 // TODO Full floors instead of just geo?
-                Floors::apply_geo_floors(G, P, m_p, gam, k, j, i, floors);
+                Floors::apply_geo_floors(G, P, m_p, gam, k, j, i, floors, floors_inner);
 
                 // Make sure to keep lockstep
                 // This will only be run for GRMHD, so we can call its p_to_u

--- a/kharma/inverter/invert_template.hpp
+++ b/kharma/inverter/invert_template.hpp
@@ -88,5 +88,6 @@ KOKKOS_INLINE_FUNCTION int u_to_p(const GRCoordinates& G, const VariablePack<Rea
                                               const Real& gam, const int& k, const int& j, const int& i,
                                               const VariablePack<Real>& P, const VarMap& m_p,
                                               const Loci& loc, const Floors::Prescription& inverter_floors,
+                                              const Floors::Prescription& inverter_floors_inner,
                                               const int& max_iterations, const Real& tol);
 } // namespace Inverter

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -146,7 +146,7 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
     pmb->par_for("U_to_P", b.ks, b.ke, b.js, b.je, b.is, b.ie,
         KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
             int pflagl = Inverter::u_to_p<inverter>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                    inverter_floors, inverter_floors_inner,  err_tol);
+                                                    inverter_floors, inverter_floors_inner, iter_max, err_tol);
             pflag(0, k, j, i) = pflagl % Floors::FFlag::MINIMUM;
             int fflagl = (pflagl / Floors::FFlag::MINIMUM) * Floors::FFlag::MINIMUM;
             fflag(0, k, j, i) = fflagl;

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -68,7 +68,10 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     // Use a custom block for inverter floors to allow customization.  Not sure anyone *wants* that but...
     if (!pin->DoesBlockExist("inverter_floors")) {
         params.Add("inverter_prescription", Floors::MakePrescription(pin, "floors"));
-        params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+            if (pin->DoesBlockExist("floors_inner"))
+                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+            else
+                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
     } else {
         params.Add("inverter_prescription", Floors::MakePrescription(pin, "inverter_floors"));
         params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "inverter_floors"), "inverter_floors"));

--- a/kharma/inverter/onedw.hpp
+++ b/kharma/inverter/onedw.hpp
@@ -91,6 +91,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
                                               const Real& gam, const int& k, const int& j, const int& i,
                                               const VariablePack<Real>& P, const VarMap& m_p,
                                               const Loci& loc, const Floors::Prescription& inverter_floors,
+                                              const Floors::Prescription& inverter_floors_inner,
                                               const int& max_iterations, const Real& tol)
 {
     // TODO try inline floors in the old 1Dw?  Probably not relevant anymore

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -300,8 +300,10 @@ Packages_t KHARMA::ProcessPackages(std::unique_ptr<ParameterInput> &pin)
     // GRMHD needs globals to mark packages
     auto t_grmhd = tl.AddTask(t_globals | t_driver, KHARMA::AddPackage, packages, GRMHD::Initialize, pin.get());
     // Only load the inverter if GRMHD/EMHD isn't being evolved implicitly
+    // Unless we want to use the explicitly-evolved ideal MHD variables as a guess for the solver
     auto t_inverter = t_grmhd;
-    if (!pin->GetOrAddBoolean("GRMHD", "implicit", pin->GetOrAddBoolean("emhd", "on", false))) {
+    if (!pin->GetOrAddBoolean("GRMHD", "implicit", pin->GetOrAddBoolean("emhd", "on", false)) ||
+        pin->GetOrAddBoolean("emhd", "ideal_guess", false)) {
         t_inverter = tl.AddTask(t_grmhd, KHARMA::AddPackage, packages, Inverter::Initialize, pin.get());
     }
     // Floors package is only loaded if floors aren't disabled (TODO rename "on"?)

--- a/kharma/prob/bz_monopole.cpp
+++ b/kharma/prob/bz_monopole.cpp
@@ -49,7 +49,7 @@ TaskStatus InitializeBZMonopole(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
 
     Real bsq_o_rho_max = pin->GetOrAddReal("floors", "bsq_over_rho_max", 1.e2);
     Real rho_min_limit = pin->GetOrAddReal("floors", "rho_min_geom", 1.e-6);
-    Real u_min_limit = pin->GetOrAddReal("floors", "u_min_geom", 1.e-8);
+    Real u_min_limit   = pin->GetOrAddReal("floors", "u_min_geom", 1.e-8);
 
     IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);

--- a/tests/bondi_viscous/run.sh
+++ b/tests/bondi_viscous/run.sh
@@ -22,7 +22,7 @@ conv_2d() {
         mv bondi.out0.final.phdf emhd_2d_${res}_end_${1}.phdf
     done
     check_code=0
-    python check.py $ALL_RES $1 2d || check_code=$?
+    python3 check.py $ALL_RES $1 2d || check_code=$?
     rm -r *.xdmf
     rm -r *.out0*
     if [[ $check_code != 0 ]]; then
@@ -34,6 +34,8 @@ conv_2d() {
 }
 
 ALL_RES="8,16,32,64"
-conv_2d emhd2d_weno driver/reconstruction=weno5 "in 2D, WENO5"
+conv_2d emhd2d_weno driver/reconstruction=weno5 "Viscous Bondi in 2D, WENO5"
+# Test if it works with ideal solution as guess
+conv_2d emhd2d_weno_ideal_guess emhd/ideal_guess=true "Viscous bondi in 2D, WENO5, Ideal guess"
 
 exit $exit_code

--- a/tests/conducting_atmosphere/run.sh
+++ b/tests/conducting_atmosphere/run.sh
@@ -25,7 +25,7 @@ conv_2d() {
     done
     check_code=0
     pyharm-convert --double *.phdf
-    python check.py $ALL_RES $1 2d || check_code=$?
+    python3 check.py $ALL_RES $1 2d || check_code=$?
     if [[ $check_code != 0 ]]; then
         echo Conducting atmosphere test $3 FAIL: $check_code
         exit_code=1
@@ -36,5 +36,7 @@ conv_2d() {
 
 ALL_RES="64,128,256,512"
 conv_2d emhd2d_weno driver/reconstruction=weno5 "in 2D, WENO5"
+# Test if it works with ideal solution as guess
+conv_2d emhd2d_weno_ideal_guess emhd/ideal_guess=true "in 2D, WENO5, Ideal guess"
 
 exit $exit_code

--- a/tests/emhdmodes/check.py
+++ b/tests/emhdmodes/check.py
@@ -97,10 +97,11 @@ if __name__=='__main__':
         if not (dvar_cos[k] == 0 and dvar_sin[k] == 0):
             powerfits[k] = np.polyfit(np.log(RES), np.log(L1[:,k]), 1)[0]
             print("Power fit {}: {} {}".format(VARS[k], powerfits[k], L1[:,k]))
-            if powerfits[k] > -1.6 or powerfits[k] < -2.7:
+            if powerfits[k] > -1.6 or powerfits[k] < -3.3:
                 # Everything *should* converge at ~2, but we relax the reqt due to known behavior:
                 # 1. B field in WENO seems to lag, at ~1.7
                 # 2. Problems run under linear/MC seem to converge ~2.5 in most variables
+                # 3. EMHD modes with ideal guess has ~3 convergence for rho
                 fail = 1
 
     # plot

--- a/tests/emhdmodes/run.sh
+++ b/tests/emhdmodes/run.sh
@@ -21,7 +21,7 @@ conv_2d() {
         mv emhdmodes.out0.final.phdf emhd_2d_${res}_end_${1}.phdf
     done
     check_code=0
-    python check.py $ALL_RES "$3" $1 2d || check_code=$?
+    python3 check.py $ALL_RES "$3" $1 2d || check_code=$?
     if [[ $check_code != 0 ]]; then
         echo $3 FAIL: $check_code
         exit_code=1
@@ -34,12 +34,14 @@ conv_2d() {
 ALL_RES="32,64,128"
 conv_2d emhd2d_weno flux/reconstruction=weno5 "EMHD mode in 2D, WENO5"
 
-# ...but linear doesn't capture wave until higher res.  Troubling.
+# ...but linear doesn't capture wave until higher res. Troubling.
 ALL_RES="64,128,256"
 conv_2d emhd2d_mc flux/reconstruction=linear_mc "EMHD mode in 2D, linear/MC reconstruction"
 # Test that higher-order terms don't mess anything up
 conv_2d emhd2d_higher_order emhd/higher_order_terms=true "EMHD mode in 2D, higher order terms enabled"
 # Test we can use imex/EMHD and face CT
 conv_2d emhd2d_face_ct b_field/solver=face_ct "EMHD mode in 2D w/Face CT"
+# Test if it works with ideal solution as guess
+conv_2d emhd2d_ideal_guess emhd/ideal_guess=true "EMHD mode in 2D, Ideal guess"
 
 exit $exit_code

--- a/tests/mhdmodes/run.sh
+++ b/tests/mhdmodes/run.sh
@@ -29,7 +29,7 @@ conv_3d() {
         mv mhdmodes.out0.final.phdf mhd_3d_${1}_${res}_end.phdf
     done
     check_code=0
-    python check.py $ALL_RES "$3" $1 3d 3 || check_code=$?
+    python3 check.py $ALL_RES "$3" $1 3d 3 || check_code=$?
     if [[ $check_code != 0 ]]; then
         echo MHD modes test \"$3\" FAIL: $check_code
         exit_code=1
@@ -52,7 +52,7 @@ conv_2d() {
         mv mhdmodes.out0.final.phdf mhd_2d_${1}_${res}_end.phdf
     done
     check_code=0
-    python check.py $ALL_RES "$3" $1  2d || check_code=$?
+    python3 check.py $ALL_RES "$3" $1  2d || check_code=$?
     if [[ $check_code != 0 ]]; then
         echo MHD modes test \"$3\" FAIL: $check_code
         exit_code=1


### PR DESCRIPTION
A couple of new stability features primarily for torus simulations,

- Ideal GRMHD guess for Extended GRMHD simulations: The `emhd` block now accepts a new argument `ideal_guess` (default is `false`) that if enabled, will use the ideal MHD solution as the guess for the implicit solver. The ideal fluid variables are solved for in the usual, explicit way using the Kastaun solver while the extended variables are carried over from the last state. This features hinges on the fact that the contributions from the new / extended variables are subdominant to the stress-energy tensor. I have tested this feature locally on `bh` and it passes the `extended` tests (and so it does also during CI) but for some reason it fails a couple of tests like `torus_sanity` during CI and throws a `nan` on `divB`. However, when I run the test on `bh` it gives me divB of `1e-11`, so not sure what is going on there. I have submitted a 2D run with this feature enabled on NCSA Delta to see if there is any significant improvements. Although, I doubt the stability improvements will be evident with a 2D SANE run, perhaps a 3D MAD is where we might reap benefits, but that's too expensive to test.
- A radius dependent floor prescription: The `floors` block now accepts a `floors_inner` argument, which if enabled, allows one to set two different floor prescriptions at different radii. The `floors/floors_switch_r` sets the transition radius. This feature in it's current state may not be very useful as sharp transitions can introduce numerical instabilities. However, the feature exists, and it's probably good to have the option if some user wants it. Eventually what we'd probably want is a smoother transition at the transition radius, say tanh(r).