### PR TITLE
Polar averaging for angular momentum

### DIFF
--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -288,6 +288,8 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
     auto B_U = rc->PackVariables(std::vector<std::string>{"cons.B"});
     auto B_P = rc->PackVariables(std::vector<std::string>{"prims.B"});
 
+    const auto& G = pmb->coords;
+
     // Subtract the average B3 as "reconnection"
     IndexRange3 b = KDomain::GetRange(rc, domain, F3, coarse);
     IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, F3, coarse);

--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -270,42 +270,6 @@ void B_CT::DestructiveBoundaryClean(MeshBlockData<Real> *rc, IndexDomain domain,
     }
 }
 
-// Reducer class for unused MinAbs B below
-// template <class Space>
-// struct MinAbsReducer {
-//  public:
-//   // Required
-//   typedef MinAbsReducer reducer;
-//   typedef double value_type;
-// //   typedef Kokkos::View<value_type*, Space, Kokkos::MemoryUnmanaged>
-// //       result_view_type;
-
-//  private:
-//   value_type& value;
-
-//  public:
-//   KOKKOS_INLINE_FUNCTION
-//   MinAbsReducer(value_type& value_) : value(value_) {}
-
-//   // Required
-//   KOKKOS_INLINE_FUNCTION
-//   void join(value_type& dest, const value_type& src) const {
-//     dest = (m::abs(src) < m::abs(dest)) ? src : dest;
-//   }
-
-//   KOKKOS_INLINE_FUNCTION
-//   void init(value_type& val) const { val = 0; }
-
-//   KOKKOS_INLINE_FUNCTION
-//   value_type& reference() const { return value; }
-
-//   //KOKKOS_INLINE_FUNCTION
-//   //result_view_type view() const { return result_view_type(&value, 1); }
-
-//   KOKKOS_INLINE_FUNCTION
-//   bool references_scalar() const { return true; }
-// };
-
 void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &fpack, bool coarse)
 {
     // We're also sometimes called on coarse buffers with or without AMR.
@@ -319,6 +283,10 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const int bdir = KBoundaries::BoundaryDirection(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
+
+    // TODO standardize on passing Packs or Datas...
+    auto B_U = rc->PackVariables(std::vector<std::string>{"cons.B"});
+    auto B_P = rc->PackVariables(std::vector<std::string>{"prims.B"});
 
     // Subtract the average B3 as "reconnection"
     IndexRange3 b = KDomain::GetRange(rc, domain, F3, coarse);
@@ -335,6 +303,7 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
                     local_result += fpack(F3, v, k, jf, i);
                 }
             , sum_reducer);
+            member.team_barrier();
 
             // Calculate the average and modify all B3 identically
             // This will preserve their differences->divergence
@@ -344,32 +313,16 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
                     fpack(F3, v, k, jf, i) -= B3_av;
                 }
             );
+            member.team_barrier();
+
+            // Update cell-centered conserved & primitive B3. Not worth a separate BlockUtoP call
+            parthenon::par_for_inner(member, b.ks, b.ke-1,
+                [&](const int& k) {
+                    B_P(V3, k, jf, i) =  (fpack(F3, 0, k, jf, i) / G.gdet(Loci::face3, jf, i)
+                                        + fpack(F3, 0, k + 1, jf, i) / G.gdet(Loci::face3, jf, i)) / 2;
+                    B_U(V3, k, jf, i) = B_P(V3, k, jf, i) * G.gdet(Loci::center, jf, i);
+                }
+            );
         }
     );
-    // Option for subtracting minimum by absolute value, much less stable
-    // parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_B3_" + bname, pmb->exec_space,
-    //     0, 1, 0, fpack.GetDim(4)-1, b.is, b.ie,
-    //     KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int &v, const int& i) {
-    //         // Sum the first rank of B3
-    //         double B3_min = 0.;
-    //         MinAbsReducer<double> min_abs_reducer(B3_min);
-    //         parthenon::par_reduce_inner(member, bi.ks, bi.ke - 1,
-    //             [&](const int& k, double& local_result) {
-    //                 // Compare unsigned
-    //                 if (m::abs(fpack(F3, v, k, jf, i)) < m::abs(local_result)) {
-    //                     // Assign signed, reducer will compare unsigned
-    //                     local_result = fpack(F3, v, k, jf, i);
-    //                 }
-    //             }
-    //         , min_abs_reducer);
-
-    //         // Subtract from all B3 identically
-    //         // This will preserve their differences->divergence
-    //         parthenon::par_for_inner(member, b.ks, b.ke,
-    //             [&](const int& k) {
-    //                 fpack(F3, v, k, jf, i) -= B3_min;
-    //             }
-    //         );
-    //     }
-    // );
 }

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -192,11 +192,12 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                                                                                     (btype == "dirichlet" && !average_EMF)));
             params.Add("zero_EMF_"+bname, zero_EMF);
         }
-        // Advect together/cancel U3, under the theory it's in a similar position to B3 above (albeit no CT constraining it)
+        // Advect together/cancel U3 or T3, under the theory it's in a similar position to B3 above (albeit no CT constraining it)
         // Not enabled by default as it does not conserve angular momentum and isn't necessary for stability
         bool cancel_U3 = pin->GetOrAddBoolean("boundaries", "cancel_U3_" + bname, false);
         params.Add("cancel_U3_"+bname, cancel_U3);
-
+        bool cancel_T3 = pin->GetOrAddBoolean("boundaries", "cancel_T3_" + bname, false);
+        params.Add("cancel_T3_"+bname, cancel_T3);
 
         // String manip to get the Parthenon boundary name, e.g., "ox1_bc"
         auto bname_parthenon = bname.substr(0, 1) + "x" + bname.substr(7, 8) + "_bc";
@@ -395,6 +396,9 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     if (pmb->packages.AllPackages().count("GRMHD")) {
         if (params.Get<bool>("cancel_U3_" + bname) && full_grmhd_boundary) {
             GRMHD::CancelBoundaryU3(rc.get(), domain, coarse);
+        }
+        if (params.Get<bool>("cancel_T3_" + bname) && full_grmhd_boundary) {
+            GRMHD::CancelBoundaryT3(rc.get(), domain, coarse);
         }
     }
 

--- a/kharma/flux/flux_functions.hpp
+++ b/kharma/flux/flux_functions.hpp
@@ -309,6 +309,8 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar(const GRCoordinates& G, const Local& P, c
     // Find sound speed
     const Real ef  = P(m.RHO) + gam * P(m.UU);
     const Real cs2 = gam * (gam - 1) * P(m.UU) / ef;
+    // The fluid sound speed should be at most sqrt(gam-1) for a relativistic fluid
+    clip(cs2, 0., gam - 1.);
     Real cms2;
     if (m.Q >= 0 || m.DP >= 0) {
          // Get the EGRMHD parameters
@@ -338,7 +340,8 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar(const GRCoordinates& G, const Local& P, c
     } else {
         cms2 = cs2;
     }
-    //clip(cms2, SMALL, 1.);
+    // The signal speed should be at most the speed of light
+    clip(cms2, 0., 1.); // TODO would love to record this...
 
     // Require that speed of wave measured by observer q.ucon is cms2
     Real A, B, C;
@@ -381,6 +384,8 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar_global(const GRCoordinates& G, const Glob
     // Find sound speed
     const Real ef  = P(m.RHO, k, j, i) + gam * P(m.UU, k, j, i);
     const Real cs2 = gam * (gam - 1) * P(m.UU, k, j, i) / ef;
+    // The fluid sound speed should be at most sqrt(gam-1) for a relativistic fluid
+    clip(cs2, 0., gam - 1.);
     Real cms2;
     if (m.Q >= 0 || m.DP >= 0) {
          // Get the EGRMHD parameters
@@ -410,6 +415,8 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar_global(const GRCoordinates& G, const Glob
     } else {
         cms2 = cs2;
     }
+    // The signal speed should be at most the speed of light
+    clip(cms2, 0., 1.);
 
     // Require that speed of wave measured by observer q.ucon is cms2
     Real A, B, C;

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -462,6 +462,14 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_U3_" + bname, pmb->exec_space,
         0, 1, b.is, b.ie,
         KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i) {
+            // Recover primitive GRMHD variables from our modified U
+            parthenon::par_for_inner(member, bi.ks, bi.ke,
+                [&](const int& k, Real& local_result) {
+                Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
+                                                            floors, 8, 1e-8);
+                }
+            );
+
             // Sum the first rank of U3
             Real U3_sum = 0.;
             Kokkos::Sum<Real> sum_reducer(U3_sum);

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -477,7 +477,7 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                 [&](const int& k) {
                     P(m_p.U3, k, jf, i) -= U3_avg;
                     // Apply floors
-                    Floors::apply_geo_floors(G, P, m_p, gam, jf, i, floors, floors, Loci::center);
+                    Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Always PtoU, we modified P.  Accomodate EMHD
                     Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, jf, i, U, m_u);
                 }
@@ -536,7 +536,7 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
                                                               floors, 8, 1e-8);
                     // Floor them
-                    int fflag = Floors::apply_geo_floors(G, P, m_p, gam, jf, i, floors, floors, Loci::center);
+                    int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Recalculate U on anything we floored
                     if (fflag)
                         p_to_u(G, P, m_p, gam, k, jf, i, U, m_u, Loci::center);

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -452,6 +452,7 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
+    const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
     // Subtract the average B3 as "reconnection"
@@ -471,7 +472,6 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
             , sum_reducer);
 
             // Calculate the average and subtract it
-            const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
             const Real U3_avg = U3_sum / (bi.ke - bi.ks + 1);
             parthenon::par_for_inner(member, b.ks, b.ke,
                 [&](const int& k) {

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -464,7 +464,7 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
         KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i) {
             // Recover primitive GRMHD variables from our modified U
             parthenon::par_for_inner(member, bi.ks, bi.ke,
-                [&](const int& k, Real& local_result) {
+                [&](const int& k) {
                 Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
                                                             floors, 8, 1e-8);
                 }

--- a/kharma/grmhd/grmhd.hpp
+++ b/kharma/grmhd/grmhd.hpp
@@ -95,4 +95,9 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *rc);
  */
 void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
 
+/**
+ * Same but for the conserved angular momentum T3
+ */
+void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+
 }


### PR DESCRIPTION
This PR adds an alternative to the U3 averaging introduced in #90.  Recall that PR introduced the concept of "reconnecting" circular velocity around the pole, canceling opposing U3 in the very last row of zones surrounding the pole.

This applies the same average subtraction to the angular momentum $T^0_3$ instead, recalculating the primitive variables from the resulting modified stress-energy tensor.  This is potentially more defensible than directly modifying primitive variables, since it only breaks conservation of angular momentum, which has little meaning at a coordinate singularity anyway.

That said, it's not yet agreed to be more defensible, nor tested to be any more effective, than the raw U3 averaging.  YMMV.  I've posted it in case it helps anyone else running spicy enough simulations to still be running into stability issues due to polar effects.

Enable with `boundaries/cancel_T3_inner_x2=true` and `boundaries/cancel_T3_outer_x2=true`