### PR TITLE
Fix compile with CUDA 11 versions

### DIFF
--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -53,7 +53,7 @@ KOKKOS_INLINE_FUNCTION void apply_ceilings(const GRCoordinates& G, const Variabl
                                           const VariablePack<Real>& U, const VarMap& m_u, const Loci loc=Loci::center)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors && G.coords.is_spherical()
+    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
                                             && G.r(k, j, i) < floors.floors_switch_r) ? floors_inner : floors;
 
     // Compute max values for ceilings
@@ -86,7 +86,7 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
                                         const Floors::Prescription& floors_inner, Real& rhoflr_max, Real& uflr_max)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors && G.coords.is_spherical()
+    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
                                             && G.r(k, j, i) < floors.floors_switch_r) ? floors_inner : floors;
 
     // Calculate the different floor values in play:
@@ -330,7 +330,7 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Local& P, co
                                             const Loci loc=Loci::center)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors && G.coords.is_spherical()
+    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
                                             && G.r(0, j, i) < floors.floors_switch_r) ? floors_inner : floors;
 
     // Apply only the geometric floors
@@ -364,7 +364,7 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, c
                                             const Loci loc=Loci::center)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors && G.coords.is_spherical()
+    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
                                             && G.r(0, j, i) < floors.floors_switch_r) ? floors_inner : floors;
 
     // Apply only the geometric floors


### PR DESCRIPTION
Looks like CUDA 11 really hates compiling `G.coords.is_spherical()` since it points to a boolean `spherical` inside a `variant` over the different coordinate systems.  The result is a horribly confusing internal error with no line numbers (`PHINode should have one entry for each predecessor of its parent basic block!`), so best to work around it in the code rather than try to fix the build process or the compiler.  The issue is fixed in CUDA 12 anyway.

Since we may want radius-dependent floors in Cartesian KS coordinates anyway, and the plan is `G.r` should work fine when we implement such coordinates, I just took out the checks -- probably KHARMA will now crash if you enable `radius_dependent_floors` in Cartesian coordinates now (i.e., Minkowski space test problems), but if you do that it was on you to begin with, and the previous behavior just would have been silently confusing anyway.

Hopefully by the time we'd run into this next, no one will be using CUDA 11 anymore...