### PR TITLE
Polar Papercuts

### DIFF
--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_cd.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -246,7 +246,7 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
 
 void FillOutput(MeshBlock *pmb, ParameterInput *pin)
 {
-    auto rc = pmb->meshblock_data.Get().get();
+    auto rc = pmb->meshblock_data.Get("base").get();
     IndexDomain domain = IndexDomain::interior;
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);

--- a/kharma/b_ct/b_ct.cpp
+++ b/kharma/b_ct/b_ct.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_ct.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -582,7 +582,8 @@ void B_CT::CalcDivB(MeshData<Real> *md, std::string divb_field_name)
 
 void B_CT::FillOutput(MeshBlock *pmb, ParameterInput *pin)
 {
-    auto rc = pmb->meshblock_data.Get();
+    // This is called after the step, use "base" container
+    auto rc = pmb->meshblock_data.Get("base");
     const int ndim = pmb->pmy_mesh->ndim;
     if (ndim < 2) return;
 

--- a/kharma/b_flux_ct/b_flux_ct.cpp
+++ b/kharma/b_flux_ct/b_flux_ct.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_flux_ct.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -410,7 +410,7 @@ void ZeroBoundaryFlux(MeshData<Real> *md, IndexDomain domain, bool coarse)
     // Compare this section with calculation of emf3 in FluxCT:
     // these changes ensure that boundary emfs emf3(i,js,k)=0, etc.
     for (auto &pmb : pmesh->block_list) {
-        auto& rc = pmb->meshblock_data.Get();
+        auto& rc = pmb->meshblock_data.Get(md->StageName());
         auto& B_F = rc->PackVariablesAndFluxes(std::vector<std::string>{"cons.B"});
 
         if (domain == IndexDomain::inner_x2 &&
@@ -495,7 +495,7 @@ void Bflux0(MeshData<Real> *md, IndexDomain domain, bool coarse)
     // Compare this section with calculation of emf3 in FluxCT:
     // these changes ensure that boundary emfs emf3(i,js,k)=0, etc.
     for (auto &pmb : pmesh->block_list) {
-        auto& rc = pmb->meshblock_data.Get();
+        auto& rc = pmb->meshblock_data.Get(md->StageName());
         auto& B_F = rc->PackVariablesAndFluxes(std::vector<std::string>{"cons.B"});
 
         // "Bflux0" prescription for keeping divB~=0 on zone corners of the interior & exterior X1 faces
@@ -555,7 +555,7 @@ IndexRange ValidDivBX1(MeshBlock *pmb)
 {
     // All user, physical (not MPI/periodic) boundary conditions in X1 will generate divB on corners
     // intersecting the interior & exterior faces. Don't report these zones, as we expect it.
-    const IndexRange ibl = pmb->meshblock_data.Get()->GetBoundsI(IndexDomain::interior);
+    const IndexRange ibl = pmb->meshblock_data.Get("base")->GetBoundsI(IndexDomain::interior);
     bool avoid_inner = (!pmb->packages.Get("B_FluxCT")->Param<bool>("fix_flux_inner_x1") &&
         pmb->boundary_flag[BoundaryFace::inner_x1] == BoundaryFlag::user);
     bool avoid_outer = (!pmb->packages.Get("B_FluxCT")->Param<bool>("fix_flux_outer_x1") &&
@@ -677,7 +677,7 @@ void CalcDivB(MeshData<Real> *md, std::string divb_field_name)
 }
 void FillOutput(MeshBlock *pmb, ParameterInput *pin)
 {
-    auto rc = pmb->meshblock_data.Get().get();
+    auto rc = pmb->meshblock_data.Get("base").get();
     const int ndim = pmb->pmy_mesh->ndim;
     if (ndim < 2) return;
 

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -626,7 +626,7 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
     const IndexRange3 b1 = KDomain::GetRange(md, IndexDomain::interior, -1, 1);
 
     for (auto &pmb : pmesh->block_list) {
-        auto &rc = pmb->meshblock_data.Get();
+        auto &rc = pmb->meshblock_data.Get(md->StageName());
 
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
             BoundaryFace bface = (BoundaryFace)i;

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -192,7 +192,7 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
             // introduce divergence to the first physical zone.
             bool clean_face_B = pin->GetOrAddBoolean("boundaries", "clean_face_B_" + bname, (btype == "outflow"));
             params.Add("clean_face_B_"+bname, clean_face_B);
-            // Forcibly reconnect field loops that get trapped around the polar boundary.  Probably not needed anymore.
+            // Forcibly reconnect field loops that get trapped around the polar boundary
             bool reconnect_B3 = pin->GetOrAddBoolean("boundaries", "reconnect_B3_" + bname, false);
             params.Add("reconnect_B3_"+bname, reconnect_B3);
 

--- a/kharma/coord_output/coord_output.cpp
+++ b/kharma/coord_output/coord_output.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: coord_output.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -70,7 +70,7 @@ std::shared_ptr<KHARMAPackage> CoordinateOutput::Initialize(ParameterInput *pin,
     pkg->AddField("coords.r", m0);
     pkg->AddField("coords.th", m0);
     pkg->AddField("coords.phi", m0);
-    
+
     // Metric
     pkg->AddField("coords.gcon", m2);
     pkg->AddField("coords.gcov", m2);
@@ -100,7 +100,7 @@ TaskStatus CoordinateOutput::BlockUserWorkBeforeOutput(MeshBlock *pmb, Parameter
 {
     auto& globals = pmb->packages.Get("Globals")->AllParams();
     if (!globals.Get<bool>("in_loop")) {
-        auto rc = pmb->meshblock_data.Get();
+        auto rc = pmb->meshblock_data.Get("base");
 
         PackIndexMap geom_map;
         auto Geom = rc->PackVariables({Metadata::GetUserFlag("CoordinateOutput")}, geom_map);

--- a/kharma/current/current.cpp
+++ b/kharma/current/current.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: current.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -118,7 +118,7 @@ void Current::FillOutput(MeshBlock *pmb, ParameterInput *pin)
 {
     // The "preserve" container will only exist after we've taken a step,
     // catch that situation
-    auto& rc1 = pmb->meshblock_data.Get();
+    auto& rc1 = pmb->meshblock_data.Get("base");
     auto rc0 = rc1; // Avoid writing rc0's type when initializing. Still light.
     try {
         // Get the state at beginning of the step

--- a/kharma/driver/simple_step.cpp
+++ b/kharma/driver/simple_step.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: simple_step.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -52,7 +52,7 @@ TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t &blocks, int s
 
     // Allocate the fluid states ("containers") we need for each block
     for (auto& pmb : blocks) {
-        auto &base = pmb->meshblock_data.Get();
+        auto &base = pmb->meshblock_data.Get("base");
         if (stage == 1) {
             pmb->meshblock_data.Add("dUdt", base);
             for (int i = 1; i < integrator->nstages; i++)
@@ -68,7 +68,7 @@ TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t &blocks, int s
     TaskRegion &single_tasklist_per_pack_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
         auto &tl = single_tasklist_per_pack_region[i];
-        // Container names: 
+        // Container names:
         // '_full_step_init' refers to the fluid state at the start of the full time step (Si in iharm3d)
         // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in iharm3d)
         // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in iharm3d)
@@ -86,7 +86,7 @@ TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t &blocks, int s
         // Any package modifications to the fluxes.  e.g.:
         // 1. CT calculations for B field transport
         // 2. Zero fluxes through poles
-        // etc 
+        // etc
         auto t_fix_flux = tl.AddTask(t_fluxes, Packages::FixFlux, md_sub_step_init.get());
 
         // Apply the fluxes to calculate a change in cell-centered values "md_flux_src"

--- a/kharma/flux/reconstruction.hpp
+++ b/kharma/flux/reconstruction.hpp
@@ -79,9 +79,9 @@ KOKKOS_FORCEINLINE_FUNCTION double Median(double a, double b, double c)
 template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct(RECONSTRUCT_ONE_ARGS) {}
 
+// TODO better defaults?  As-is, forgetting to implement these causes problems!
 template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left(RECONSTRUCT_ONE_LEFT_ARGS) {}
-
 template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right(RECONSTRUCT_ONE_RIGHT_ARGS) {}
 
@@ -260,7 +260,7 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::weno5_linear>(RECONSTRUCT_ONE
     Real dq = x4 - x3;
     dq = mc(x3 - x2, dq, 2.0);
 
-    const Real alpha_lin = 2.0 * alpha_r * alpha_l / (alpha_r + alpha_l);
+    const Real alpha_lin = clip(2.0 * alpha_r * alpha_l / (alpha_r + alpha_l), 0.0, 1.0);
     rout = alpha_lin * rout + (1.0 - alpha_lin) * (x3 + 0.5 * dq);
     lout = alpha_lin * lout + (1.0 - alpha_lin) * (x3 - 0.5 * dq);
 }
@@ -492,6 +492,18 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::ppmx>(const Real &q_im2, cons
       qlv = q_i - 2.0*qc;
     }
   }
+}
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::ppmx>(RECONSTRUCT_ONE_LEFT_ARGS)
+{
+    Real null;
+    reconstruct<Type::ppmx>(x1, x2, x3, x4, x5, lout, null);
+}
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::ppmx>(RECONSTRUCT_ONE_RIGHT_ARGS)
+{
+    Real null;
+    reconstruct<Type::ppmx>(x1, x2, x3, x4, x5, null, rout);
 }
 
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -297,7 +297,7 @@ Real EstimateTimestep(MeshData<Real> *md)
     // TODO maybe split normal, ISMR timesteps? Excised pole/recalculated ctop too?
     double min_ndt = std::numeric_limits<double>::max();
     for (auto &pmb : pmesh->block_list) {
-        auto rc = pmb->meshblock_data.Get().get();
+        auto rc = pmb->meshblock_data.Get(md->StageName()).get();
         // We only need this block-wise to check boundary flags for ISMR, could special-case that
         const bool polar_inner_x2 = pmb->boundary_flag[BoundaryFace::inner_x2] == BoundaryFlag::user;
         const bool polar_outer_x2 = pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::user;
@@ -629,7 +629,7 @@ void UpdateAveragedCtop(MeshData<Real> *md)
     auto pmesh = md->GetMeshPointer();
     auto& params = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
     for (auto &pmb : pmesh->block_list) {
-        auto &rc = pmb->meshblock_data.Get();
+        auto &rc = pmb->meshblock_data.Get(md->StageName());
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
             BoundaryFace bface = (BoundaryFace)i;
             auto bname = KBoundaries::BoundaryName(bface);

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -296,8 +296,10 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
 #endif
                 const auto& G = U_full_step_init_all.GetCoords(b);
 
-                // Solver performance diagnostics.  Reset at first iteration!
-                Real &solve_fail = (iter == 1) ? SolverStatusR::converged : solve_fail_all(b, 0, k, j, i);
+                // Solver performance diagnostics.
+                Real &solve_fail = solve_fail_all(b, 0, k, j, i);
+                // Reset (locally and in View) at first iteration!
+                if (iter == 1) solve_fail = SolverStatusR::converged;
 
                 // Perform the solve only if it hadn't failed in any of the previous iterations.
                 if (solve_fail != SolverStatusR::fail) {

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -296,8 +296,8 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
 #endif
                 const auto& G = U_full_step_init_all.GetCoords(b);
 
-                // Solver performance diagnostics
-                Real &solve_fail = solve_fail_all(b, 0, k, j, i);
+                // Solver performance diagnostics.  Reset at first iteration!
+                Real &solve_fail = (iter == 1) ? SolverStatusR::converged : solve_fail_all(b, 0, k, j, i);
 
                 // Perform the solve only if it hadn't failed in any of the previous iterations.
                 if (solve_fail != SolverStatusR::fail) {

--- a/kharma/prob/post_initialize.cpp
+++ b/kharma/prob/post_initialize.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: post_initialize.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -97,7 +97,7 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
     // since seeding may be based on density
     if (pin->GetOrAddBoolean("blob", "add_blob", false)) {
         for (auto &pmb : pmesh->block_list) {
-            auto rc = pmb->meshblock_data.Get();
+            auto rc = pmb->meshblock_data.Get("base");
             // This inserts only in vicinity of some global r,th,phi
             InsertBlob(rc.get(), pin);
         }
@@ -172,7 +172,7 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
     }
 
     // The e- initialization is called during problem initialization, but we want an option
-    // to force it -- for example, if restarting an ideal GRMHD run, 
+    // to force it -- for example, if restarting an ideal GRMHD run,
     if (pkgs.count("Electrons") && pin->GetOrAddBoolean("electrons", "reinitialize", false)) {
         std::cout << "Reinitializing electron temperatures!" << std::endl;
         Electrons::MeshInitElectrons(md.get(), pin);

--- a/kharma/prob/problem.cpp
+++ b/kharma/prob/problem.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: problem.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -69,7 +69,7 @@ using namespace parthenon;
 
 void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
 {
-    auto rc = pmb->meshblock_data.Get();
+    auto rc = pmb->meshblock_data.Get("base");
     auto prob = pin->GetString("parthenon/job", "problem_id"); // Required parameter
     Flag("ProblemGenerator_"+prob);
     // Also just print this, it's important

--- a/pars/tests/mhdmodes.par
+++ b/pars/tests/mhdmodes.par
@@ -53,6 +53,7 @@ integrator = rk2
 dt_min = 0.0001
 
 <GRMHD>
+# Courant number, where limit of 2o scheme is 1.0 regardless of dimensionality
 cfl = 0.9
 gamma = 1.333333
 # Whether to evolve these variables with an
@@ -63,7 +64,7 @@ implicit = false
 # Local Lax-Friedrichs fluxes
 # `hlle` selects Harten, Lax, van Leer & Einfeldt
 # No production problems use HLLE as it has failure modes
-# we do not test for.
+# we do not catch in the code.
 type = llf
 # Lots of reconstruction options, see the wiki
 reconstruction = weno5

--- a/pars/tori_3d/mad.par
+++ b/pars/tori_3d/mad.par
@@ -11,15 +11,15 @@ problem_id = torus
 archive_parameters = timestamp
 
 <parthenon/mesh>
-nx1 = 288
-nx2 = 128
-nx3 = 128
+nx1 = 128
+nx2 = 64
+nx3 = 64
 
 <parthenon/meshblock>
-nx1 = 144
+nx1 = 128
 nx2 = 64
 # Cannot break up phi with transmitting boundaries
-nx3 = 128
+nx3 = 64
 
 <coordinates>
 base = spherical_ks
@@ -54,7 +54,9 @@ gamma = 1.666667
 
 <flux>
 type = llf
-reconstruction = weno5
+# WENO5 Adaptive Order "At Home" --
+# WENO5Z with fallback to linear recon in difficult regions
+reconstruction = weno5_linear
 
 <driver>
 type = kharma
@@ -69,6 +71,10 @@ outer_x2 = transmitting
 # This reduces the polar "wake," but shrinks the timestep,
 # and has caused instabilities. YMMV.
 #excise_polar_flux = true
+# Reconnect phi component of B at the pole, as if it were one zone
+# Dramatically reduces instabilities
+reconnect_B3_inner_x2 = true
+reconnect_B3_outer_x2 = true
 
 <floors>
 frame        = drift

--- a/pars/tori_3d/sane.par
+++ b/pars/tori_3d/sane.par
@@ -52,7 +52,9 @@ gamma = 1.666667
 
 <flux>
 type = llf
-reconstruction = weno5
+# WENO5 Adaptive Order "At Home" --
+# WENO5Z with fallback to linear recon in difficult regions
+reconstruction = weno5_linear
 
 <driver>
 type = kharma
@@ -67,6 +69,10 @@ outer_x2 = transmitting
 # This reduces the polar "wake," but shrinks the timestep,
 # and has caused instabilities. YMMV.
 #excise_polar_flux = true
+# Reconnect phi component of B at the pole, as if it were one zone
+# Dramatically reduces instabilities
+reconnect_B3_inner_x2 = true
+reconnect_B3_outer_x2 = true
 
 <floors>
 # Now with FOFC it might work to set "frame = normal",


### PR DESCRIPTION
Pushing through later INCITE runs and chasing down people's issues, I've learned that some issues I assumed were unique to high resolution and adiabatic index, were in fact universal to the WENO5/face-centered/transmitting scheme we had put together.  This PR extends the mitigations I was using at high res back down to all simulations, and fixes some little issues with them.

This PR also fixes an issue with the implicit solver never "un-flagging" previously flagged zones, leading to comically large numbers of failed zones causing dissipation problems.  Finally, it backports #133 for the `stable` branch, which could help dramatically for anyone using excised polar boundary conditions or cell-centered/Flux-CT transport.  There's a small chance it fixes even more than that, see the PR for details.

### Reconstruction

WENO5 is particularly unstable at the pole, and this led to large, rapid B field increases which would cause the code to stop due to large divB.  In particular, if there is a coherent $B_{\phi}$ around the pole (as there often is) but the sign oscillates in X1 (imagine stacked, anti-aligned field loops around the pole), then WENO5 will cause positive feedback, reconstructing fluxes into the already positive loops and out of the already negative loops.  Note this also disappears if we use reconstructed versions of all three magnetic field components (i.e., of X1, rather than using the value already present on the face).  But reconstructing B leads to other problems (#79).

I don't believe the WENO feedback loop is the source of all polar issues (more on that below) but it's certainly a rake we're leaving lying around to step on.  One can attempt to just prevent the prerequisite state from happening (just, never accumulate coherent layers of B in oscillatory directions) but I don't think there's a good heuristic or fix to *always* prevent these WENO runaways.

Instead, we should use a different reconstruction, and indeed the problem disappears when I do (despite persisting with different floors, reflecting or transmitting poles, FOFC on/off, lower CFL, etc).  In particular I've tested the linear options, PPM, and "WENO5-AO at home," the reconstruction used in [Phoebus](https://github.com/lanl/phoebus).  "WENO5-AO-AH" is usually WENO5Z, but interpolates to a linear reconstruction as the WENO5 smoothness parameters get bad, which surely happens whenever we encounter runaway positive feedback -- overall it's much like an "adaptive order" scheme, but less formal.  It behaves pretty similarly to WENO5 even under duress (I tested it as a part of #79, and it only adds some wobbles).  So, I've made WENO5-AO-AH the default in the sample `mad.par` and `sane.par`, and I recommend using it.

There was a recent [issue](https://github.com/lanl/phoebus/issues/222) noticed with this scheme in Phoebus, where the interpolation factor could slightly escape the range [0,1] -- I don't know if KHARMA suffers the same, but I've "fixed" it by just clipping the value to always lie in that range.

### Reconnection

The "instant-death" WENO feedback loop is not the only way that the poles can cause problems, however.  Smaller explosions seem to occur even under WENO5-AO-AH or other reconstructions, which seem to consist of high temperature and magnetic field buildup, pushing out a wave through the disk. These appear to be due to high magnetic field at the pole, as well, though this is less certain than the above case since explosions can take thousands of steps to develop over broad regions of X1/X3.

What we do know is that regardless of polar boundary conditions, the azimuthal components of velocity and magnetic field, U3 & B3, still build up at polar boundaries -- less in the transmitting case, but still enough to cause problems.  Fixing the averaging to fully allow rotation under transmitting boundaries (#126) can't have hurt, but the behavior seems to persist after that fix as well.  Physically, this buildup represents tight loops of field and quickly circulating material, which would reconnect or blow away if not for the strained connectivity of the logically Cartesian grid.  Thus the idea of forcible reconnection (see #90).

Reconnecting B3 was off by default because it's a new algorithm no one else has tried -- indeed there was a bug (#131) around conserving energy with it enabled (which is fixed in this PR).  Now at least a few more pairs of eyes have passed over the code, and it has more or less proven itself necessary if one adopts the other algorithmic changes (i.e., less dissipative face-centered B field, reliable Kastaun inversion which does not inject dissipation through failures).  Thus I've also enabled it by default in `mad.par` and `sane.par`, and (somewhat reluctantly) recommend it, especially for MADs at adiabatic index 5./3 or if your simulation fails without it.