### PR TITLE
Excised transmitting boundaries

### DIFF
--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -361,6 +361,8 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
     // Callbacks
     // Fix flux
     pkg->FixFlux = KBoundaries::FixFlux;
+    // Source term (only needed for excise_flux)
+    pkg->AddSource = KBoundaries::AddSource;
     return pkg;
 }
 
@@ -619,18 +621,9 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
     // These functions do *not* need an extra row outside the domain,
     // like B_FluxCT::ZeroBoundaryFlux does.
     const int ndim = pmesh->ndim;
-    // Entire range
-    const IndexRange ibe = pmb0->cellbounds.GetBoundsI(IndexDomain::entire);
-    const IndexRange jbe = pmb0->cellbounds.GetBoundsJ(IndexDomain::entire);
-    const IndexRange kbe = pmb0->cellbounds.GetBoundsK(IndexDomain::entire);
-    // Ranges for sides
-    const IndexRange ibs = pmb0->cellbounds.GetBoundsI(IndexDomain::interior);
-    const IndexRange jbs = pmb0->cellbounds.GetBoundsJ(IndexDomain::interior);
-    const IndexRange kbs = pmb0->cellbounds.GetBoundsK(IndexDomain::interior);
-    // Ranges for faces
-    const IndexRange ibf = IndexRange{ibs.s, ibs.e + 1};
-    const IndexRange jbf = IndexRange{jbs.s, jbs.e + (ndim > 1)};
-    const IndexRange kbf = IndexRange{kbs.s, kbs.e + (ndim > 2)};
+    // One-zone halo for fluxes
+    const IndexRange3 bi = KDomain::GetRange(md, IndexDomain::interior);
+    const IndexRange3 b1 = KDomain::GetRange(md, IndexDomain::interior, -1, 1);
 
     for (auto &pmb : pmesh->block_list) {
         auto &rc = pmb->meshblock_data.Get();
@@ -643,16 +636,17 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
 
             if (bdir > ndim) continue;
 
-            // Set ranges for entire width.  Probably not needed for fluxes but won't hurt
-            // Transmitting fluxes now require at least 1-zone halo as they replace all directions
-            IndexRange ib = ibe, jb = jbe, kb = kbe;
+            const IndexRange3 bf = KDomain::GetRange(rc, IndexDomain::interior, FaceOf(bdir));
+
+            // Fluxes are needed in 1-zone halo for FluxCT
+            IndexRange3 b = b1;
             // Range for inner_x1 bounds is first face only, etc.
             if (bdir == 1) {
-                ib.s = ib.e = (binner) ? ibf.s : ibf.e;
+                b.is = b.ie = (binner) ? bf.is : bf.ie;
             } else if (bdir == 2) {
-                jb.s = jb.e = (binner) ? jbf.s : jbf.e;
+                b.js = b.je = (binner) ? bf.js : bf.je;
             } else {
-                kb.s = kb.e = (binner) ? kbf.s : kbf.e;
+                b.ks = b.ke = (binner) ? bf.ks : bf.ke;
             }
 
             PackIndexMap cons_map;
@@ -665,14 +659,14 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
                 if (pmb->boundary_flag[bface] == BoundaryFlag::user) {
                     if (binner) {
                         pmb->par_for(
-                            "zero_inflow_flux_" + bname, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                            "zero_inflow_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
                             KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
                                 F.flux(bdir, m_rho, k, j, i) = m::min(F.flux(bdir, m_rho, k, j, i), 0.);
                             }
                         );
                     } else {
                         pmb->par_for(
-                            "zero_inflow_flux_" + bname, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                            "zero_inflow_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
                             KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
                                 F.flux(bdir, m_rho, k, j, i) = m::max(F.flux(bdir, m_rho, k, j, i), 0.);
                             }
@@ -686,7 +680,7 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
                 // ...and if this face of the block corresponds to a global boundary...
                 if (pmb->boundary_flag[bface] == BoundaryFlag::user) {
                     pmb->par_for(
-                        "zero_flux_" + bname, 0, F.GetDim(4) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                        "zero_flux_" + bname, 0, F.GetDim(4) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
                         KOKKOS_LAMBDA(const int &p, const int &k, const int &j, const int &i) {
                             F.flux(bdir, p, k, j, i) = 0.;
                         }
@@ -722,13 +716,59 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
                     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
                     const auto& G = pmb->coords;
                     const int nvar = F.GetDim(4);
+                    const Loci loc = (binner) ? Loci::outer_half : Loci::inner_half;
+
+                    const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, CC);
                     // Cell center of our two which is actually on grid
-                    const int j_cell = (binner) ? jb.s : jb.s - 1;
+                    const int j_cell = (binner) ? b.js : b.js - 1;
+
+                    // Replace existing X3 fluxes in last row with true half-cell versions
+                    const int dir = X3DIR;
+                    pmb->par_for(
+                        "excise_flux_" + bname, b.ks, b.ke, j_cell, j_cell, b.is, b.ie,
+                        KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+                            // Leftover Pl/Pr from X3DIR flux calculation!
+                            const int jn = (binner) ? j+1 : j-1;
+                            PLOOP Pl_all(ip, k, j, i) = 0.75 * Pl_all(ip, k, j, i) + 0.25 * Pl_all(ip, k, jn, i);
+                            PLOOP Pr_all(ip, k, j, i) = 0.75 * Pr_all(ip, k, j, i) + 0.25 * Pr_all(ip, k, jn, i);
+
+                            FourVectors Dtmp;
+                            // Left
+                            GRMHD::calc_4vecs(G, Pl_all, m_p, k, j, i, loc, Dtmp);
+                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ul_all, m_u, loc);
+                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k, j, i, dir, Fl_all, m_u, loc);
+                            // Magnetosonic speeds
+                            Real cmaxL, cminL;
+                            Flux::vchar_global(G, Pl_all, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxL, cminL);
+                            // Record speeds
+                            cmax(dir-1, k, j, i) = m::max(0., cmaxL);
+                            cmin(dir-1, k, j, i) = m::min(0., cminL);
+
+                            // Right
+                            GRMHD::calc_4vecs(G, Pr_all, m_p, k, j, i, loc, Dtmp);
+                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ur_all, m_u, loc);
+                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k, j, i, dir, Fr_all, m_u, loc);
+                            // Magnetosonic speeds
+                            Real cmaxR, cminR;
+                            Flux::vchar_global(G, Pr_all, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxR, cminR);
+
+                            // Reset cmax/cmin based on our flux
+                            cmax(dir-1, k, j, i) =  m::max(cmax(dir-1, k, j, i), cmaxR);
+                            cmin(dir-1, k, j, i) = -m::min(cmin(dir-1, k, j, i), cminR);
+
+                            // Use LLF flux
+                            PLOOP {
+                                F.flux(dir, ip, k, j, i) = Flux::llf(Fl_all(ip, k, j, i), Fr_all(ip, k, j, i),
+                                                                    cmax(dir-1, k, j, i), cmin(dir-1, k, j, i),
+                                                                    Ul_all(ip, k, j, i), Ur_all(ip, k, j, i)) * 0.5;
+                            }
+                        }
+                    );
 
                     // Replace fluxes through the pole (would be zero) with fluxes through
-                    // the middle of the cell. Only in X2 for dir 2
+                    // the middle of the cell. Should be general, remember this has 1-zone halo!
                     pmb->par_for(
-                        "excise_flux_" + bname, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                        "excise_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
                         KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
                             // Face i,j,k borders cell with same index and 1 left with index:
                             int kk = (bdir == 3) ? k - 1 : k;
@@ -768,28 +808,29 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
                                 F.flux(bdir, ip, k, j, i) = Flux::llf(Fl_all(ip, k, j, i), Fr_all(ip, k, j, i),
                                                                     cmax(bdir-1, k, j, i), cmin(bdir-1, k, j, i),
                                                                     Ul_all(ip, k, j, i), Ur_all(ip, k, j, i));
-                                // Our zone now sees only half-size r, th faces, therefore fluxes
-                                // Convert to/from zero-index to modulate
-                                // TODO should actually recalcuate at new face center...
-                                F.flux((bdir - 1 + 1) % 3 + 1, ip, k, j_cell, i) /= 2;
-                                F.flux((bdir - 1 + 2) % 3 + 1, ip, k, j_cell, i) /= 2;
+                                // Reduce the X1 flux in a semi-consistent way
+                                const int jc = (binner) ? j_cell + 1 : j_cell;
+                                F.flux(X1DIR, ip, k, j_cell, i) *= 0.5
+                                    * (G.gdet(Loci::face1, j_cell, i) + G.gdet(Loci::corner, jc, i)) / 2 / G.gdet(Loci::face1, j_cell, i);
+                                // This is also a decent guess, but less accurate than recalculating as above
+                                // F.flux(X3DIR, ip, k, j_cell, i) *= 0.5
+                                //     * G.gdet(loc, j_cell, i) / G.gdet(Loci::center, j_cell, i);
                             }
 
                             // Account for the half-size in the timestep later
                             cmax(bdir-1, k, j, i) *= 2;
                             cmin(bdir-1, k, j, i) *= 2;
-
                         }
                     );
                     // Then average to make absolutely sure fluxes match
                     // TODO only for X2 bound currently!
-                    const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, CC);
+                    // Must pay attention that only physical zones are touched: no averaging w/ghosts!
                     const int Nk3p = (bi.ke - bi.ks + 1);
                     const int Nk3p2 = Nk3p/2;
                     const int ksp = bi.ks;
-                    // Run over previous X1/X2 but half the X3 range...
+                    // Run over X1 *interior* on the X2 face, for half the *interior* X3 range
                     pmb->par_for(
-                        "average_excised_flux_" + bname, 0, F.GetDim(4)-1, kb.s, (kb.e-kb.s+1)/2 + kb.s, jb.s, jb.e, ib.s, ib.e,
+                        "average_excised_flux_" + bname, 0, F.GetDim(4)-1, bi.ks, bi.ks + Nk3p2 - 1, b.js, b.je, bi.is, bi.ie,
                         KOKKOS_LAMBDA(const int &v, const int &k, const int &j, const int &i) {
                             const int ki = ((k - ksp + Nk3p2) % Nk3p) + ksp;
                             Real avg = 0.;
@@ -812,4 +853,59 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
     }
 
     return TaskStatus::complete;
+}
+
+void KBoundaries::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+{
+    // Note we're ignoring "domain," we just add the "source" where it's needed next to the pole
+    auto pmesh = mdudt->GetMeshPointer();
+    auto& params = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
+    for (int i=0; i < mdudt->NumBlocks(); ++i) {
+        auto &rc = mdudt->GetBlockData(i);
+        auto pmb = rc->GetBlockPointer();
+        for (int i = 0; i < BOUNDARY_NFACES; i++) {
+            BoundaryFace bface = (BoundaryFace)i;
+            auto bname = KBoundaries::BoundaryName(bface);
+            const auto bdir = KBoundaries::BoundaryDirection(bface);
+            const auto binner = KBoundaries::BoundaryIsInner(bface);
+            const auto bdomain = KBoundaries::BoundaryDomain(bface);
+
+            if (bdir > pmesh->ndim) continue;
+
+            // If we should replace fluxes with excised versions...
+            if (params.Get<bool>("excise_flux_" + bname)) {
+                // ...and if this face of the block corresponds to a global boundary...
+                if (pmb->boundary_flag[bface] == BoundaryFlag::user) {
+                    if (bdir != 2) throw std::runtime_error("Excised polar fluxes only fully implemented in X2!");
+
+                    const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior);
+
+                    // Interior only! We're about to sync anyway
+                    IndexRange3 b = bi;
+                    // Range is last physical cell-center around the pole
+                    if (bdir == 1) {
+                        b.is = b.ie = (binner) ? bi.is : bi.ie;
+                    } else if (bdir == 2) {
+                        b.js = b.je = (binner) ? bi.js : bi.je;
+                    } else {
+                        b.ks = b.ke = (binner) ? bi.ks : bi.ke;
+                    }
+
+                    auto &dUdt = rc->PackVariables({Metadata::WithFluxes});
+                    const auto& G = pmb->coords;
+                    const Loci loc = (binner) ? Loci::outer_half : Loci::inner_half;
+
+                    pmb->par_for(
+                        "normalize_excised_flux_" + bname, 0, dUdt.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+                        KOKKOS_LAMBDA(const int &v, const int &k, const int &j, const int &i) {
+                            // Factor of 2 because cell is half-size in fluxdiv
+                            // gdet factors move conserved vars at outer cell to the center
+                            dUdt(v, k, j, i) *= 2 * G.gdet(Loci::center, j, i) / G.gdet(loc, j, i);
+                        }
+                    );
+
+                }
+            }
+        }
+    }
 }

--- a/kharma/boundaries/boundaries.hpp
+++ b/kharma/boundaries/boundaries.hpp
@@ -37,7 +37,6 @@
 
 #include "boundary_types.hpp"
 #include "dirichlet.hpp"
-#include "flux.hpp"
 #include "grmhd_functions.hpp"
 #include "one_block_transmit.hpp"
 

--- a/kharma/boundaries/boundaries.hpp
+++ b/kharma/boundaries/boundaries.hpp
@@ -72,9 +72,20 @@ inline void ApplyBoundaryTemplate(std::shared_ptr<MeshBlockData<Real>> &rc, bool
  * Fix fluxes on physical boundaries.
  * 1. Ensure no inflow of density onto the domain
  * 2. Ensure flux through the size-zero faces on poles is zero
- * The latter may be unnecessary
+ * OR
+ * 2. Ensure that fluxes through & around the pole reflect a half-zone excision
  */
 TaskStatus FixFlux(MeshData<Real> *rc);
+
+/**
+ * When fluxes are allowed across the pole, they are computed by assuming half-size zones
+ * next to the pole, with the remaining space excised.  The flux divergence, however,
+ * divides by the full zone volume (as with every other zone on the grid).
+ * This doubles the flux-divergence term to reflect changes to the larger, real zones.
+ * Since *only* the divergence term should be doubled, this must be run *first* after
+ * FluxDivergence, which is ensured by Packages::AddSource.
+ */
+void AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
 
 // INTERNAL FUNCTIONS
 

--- a/kharma/coordinates/gr_coordinates.cpp
+++ b/kharma/coordinates/gr_coordinates.cpp
@@ -133,8 +133,8 @@ void init_GRCoordinates(GRCoordinates& G) {
                     // Get a square of points evenly across each cell,
                     // over both nontrivial geometry directions 1,2
                     // Note this never hits/passes the pole
-                    for (int k=-radius; k <= radius; k++) {
-                        for (int l=-radius; l <= radius; l++) {
+                    for (int k = -radius; k <= radius; k++) {
+                        for (int l = -radius; l <= radius; l++) {
                             GReal X[GR_DIM];
                             G.coord(0, j, i, loc, X);
                             GReal Xn1[GR_DIM], Xn2[GR_DIM];
@@ -185,7 +185,7 @@ void init_GRCoordinates(GRCoordinates& G) {
                             gcon_local(loc, j, i, mu, nu) += gcon_loc[mu][nu] / diameter;
                         }
                     }
-                } else { // corner
+                } else { // corner or exotic locations, no averaging
                     // Just one point
                     GReal X[GR_DIM];
                     G.coord(0, j, i, loc, X);

--- a/kharma/coordinates/gr_coordinates.hpp
+++ b/kharma/coordinates/gr_coordinates.hpp
@@ -211,6 +211,16 @@ KOKKOS_INLINE_FUNCTION void GRCoordinates::coord(const int& k, const int& j, con
         X[2] = Xf<2>(j);
         X[3] = Xf<3>(k);
         break;
+    case Loci::outer_half:
+        X[1] = Xc<1>(i);
+        X[2] = (Xc<2>(j) + Xf<2>(j+1)) / 2;
+        X[3] = Xc<3>(k);
+        break;
+    case Loci::inner_half:
+        X[1] = Xc<1>(i);
+        X[2] = (Xc<2>(j) + Xf<2>(j)) / 2;
+        X[3] = Xc<3>(k);
+        break;
     }
 }
 

--- a/kharma/decs.hpp
+++ b/kharma/decs.hpp
@@ -100,8 +100,8 @@ using GReal = double;
 // Useful enum to avoid lots of #defines
 // See following functions and coord() in gr_coordinates.hpp to
 // get an idea of these locations.  All faces/corner are *left* of center
-#define NLOC 5
-enum class Loci{face1=0, face2, face3, center, corner};
+#define NLOC 7
+enum class Loci{face1=0, face2, face3, center, corner, outer_half, inner_half};
 
 // Return the face location corresponding to the direction 'dir'
 KOKKOS_FORCEINLINE_FUNCTION Loci loc_of(const int& dir)

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -39,8 +39,7 @@
 
 using namespace parthenon;
 
-// Very bad definitions. TODO get rid of them eventually
-#define NPRIM_MAX 12
+// Very bad definition. TODO get rid of this eventually
 #define PLOOP for(int ip=0; ip < nvar; ++ip)
 
 TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)

--- a/kharma/flux/reconstruction.hpp
+++ b/kharma/flux/reconstruction.hpp
@@ -731,7 +731,12 @@ KOKKOS_INLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X1DIR>(parth
                                         const int& k, const int& j, const int& is_l, const int& ie_l, 
                                         ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
 {
-    ReconstructRow<Type::weno5, X1DIR>(member, P, k, j, is_l, ie_l, ql, qr);
+    constexpr int o = 6;
+    if (j > o && j < P.GetDim(2) - o) {
+        ReconstructRow<Type::weno5, X1DIR>(member, P, k, j, is_l, ie_l, ql, qr);
+    } else {
+        ReconstructRow<Type::linear_mc, X1DIR>(member, P, k, j, is_l, ie_l, ql, qr);
+    }
 }
 template <>
 KOKKOS_INLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X2DIR>(parthenon::team_mbr_t& member,
@@ -741,8 +746,9 @@ KOKKOS_INLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X2DIR>(parth
 {
     // This prioiritizes using the same fluxes on faces rather than for cells.
     // Neither is transparently wrong (afaict) but this feels nicer
-    constexpr int o = 6; //5;
-    if (j > o || j < P.GetDim(2) - o) {
+    // Use first 2 physical rows to prevent high-order recon reaching from rank 2 across pole
+    constexpr int o = 6;
+    if (j > o && j < P.GetDim(2) - o) {
         ReconstructX2l<Type::weno5>(member, k, j - 1, is_l, ie_l, P, ql);
         ReconstructX2r<Type::weno5>(member, k, j, is_l, ie_l, P, qr);
     } else {
@@ -756,7 +762,12 @@ KOKKOS_INLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X3DIR>(parth
                                         const int& k, const int& j, const int& is_l, const int& ie_l, 
                                         ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
 {
-    ReconstructRow<Type::weno5, X3DIR>(member, P, k, j, is_l, ie_l, ql, qr);
+    constexpr int o = 6;
+    if (j > o && j < P.GetDim(2) - o) {
+        ReconstructRow<Type::weno5, X3DIR>(member, P, k, j, is_l, ie_l, ql, qr);
+    } else {
+        ReconstructRow<Type::linear_mc, X3DIR>(member, P, k, j, is_l, ie_l, ql, qr);
+    }
 }
 
 /**

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -52,6 +52,7 @@
 #include "implicit.hpp"
 #include "inverter.hpp"
 #include "floors.hpp"
+#include "flux.hpp"
 #include "grmhd.hpp"
 #include "reductions.hpp"
 #include "emhd.hpp"

--- a/kharma/kharma_package.cpp
+++ b/kharma/kharma_package.cpp
@@ -158,9 +158,18 @@ TaskStatus Packages::BoundaryPtoUElseUtoP(MeshBlockData<Real> *rc, IndexDomain d
 TaskStatus Packages::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
 {
     Flag("AddSource");
-    auto kpackages = md->GetMeshPointer()->packages.AllPackagesOfType<KHARMAPackage>();
+    auto pmesh = md->GetMeshPointer();
+    auto kpackages = pmesh->packages.AllPackagesOfType<KHARMAPackage>();
+    if (kpackages.count("Boundaries")) {
+        KHARMAPackage *pkpackage = pmesh->packages.Get<KHARMAPackage>("Boundaries");
+        if (pkpackage->AddSource != nullptr) {
+            Flag("AddSource_Boundaries");
+            pkpackage->AddSource(md, mdudt, domain);
+            EndFlag();
+        }
+    }
     for (auto kpackage : kpackages) {
-        if (kpackage.second->AddSource != nullptr) {
+        if (kpackage.second->AddSource != nullptr && kpackage.first != "Boundaries") {
             Flag("AddSource_"+kpackage.first);
             kpackage.second->AddSource(md, mdudt, domain);
             EndFlag();

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -39,6 +39,7 @@
 #include "boundaries.hpp"
 #include "coordinate_utils.hpp"
 #include "domain.hpp"
+#include "flux.hpp"
 #include "fm_torus.hpp"
 #include "grmhd_functions.hpp"
 


### PR DESCRIPTION
Sometimes the best excuse is that you just did it.

This should implement a more or less similar approach to polar boundaries as taken by H-AMR: pretend there's an excised region for the purposes of calculating fluxes between zones, but otherwise use a full grid with no excisions.  The magnetic field, primitive variable recovery, and all other parts of a step see a full grid, but fluxes through the "size zero" faces on the pole are computed as if it was in fact one half-cell wide.

This affects the fluxes in all directions in the last row: the X1 flux is halved (down to some geometric factors), the X2 flux is calculated as if the cell centers were the sides of new "face" with no polar region between them, and the X3 fluxes are recalculated using a linear interpolation of the primitive values reconstructed at the last and second-last X3 faces, as well as new "inner_half" and "outer_half" geometry locations reflecting `gcov` in the half-cell.

The current implementation makes what amount to guesses at the fluxes in polar zones, so it still leaves a "wake" in 90-degree MAD tori for example.  But none of the circumpolar averaging tricks are required to keep such a run stable, so I still count it a win.

Also re: stability: half-size zones mean half-size timesteps sometimes, so if you're striving for accuracy this can be slow.  Using Courant numbers too large can and will crash simulations with these boundaries enabled.  But if accuracy doesn't matter, you can enable MKS coordinates, ISMR, etc to speed things back up.

Enable with `boundaries/excise_polar_flux=true`.  You may want to disable `reconnect_B3_inner_x2` and `reconnect_B3_outer_x2`, which are enabled by default for transmitting boundary conditions but aren't needed if excised fluxes are used.