### PR TITLE
Papercuts

### DIFF
--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -49,9 +49,14 @@ void B_CT::ZeroBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const Va
     // Select edges which lie on the domain face, zero only those
     for (auto &el : OrthogonalEdges(bdir)) {
         auto b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
-        const int jf = (binner) ? b.je : b.js;
+        int i_face = (binner) ? b.ie : b.is;
+        int j_face = (binner) ? b.je : b.js;
+        int k_face = (binner) ? b.ke : b.ks;
+        IndexRange ib = (bdir == 1) ? IndexRange{i_face, i_face} : IndexRange{b.is, b.ie};
+        IndexRange jb = (bdir == 2) ? IndexRange{j_face, j_face} : IndexRange{b.js, b.je};
+        IndexRange kb = (bdir == 3) ? IndexRange{k_face, k_face} : IndexRange{b.ks, b.ke};
         pmb->par_for(
-            "zero_EMF_" + bname, b.ks, b.ke, jf, jf, b.is, b.ie,
+            "zero_EMF_" + bname, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
             KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
                 emfpack(el, 0, k, j, i) = 0;
             }

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -183,11 +183,13 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
             params.Add("reconnect_B3_"+bname, reconnect_B3);
 
             // Special EMF averaging.  Allows B slippage, e.g. around pole for transmitting conditions
-            // Still problems with averaging+dirichlet, maybe corners?
+            // Useful for certain dirichlet conditions e.g. multizone
             bool average_EMF = pin->GetOrAddBoolean("boundaries", "average_EMF_" + bname, (btype == "transmitting"));
             params.Add("average_EMF_"+bname, average_EMF);
             // Otherwise, always zero EMFs to prevent B field escaping the domain in polar/dirichlet bounds
-            bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname, (btype == "reflecting"));
+            // Default for dirichlet conditions unless averaging is set manually
+            bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname, (btype == "reflecting" ||
+                                                                                    (btype == "dirichlet" && !average_EMF)));
             params.Add("zero_EMF_"+bname, zero_EMF);
         }
         // Advect together/cancel U3, under the theory it's in a similar position to B3 above (albeit no CT constraining it)

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -97,7 +97,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
     // Face-centered fields: some duplicate stuff, leaving it separate for now
     FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face})
                 - FC({Metadata::GetUserFlag("StartupOnly")});
-    int nvar_f = m::max(KHARMA::PackDimension(packages.get(), ghost_vars_f), 1);
+    int nvar_f = 3 * m::max(KHARMA::PackDimension(packages.get(), ghost_vars_f), 1);
 
     // TODO encapsulate this
     Metadata m_x1, m_x2, m_x3, m_x1_f, m_x2_f, m_x3_f;
@@ -187,7 +187,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
             bool average_EMF = pin->GetOrAddBoolean("boundaries", "average_EMF_" + bname, (btype == "transmitting"));
             params.Add("average_EMF_"+bname, average_EMF);
             // Otherwise, always zero EMFs to prevent B field escaping the domain in polar/dirichlet bounds
-            bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname, !average_EMF);
+            bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname, (btype == "reflecting"));
             params.Add("zero_EMF_"+bname, zero_EMF);
         }
         // Advect together/cancel U3, under the theory it's in a similar position to B3 above (albeit no CT constraining it)

--- a/kharma/boundaries/dirichlet.cpp
+++ b/kharma/boundaries/dirichlet.cpp
@@ -64,8 +64,8 @@ void KBoundaries::DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Re
 {
     // We're sometimes called without any variables to sync (e.g. syncing flags, EMFs), just return
     if (q.GetDim(4) == 0) return;
-    if (q.GetDim(4) != bound.GetDim(4)) {
-        std::cerr << "Dirichlet boundary mismatch! Boundary cache: " << bound.GetDim(4) << " for pack: " << q.GetDim(4) << std::endl;
+    if ((q.GetDim(5) * q.GetDim(4)) != bound.GetDim(4)) {
+        std::cerr << "Dirichlet boundary mismatch! Boundary cache: " << bound.GetDim(4) << " for pack: " << q.GetDim(5) * q.GetDim(4) << std::endl;
     }
 
     // Indices
@@ -84,17 +84,11 @@ void KBoundaries::DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Re
     int el_tot = el_list.size();
     for (auto el : el_list) {
         // This is the domain of the boundary/ghost zones
-        IndexRange3 b;
-        if ((el == F1 && dir == 1) || (el == F2 && dir == 2) || (el == F3 && dir == 3)) {
-            // Extend domain by 1 to set domain face values
-            b = KDomain::GetRange(rc, domain, el, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
-        } else {
-            b = KDomain::GetRange(rc, domain, el, coarse);
-        }
+        IndexRange3 b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
 
         // Flatten TopologicalElements when reading/writing to boundaries cache
         pmb->par_for(
-            "dirichlet_boundary_" + bname, 0, q.GetDim(4)/el_tot-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+            "dirichlet_boundary_" + bname, 0, q.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
             KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
                 if (set) {
                     bound(el_tot*v + (static_cast<int>(el) % el_tot), k - b.ks, j - b.js, i - b.is) = q(el, v, k, j, i);

--- a/kharma/prob/bondi.hpp
+++ b/kharma/prob/bondi.hpp
@@ -162,6 +162,11 @@ KOKKOS_INLINE_FUNCTION void get_prim_bondi(const GRCoordinates& G, const bool di
             r = rin_bondi;
             // TODO(BSP) could also do values at inf, restore that?
         } else {
+            rho = 0.;
+            u = 0.;
+            u_prim[0] = 0.;
+            u_prim[1] = 0.;
+            u_prim[2] = 0.;
             return;
         }
     }

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -254,8 +254,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
         // Find the magnetic vector potential.  In X3 symmetry only A_phi is non-zero,
         // But for tilted conditions we must keep track of all components
         // TODO(BSP) Make the vector potential a proper edge-centered field, sync it before B calc
-        // that will also allow converting below into E1/E2/E3 loops
-        IndexRange3 be = KDomain::GetRange(rc, domain, 0, 1);
+        IndexRange3 be = KDomain::GetRange(rc, domain, E3);
         IndexSize3 sz = KDomain::GetBlockSize(rc);
         ParArrayND<double> A("A", NVEC, sz.n3+1, sz.n2+1, sz.n1+1);
         pmb->par_for(


### PR DESCRIPTION
These are fixes for a number of little issues

Two very funny bugs cancel each other: `zero_EMF` was being set on boundaries which should allow magnetic flux through them.  However, the function was not made general to actually *work* on boundaries which were not the poles.  So, by fixing the two issues together I think I'm safe in saying there aren't repercussions to NEW production simulations.  HOWEVER, if you started a simulation with 2024.5 and are continuing it after updating with these changes, you will need to add `boundaries/zero_EMF_inner_x1=false boundaries/zero_EMF_outer_x1=false boundaries/zero_EMF_inner_x3=false boundaries/zero_EMF_outer_x3=false` to the command line in order to turn off the existing options now that they have teeth.

Then there was a bug preventing Dirichlet boundary conditions from actually working on faces, and one which prevented initialization of the last ghost zone (thus this fixes #76).  Finally, space interior to `r_in_bondi` was left as uninitialized memory, which of course could correspond to any density & temperature and so wasn't always wiped away by applying the floors.  Now we set it zero to guarantee replacement.

Props to @hyerincho for finding most of these, and some of the fixes as well.