### PR TITLE
Fix restarting normally after resizing a problem to a new grid

### DIFF
--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -140,7 +140,7 @@ void KHARMA::PostStepWork(Mesh *pmesh, ParameterInput *pin, const SimTime &tm)
     globals.Update<double>("time", tm.time);
 }
 
-void KHARMA::FixParameters(ParameterInput *pin)
+void KHARMA::FixParameters(ParameterInput *pin, bool is_parthenon_restart)
 {
     Flag("Fixing parameters");
     // Parthenon sets 2 ghost zones as a default.
@@ -151,12 +151,14 @@ void KHARMA::FixParameters(ParameterInput *pin)
     pin->SetInteger("parthenon/mesh", "nghost", Globals::nghost);
 
     // If we're restarting (not via Parthenon), read the restart file to get most parameters
-    std::string prob = pin->GetString("parthenon/job", "problem_id");
-    if (prob == "resize_restart") {
-        ReadIharmRestartHeader(pin->GetString("resize_restart", "fname"), pin);
-    }
-    if (prob == "resize_restart_kharma") {
-        ReadKharmaRestartHeader(pin->GetString("resize_restart", "fname"), pin);
+    if (!is_parthenon_restart) {
+        std::string prob = pin->GetString("parthenon/job", "problem_id");
+        if (prob == "resize_restart") {
+            ReadIharmRestartHeader(pin->GetString("resize_restart", "fname"), pin);
+        }
+        if (prob == "resize_restart_kharma") {
+            ReadKharmaRestartHeader(pin->GetString("resize_restart", "fname"), pin);
+        }
     }
 
     // Construct a CoordinateEmbedding object.  See coordinate_embedding.hpp for supported systems/tags

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -159,6 +159,15 @@ void KHARMA::FixParameters(ParameterInput *pin, bool is_parthenon_restart)
         if (prob == "resize_restart_kharma") {
             ReadKharmaRestartHeader(pin->GetString("resize_restart", "fname"), pin);
         }
+    } else {
+        // Prevent all the special cases for resize_restart from firing, if we're
+        // restarting from a "normal" Parthenon restart file after resizing previously
+        pin->SetString("parthenon/job", "problem_id", "resized_restart");
+        // Don't automatically clean B on subsequent restarts, either!
+        pin->SetBoolean("b_cleanup", "on", false);
+        // Finally, we probably set nlim=0 or 1 for the restarting phase, clear that
+        if (pin->GetInteger("parthenon/time", "nlim") <= 1)
+            pin->SetInteger("parthenon/time", "nlim", -1);
     }
 
     // Construct a CoordinateEmbedding object.  See coordinate_embedding.hpp for supported systems/tags

--- a/kharma/kharma.hpp
+++ b/kharma/kharma.hpp
@@ -76,7 +76,7 @@ TaskStatus AddPackage(std::shared_ptr<Packages_t>& packages,
  * This includes boundaries in spherical coordinates, coordinate system translations, etc.
  * This function also handles setting parameters from restart files
  */
-void FixParameters(ParameterInput *pin);
+void FixParameters(ParameterInput *pin, bool is_parthenon_restart);
 
 /**
  * Load any packages specified in the input parameters

--- a/kharma/main.cpp
+++ b/kharma/main.cpp
@@ -154,8 +154,9 @@ int main(int argc, char *argv[])
         return 1;
     }
     auto pin = pman.pinput.get(); // All parameters in the input file or command line
-    // Modify input parameters as we need
-    KHARMA::FixParameters(pin);
+    // Modify input parameters as we need. Needs to know if Parthenon set parameters
+    // from our restart file, or whether we need to read them from a file here
+    KHARMA::FixParameters(pin, pman.IsRestart());
     // InitPackagesEtc calls ProcessPackages, then constructs the Mesh
     pman.ParthenonInitPackagesAndMesh();
     // Now pull out the mesh and app_input as well for below


### PR DESCRIPTION
The `resize_restart` problem triggers a bunch of special behavior in KHARMA -- however, that behavior should only trigger once when the problem is being resized, not afterward when it is being restarted from "normal" Parthenon `.rhdf` files.

This code detects the case of restarting a previously-resized problem, and disables all the resizing stuff for this and later restarts.  Deserves a test, but will add that to `dev` branch since the `resize` test is substantially updated there.