### PR TITLE
Try to fix a segfault when jcon is output

### DIFF
--- a/kharma/driver/imex_step.cpp
+++ b/kharma/driver/imex_step.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: imex_step.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -88,8 +88,15 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
         // Preserve state for time derivatives if we need to output current
         if (use_jcon) {
             pmesh->mesh_data.Add("preserve");
-            // Above only copies on allocate -- ensure we copy every step
-            Copy<MeshData<Real>>({Metadata::Cell}, base.get(), pmesh->mesh_data.Get("preserve").get());
+            // Above only copies on allocate -- ensure we copy the MHD variables every step with a task
+            std::vector<MetadataFlag> vars_jcon_needs = {Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")};
+            const int num_partitions = pmesh->DefaultNumPartitions();
+            TaskRegion &copy_region = tc.AddRegion(num_partitions);
+            for (int i = 0; i < num_partitions; i++) {
+                auto &tl = copy_region[i];
+                tl.AddTask(t_none, Copy<MeshData<Real>>, vars_jcon_needs,
+                            base.get(), pmesh->mesh_data.Get("preserve").get());
+            }
         }
         // FOFC needs to determine whether the "real" U-divF will violate floors, and needs a safe place to do it.
         // We populate it later, with each *sub-step*'s initial state
@@ -124,7 +131,7 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
     TaskRegion &flux_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
         auto &tl = flux_region[i];
-        // Container names: 
+        // Container names:
         // '_full_step_init' refers to the fluid state at the start of the full time step (Si in iharm3d)
         // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in iharm3d)
         // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in iharm3d)
@@ -146,7 +153,7 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
         auto t_start_recv_flux = t_start_recv_bound;
         if (pmesh->multilevel || use_b_ct)
             t_start_recv_flux = tl.AddTask(t_none, parthenon::StartReceiveFluxCorrections, md_sub_step_init);
-        
+
         // Calculate the flux of each variable through each face
         // This reconstructs the primitives (P) at faces and uses them to calculate fluxes
         // of the conserved variables (U) through each face.
@@ -162,7 +169,7 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
         // Any package modifications to the fluxes.  e.g.:
         // 1. CT calculations for B field transport
         // 2. Zero fluxes through poles
-        // etc 
+        // etc
         auto t_fix_flux = tl.AddTask(t_fluxes, Packages::FixFlux, md_sub_step_init.get());
 
         // If we're in AMR, correct fluxes from neighbors
@@ -244,7 +251,7 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
             // Time-step implicit variables by root-finding the residual.
             // This calculates the primitive values after the substep for all "isImplicit" variables --
             // no need for separately adding the flux divergence or calling UtoP
-            auto t_implicit_step = tl.AddTask(t_copy_linesearch, Implicit::Step, md_full_step_init.get(), md_sub_step_init.get(), 
+            auto t_implicit_step = tl.AddTask(t_copy_linesearch, Implicit::Step, md_full_step_init.get(), md_sub_step_init.get(),
                                          md_flux_src.get(), md_linesearch.get(), md_solver.get(), integrator->beta[stage-1] * integrator->dt);
 
             // Copy the entire solver state (everything defined on the grid, incl. our new Face variables) into the final state md_sub_step_final


### PR DESCRIPTION
Calculating the 4-current requires preserving state at the end of the last step for time derivatives. Preserving that state requires copying it somewhere, which of course requires somewhere to copy it.

On certain Nvidia machines, something about this process is not working.  This is an attempt to fix it.