### PR TITLE
Fix restarting ideal runs w/EMHD

### DIFF
--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -124,7 +124,7 @@ void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     IndexRange ib = bounds.GetBoundsI(domain);
     IndexRange jb = bounds.GetBoundsJ(domain);
     IndexRange kb = bounds.GetBoundsK(domain);
-    pmb->par_for("UtoP_B", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+    pmb->par_for("UtoP_B_CD", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
             // Update the primitive B-fields
             Real gdet = G.gdet(Loci::center, j, i);

--- a/kharma/b_flux_ct/b_flux_ct.cpp
+++ b/kharma/b_flux_ct/b_flux_ct.cpp
@@ -182,7 +182,7 @@ TaskStatus MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse)
     IndexRange vec = IndexRange{0, B_U.GetDim(4)-1};
     IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
 
-    pmb0->par_for("UtoP_B", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+    pmb0->par_for("UtoP_B_FluxCT_Mesh", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA (const int& b, const int &mu, const int &k, const int &j, const int &i) {
             const auto& G = B_U.GetCoords(b);
             // Update the primitive B-fields
@@ -206,7 +206,7 @@ TaskStatus BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const IndexRange kb = bounds.GetBoundsK(domain);
     const IndexRange vec = IndexRange({0, B_U.GetDim(4)-1});
 
-    pmb->par_for("UtoP_B", vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+    pmb->par_for("UtoP_B_FluxCT_Block", vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA (const int &mu, const int &k, const int &j, const int &i) {
             // Update the primitive B-fields
             B_P(mu, k, j, i) = B_U(mu, k, j, i) / G.gdet(Loci::center, j, i);
@@ -229,7 +229,7 @@ void MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse)
     IndexRange vec = IndexRange{0, B_U.GetDim(4)-1};
     IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
 
-    pmb0->par_for("UtoP_B", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+    pmb0->par_for("PtoU_B_FluxCT_Mesh", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA (const int& b, const int &mu, const int &k, const int &j, const int &i) {
             const auto& G = B_U.GetCoords(b);
             // Update the primitive B-fields
@@ -252,7 +252,7 @@ void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const IndexRange kb = bounds.GetBoundsK(domain);
     const IndexRange vec = IndexRange({0, B_U.GetDim(4)-1});
 
-    pmb->par_for("UtoP_B", vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+    pmb->par_for("PtoU_B_FluxCT_Block", vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA (const int &mu, const int &k, const int &j, const int &i) {
             // Update the conserved B-fields
             B_U(mu, k, j, i) = B_P(mu, k, j, i) * G.gdet(Loci::center, j, i);

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -348,9 +348,12 @@ Packages_t KHARMA::ProcessPackages(std::unique_ptr<ParameterInput> &pin)
     auto t_grmhd = tl.AddTask(t_globals | t_driver, KHARMA::AddPackage, packages, GRMHD::Initialize, pin.get());
     // Only load the inverter if GRMHD/EMHD isn't being evolved implicitly
     // Unless we want to use the explicitly-evolved ideal MHD variables as a guess for the solver
+    // Or we want first-order flux corrections, which rely on a UtoP guess
+    // Note we only accept fofc/on here, not legacy versions/defaults --
+    // FOFC should be explicitly enabled in EMHD!
     auto t_inverter = t_grmhd;
     if (!pin->GetOrAddBoolean("GRMHD", "implicit", pin->GetOrAddBoolean("emhd", "on", false)) ||
-        pin->GetOrAddBoolean("emhd", "ideal_guess", false)) {
+        pin->GetOrAddBoolean("emhd", "ideal_guess", false) || pin->GetOrAddBoolean("fofc", "on", false)) {
         t_inverter = tl.AddTask(t_grmhd, KHARMA::AddPackage, packages, Inverter::Initialize, pin.get());
     }
     // Floors package is only loaded if floors aren't disabled


### PR DESCRIPTION
When restarting from an ideal run, leaving FOFC enabled, the initialization wasn't necessarily loading the `Inverter` package.  EMHD certainly doesn't need it, but FOFC does, so we leave it enabled if we explicitly asked for FOFC.

Time will tell if FOFC actually *helps* us, but at least now it runs.