### PR TITLE
Recalculate the timestep when averaging T3/U3

### DIFF
--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -42,6 +42,12 @@ using namespace parthenon;
 // The code is here so that we can ensure it keeps compiling,
 // which should make it easier to reintroduce if we want to later
 
+// It at least needs:
+// 1. Special-casing in magnetic field initialization
+// 2. Implementation of below function to update maximum 'ctop' each step
+// 3. Ripping out a bunch of experiments toward GR support which didn't work
+// 4. Proper GR support instead
+
 namespace B_CD
 {
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -544,12 +544,12 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                     // Finally, recalculate cmax/min using cell centers and updated vars, apparently
                     // it can change a lot during this op
                     FourVectors Dtmp;
-                    GRMHD::calc_4vecs(G, P, m_p, jf, i, Loci::center, Dtmp);
-                    Flux::vchar(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 1,
+                    GRMHD::calc_4vecs(G, P, m_p, k, jf, i, Loci::center, Dtmp);
+                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 1,
                                 cmax(0, k, jf, i), cmin(0, k, jf, i));
-                    Flux::vchar(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 2,
+                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 2,
                                 cmax(1, k, jf, i), cmin(1, k, jf, i));
-                    Flux::vchar(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 3,
+                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 3,
                                 cmax(2, k, jf, i), cmin(2, k, jf, i));
                 }
             );
@@ -630,12 +630,12 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                     // Finally, recalculate cmax/min using cell centers and updated vars, apparently
                     // it can change a lot during this op
                     FourVectors Dtmp;
-                    GRMHD::calc_4vecs(G, P, m_p, jf, i, Loci::center, Dtmp);
-                    Flux::vchar(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 1,
+                    GRMHD::calc_4vecs(G, P, m_p, k, jf, i, Loci::center, Dtmp);
+                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 1,
                                 cmax(0, k, jf, i), cmin(0, k, jf, i));
-                    Flux::vchar(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 2,
+                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 2,
                                 cmax(1, k, jf, i), cmin(1, k, jf, i));
-                    Flux::vchar(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 3,
+                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 3,
                                 cmax(2, k, jf, i), cmin(2, k, jf, i));
 
                 }

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -611,7 +611,7 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     );
 }
 
-Real UpdateAveragedCtop(MeshData<Real> *md)
+void UpdateAveragedCtop(MeshData<Real> *md)
 {
     auto pmesh = md->GetMeshPointer();
     auto& params = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
@@ -626,10 +626,14 @@ Real UpdateAveragedCtop(MeshData<Real> *md)
 
             if (bdir > pmesh->ndim) continue;
 
+            bool b3_is_reconnected = (pmesh->packages.AllPackages().count("B_CT")) ?
+                                      params.Get<bool>("reconnect_B3_" + bname) :
+                                      false;
+
             // If we've modified values on the pole...
             if (params.Get<bool>("cancel_T3_" + bname) ||
                 params.Get<bool>("cancel_U3_" + bname) ||
-                params.Get<bool>("reconnect_B3_" + bname)) {
+                b3_is_reconnected) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (pmb->boundary_flag[bface] == BoundaryFlag::user) {
                     PackIndexMap prims_map, cons_map;

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -197,8 +197,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // AMR-related
     pkg->CheckRefinementBlock    = GRMHD::CheckRefinement;
-    pkg->EstimateTimestepBlock   = GRMHD::EstimateTimestep;
-    pkg->EstimateTimestepMesh    = GRMHD::MeshEstimateTimestep;
+    pkg->EstimateTimestepMesh    = GRMHD::EstimateTimestep;
     pkg->PostStepDiagnosticsMesh = GRMHD::PostStepDiagnostics;
 
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
@@ -249,32 +248,26 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     return pkg;
 }
 
-Real EstimateTimestep(MeshBlockData<Real> *rc)
+Real EstimateTimestep(MeshData<Real> *md)
 {
     // Normally the caller would place this flag before calling us, but this is from Parthenon
     // This function is a nice demo of why client-side flagging
     // like this is inadvisable: you have to EndFlag() at every different return
     Flag("EstimateTimestep");
-    auto pmb = rc->GetBlockPointer();
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);
-    const auto& G = pmb->coords;
-    auto& cmax = rc->Get("Flux.cmax").data;
-    auto& cmin = rc->Get("Flux.cmin").data;
+    auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
+    auto& globals = pmb0->packages.Get("Globals")->AllParams();
+    const auto& grmhd_pars = pmb0->packages.Get("GRMHD")->AllParams();
 
-    // TODO: move timestep limiters into KHARMADriver::SetGlobalTimestep
-    // TODO: option to keep location (in embedding coords) of zone which sets step.
-    //       (this will likely be very slow, but we should do it anyway)
+    // If we have to recompute ctop anywhere, we do it now
+    UpdateAveragedCtop(md);
 
-    auto& globals = pmb->packages.Get("Globals")->AllParams();
-    const auto& grmhd_pars = pmb->packages.Get("GRMHD")->AllParams();
-
+    // Other things we might have to return (light-crossing, pre-set timestep, etc.)
+    // TODO move these options to SetGlobalTimestep
     if (!globals.Get<bool>("in_loop")) {
         if (grmhd_pars.Get<bool>("start_dt_light") ||
             grmhd_pars.Get<bool>("use_dt_light")) {
             // Estimate based on light crossing time
-            double dt = EstimateRadiativeTimestep(rc);
+            double dt = EstimateRadiativeTimestep(md);
             // This records a per-rank minimum,
             // but Parthenon finds the global minimum anyway
             if (globals.hasKey("dt_light")) {
@@ -300,72 +293,68 @@ Real EstimateTimestep(MeshBlockData<Real> *rc)
         return globals.Get<double>("dt_light");
     }
 
-    ParArray1D<Real> min_loc("min_loc", 3);
+    // Actually compute the timestep if we have to
+    const auto& cmax  = md->PackVariables(std::vector<std::string>{"Flux.cmax"});
+    const auto& cmin  = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
+
+    const IndexRange3 b = KDomain::GetRange(md, IndexDomain::interior);
+    const IndexRange block = IndexRange{0, cmax.GetDim(5)-1};
 
     // TODO version preserving location, with switch to keep this fast one
     // std::tuple doesn't work device-side, Kokkos::pair is 2D.  pair of pairs?
     Real min_ndt = 0.;
-    pmb->par_reduce("ndt_min", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int k, const int j, const int i,
+    pmb0->par_reduce("ndt_min", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+        KOKKOS_LAMBDA (const int b, const int k, const int j, const int i,
                       Real &local_result) {
-            double ndt_zone = 1 / (1 / (G.Dxc<1>(i) /  m::max(cmax(0, k, j, i), cmin(0, k, j, i))) +
-                                   1 / (G.Dxc<2>(j) /  m::max(cmax(1, k, j, i), cmin(1, k, j, i))) +
-                                   1 / (G.Dxc<3>(k) /  m::max(cmax(2, k, j, i), cmin(2, k, j, i))));
+            const auto& G = cmax.GetCoords(b);
+            double ndt_zone = 1 / (1 / (G.Dxc<1>(i) /  m::max(cmax(b, V1, k, j, i), cmin(b, V1, k, j, i))) +
+                                   1 / (G.Dxc<2>(j) /  m::max(cmax(b, V2, k, j, i), cmin(b, V2, k, j, i))) +
+                                   1 / (G.Dxc<3>(k) /  m::max(cmax(b, V3, k, j, i), cmin(b, V3, k, j, i))));
 
             if (!m::isnan(ndt_zone) && (ndt_zone < local_result)) {
                 local_result = ndt_zone;
             }
         }
     , Kokkos::Min<Real>(min_ndt));
-    // TODO(BSP) this would need work for non-rectangular grids.
-    const double nctop = m::min(G.Dxc<1>(0), m::min(G.Dxc<2>(0), G.Dxc<3>(0))) / min_ndt;
+    //std::cerr << "Got min timestep: " << min_ndt << std::endl;
 
-    // TODO print location
-    //std::cout << "New min timestep: " << min_ndt << std::endl;
-
-    // Apply limits
+    // Apply limits (TODO move into KHARMADriver::SetGlobalTimestep)
     const double cfl = grmhd_pars.Get<double>("cfl");
     const double dt_min = grmhd_pars.Get<double>("dt_min");
     const double dt_last = globals.Get<double>("dt_last");
     const double dt_max = grmhd_pars.Get<double>("max_dt_increase") * dt_last;
     const double ndt = clip(min_ndt * cfl, dt_min, dt_max);
 
-    // Record max ctop, for constraint damping
-    // TODO could probably use generic Max inside B_CD package
-    if (pmb->packages.AllPackages().count("B_CD")) {
-        auto& b_cd_params = pmb->packages.Get("B_CD")->AllParams();
-        if (nctop > b_cd_params.Get<Real>("ctop_max"))
-            b_cd_params.Update<Real>("ctop_max", nctop);
-    }
-
     EndFlag();
     return ndt;
 }
 
-Real EstimateRadiativeTimestep(MeshBlockData<Real> *rc)
+Real EstimateRadiativeTimestep(MeshData<Real> *md)
 {
     Flag("EstimateRadiativeTimestep");
-    auto pmb = rc->GetBlockPointer();
-    IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
-    IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
-    IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);
-    const auto& G = pmb->coords;
+    auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
-    const auto& grmhd_pars = pmb->packages.Get("GRMHD")->AllParams();
+    const auto& grmhd_pars = pmb0->packages.Get("GRMHD")->AllParams();
     const bool phase_speed = grmhd_pars.Get<bool>("use_dt_light_phase_speed");
 
-    const Real dx[GR_DIM] = {0., G.Dxc<1>(0), G.Dxc<2>(0), G.Dxc<3>(0)};
+    // Doesn't actually matter what we pack here, we're just pulling G
+    const auto& dummy  = md->PackVariables(std::vector<std::string>{});
+
+    const IndexRange3 b = KDomain::GetRange(md, IndexDomain::interior);
+    const IndexRange block = IndexRange{0, dummy.GetDim(5)-1};
 
     // Leaving minmax in case the max phase speed is useful
     typename Kokkos::MinMax<Real>::value_type minmax;
-    pmb->par_reduce("ndt_min", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int& k, const int& j, const int& i,
+    pmb0->par_reduce("ndt_min", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
                       typename Kokkos::MinMax<Real>::value_type& lminmax) {
+            const auto& G = dummy.GetCoords(b);
 
             double light_phase_speed = SMALL;
             double dt_light_local = 0.;
 
             if (phase_speed) {
+                double local_phase_speed[GR_DIM];
                 for (int mu = 1; mu < GR_DIM; mu++) {
                     if(SQR(G.gcon(Loci::center, j, i, 0, mu)) -
                         G.gcon(Loci::center, j, i, mu, mu)*G.gcon(Loci::center, j, i, 0, 0) >= 0.) {
@@ -380,16 +369,19 @@ Real EstimateRadiativeTimestep(MeshBlockData<Real> *rc)
                                                 G.gcon(Loci::center, j, i, mu, mu)*G.gcon(Loci::center, j, i, 0, 0)))/
                                             G.gcon(Loci::center, j, i, 0, 0));
 
-                        light_phase_speed = m::max(cplus,cminus);
+                        local_phase_speed[mu] = m::max(cplus,cminus);
                     } else {
-                        light_phase_speed = SMALL;
+                        local_phase_speed[mu] = SMALL;
                     }
-
-                    dt_light_local += 1./(dx[mu]/light_phase_speed);
                 }
+                dt_light_local = 1./(G.Dxc<1>(0)/local_phase_speed[1]) +
+                                 1./(G.Dxc<2>(0)/local_phase_speed[2]) +
+                                 1./(G.Dxc<3>(0)/local_phase_speed[3]);
+                light_phase_speed = m::max(local_phase_speed[1], m::max(local_phase_speed[2], local_phase_speed[3]));
             } else {
-                for (int mu = 1; mu < GR_DIM; mu++)
-                    dt_light_local += 1./dx[mu];
+                dt_light_local = 1./G.Dxc<1>(0) +
+                                 1./G.Dxc<2>(0) +
+                                 1./G.Dxc<3>(0);
             }
             dt_light_local = 1/dt_light_local;
 
@@ -484,15 +476,14 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const BoundaryFace bface = KBoundaries::BoundaryFaceOf(domain);
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
+    const auto bdir = KBoundaries::BoundaryDirection(bface);
+    if (bdir != 2) throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
 
     // Pull variables (TODO take packs & maps, see boundaries.cpp)
     PackIndexMap prims_map, cons_map;
     auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
     auto U = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
-
-    const auto& cmax  = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
-    const auto& cmin  = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
     const auto &G = pmb->coords;
 
@@ -540,17 +531,6 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
 
                     // Always PtoU, we modified P.  Accommodate EMHD
                     Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, jf, i, U, m_u);
-
-                    // Finally, recalculate cmax/min using cell centers and updated vars, apparently
-                    // it can change a lot during this op
-                    FourVectors Dtmp;
-                    GRMHD::calc_4vecs(G, P, m_p, k, jf, i, Loci::center, Dtmp);
-                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 1,
-                                cmax(0, k, jf, i), cmin(0, k, jf, i));
-                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 2,
-                                cmax(1, k, jf, i), cmin(1, k, jf, i));
-                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 3,
-                                cmax(2, k, jf, i), cmin(2, k, jf, i));
                 }
             );
         }
@@ -569,15 +549,14 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const BoundaryFace bface = KBoundaries::BoundaryFaceOf(domain);
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
+    const auto bdir = KBoundaries::BoundaryDirection(bface);
+    if (bdir != 2) throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
 
     // Pull variables (TODO take packs & maps, see boundaries.cpp)
     PackIndexMap prims_map, cons_map;
     auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
     auto U = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
-
-    const auto& cmax  = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
-    const auto& cmin  = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
     const auto &G = pmb->coords;
 
@@ -626,22 +605,70 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                     // Recalculate U on anything we floored
                     if (fflag)
                         p_to_u(G, P, m_p, gam, k, jf, i, U, m_u, Loci::center);
-
-                    // Finally, recalculate cmax/min using cell centers and updated vars, apparently
-                    // it can change a lot during this op
-                    FourVectors Dtmp;
-                    GRMHD::calc_4vecs(G, P, m_p, k, jf, i, Loci::center, Dtmp);
-                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 1,
-                                cmax(0, k, jf, i), cmin(0, k, jf, i));
-                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 2,
-                                cmax(1, k, jf, i), cmin(1, k, jf, i));
-                    Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, 3,
-                                cmax(2, k, jf, i), cmin(2, k, jf, i));
-
                 }
             );
         }
     );
+}
+
+Real UpdateAveragedCtop(MeshData<Real> *md)
+{
+    auto pmesh = md->GetMeshPointer();
+    auto& params = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
+    for (auto &pmb : pmesh->block_list) {
+        auto &rc = pmb->meshblock_data.Get();
+        for (int i = 0; i < BOUNDARY_NFACES; i++) {
+            BoundaryFace bface = (BoundaryFace)i;
+            auto bname = KBoundaries::BoundaryName(bface);
+            const auto bdir = KBoundaries::BoundaryDirection(bface);
+            const auto binner = KBoundaries::BoundaryIsInner(bface);
+            const auto bdomain = KBoundaries::BoundaryDomain(bface);
+
+            if (bdir > pmesh->ndim) continue;
+
+            // If we've modified values on the pole...
+            if (params.Get<bool>("cancel_T3_" + bname) ||
+                params.Get<bool>("cancel_U3_" + bname) ||
+                params.Get<bool>("reconnect_B3_" + bname)) {
+                // ...and if this face of the block corresponds to a global boundary...
+                if (pmb->boundary_flag[bface] == BoundaryFlag::user) {
+                    PackIndexMap prims_map, cons_map;
+                    auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+                    const VarMap m_p(prims_map, false);
+                    const auto& cmax  = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
+                    const auto& cmin  = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
+
+                    const auto& G = pmb->coords;
+                    const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
+                    const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+                    const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
+
+                    // Recompute ctop in zones affected by averaging
+                    IndexRange3 b = KDomain::GetRange(rc, bdomain);
+                    IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior);
+                    // TODO this part wouldn't be hard to generalize if polar boundary moves
+                    const int jf = (binner) ? bi.js : bi.je;
+                    pmb->par_for("check_refinement", b.ks, b.ke, b.is, b.ie,
+                        KOKKOS_LAMBDA(const int& k, const int& i) {
+                            FourVectors Dtmp;
+                            GRMHD::calc_4vecs(G, P, m_p, k, jf, i, Loci::center, Dtmp);
+                            // Remember our 'cmin' array stores *positive* values!
+                            Real cmin_minus;
+                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, X1DIR,
+                                        cmax(V1, k, jf, i), cmin_minus);
+                            cmin(V1, k, jf, i) = -cmin_minus;
+                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, X2DIR,
+                                        cmax(V2, k, jf, i), cmin_minus);
+                            cmin(V2, k, jf, i) = -cmin_minus;
+                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, X3DIR,
+                                        cmax(V3, k, jf, i), cmin_minus);
+                            cmin(V3, k, jf, i) = -cmin_minus;
+                        }
+                    );
+                }
+            }
+        }
+    }
 }
 
 } // namespace GRMHD

--- a/kharma/grmhd/grmhd.hpp
+++ b/kharma/grmhd/grmhd.hpp
@@ -54,21 +54,10 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
  * This is just for a particular MeshBlock/package, so don't rely on it
  * Parthenon will take the minimum and put it in pmy_mesh->dt
  */
-Real EstimateTimestep(MeshBlockData<Real> *rc);
-inline Real MeshEstimateTimestep(MeshData<Real> *md)
-{
-    Flag("MeshEstimateTimestep");
-    Real ndt = std::numeric_limits<Real>::max();
-    for (int i=0; i < md->NumBlocks(); ++i) {
-        double dtb = EstimateTimestep(md->GetBlockData(i).get());
-        if (dtb < ndt) ndt = dtb;
-    }
-    EndFlag();
-    return ndt;
-}
+Real EstimateTimestep(MeshData<Real> *md);
 
 // Internal version for the light phase speed crossing time of smallest zone
-Real EstimateRadiativeTimestep(MeshBlockData<Real> *rc);
+Real EstimateRadiativeTimestep(MeshData<Real> *md);
 
 /**
  * Return a tag per-block indicating whether to refine it
@@ -99,5 +88,11 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
  * Same but for the conserved angular momentum T3
  */
 void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+
+/**
+ * Update the signal speeds in zones affected by the above operations.
+ * This is important to stay under the Courant limit at times
+ */
+Real UpdateAveragedCtop(MeshData<Real> *md);
 
 }

--- a/kharma/grmhd/grmhd.hpp
+++ b/kharma/grmhd/grmhd.hpp
@@ -93,6 +93,6 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
  * Update the signal speeds in zones affected by the above operations.
  * This is important to stay under the Courant limit at times
  */
-Real UpdateAveragedCtop(MeshData<Real> *md);
+void UpdateAveragedCtop(MeshData<Real> *md);
 
 }


### PR DESCRIPTION
After fixing some silly mistakes, and unwinding some complexity in `EstimateTimestep` and related that didn't need to exist anymore, you can now enable `cancel_U3` and `cancel_T3` safe in the knowledge that whatever havoc they wreak, it's not related to overstepping the Courant condition.