### PR TITLE
Better Inversion Floors

### DIFF
--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -191,8 +191,14 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
 
         int fofc_polar_cells = pin->GetOrAddInteger("fofc", "polar_cells", 0);
         params.Add("fofc_polar_cells", fofc_polar_cells);
-        const GReal eh_buffer = pin->GetOrAddReal("fofc", "eh_buffer", 0.1);
-        params.Add("fofc_eh_buffer", eh_buffer);
+        // Usually we use LLF everywhere and this fallback is optional.
+        // If we use HLLE outside EH, we need to fall back to LLF/donor-cell inside.
+        const bool use_eh_buffer = pin->GetOrAddReal("fofc", "use_eh_buffer", (flux != "llf"));
+        params.Add("fofc_use_eh_buffer", use_eh_buffer);
+        if (use_eh_buffer) {
+            const GReal eh_buffer = pin->GetOrAddReal("fofc", "eh_buffer", 0.1);
+            params.Add("fofc_eh_buffer", eh_buffer);
+        }
 
         if (packages->AllPackages().count("B_CT")) {
             // Use consistent B for FOFC (see above)

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -55,9 +55,11 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
     // Parameters
     const auto& pars = pmb0->packages.Get("Flux")->AllParams();
     const bool spherical = pmb0->coords.coords.is_spherical();
-    const GReal r_eh = pmb0->coords.coords.get_horizon();
     const int polar_cells = pars.Get<int>("fofc_polar_cells");
-    const GReal eh_buffer = pars.Get<GReal>("fofc_eh_buffer");
+    const GReal r_eh = pmb0->coords.coords.get_horizon();
+    const GReal fofc_radius = pars.Get<bool>("fofc_use_eh_buffer") ?
+                                r_eh + pars.Get<GReal>("fofc_eh_buffer") :
+                                0.;
 
     // Pre-mark cells which will need fluxes reduced.
     // This avoids a race condition marking them multiple times when iterating faces,
@@ -70,7 +72,7 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
             // if cell failed to invert or would call floors...
             // TODO preserve cause in the fofcflag
             if (static_cast<int>(fflag(b, 0, k, j, i)) || //Inverter::failed(pflag(b, 0, k, j, i)) ||
-                (spherical && G.r(k, j, i) < r_eh + eh_buffer)) {
+                (spherical && G.r(k, j, i) < fofc_radius)) {
                 fofcflag(b, 0, k, j, i) = 1;
             } else {
                 fofcflag(b, 0, k, j, i) = 0;
@@ -167,7 +169,7 @@ TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
                 int kk = (dir == 3) ? k - 1 : k;
                 int jj = (dir == 2) ? j - 1 : j;
                 int ii = (dir == 1) ? i - 1 : i;
-                // If either bordering cell is marked, and always inside the EH
+                // If either bordering cell is marked
                 if (static_cast<int>(fofcflag(b, 0, k, j, i)) ||
                     static_cast<int>(fofcflag(b, 0, kk, jj, ii))) { // TODO allow customizing
 

--- a/kharma/inverter/invert_template.hpp
+++ b/kharma/inverter/invert_template.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: invert_template.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -50,7 +50,7 @@ enum class Type{none=0, onedw, kastaun};
 
 // Denote inversion failures (pflags)
 // This enum should grow to cover any inversion algorithm
-enum class Status{success=0, neg_input, max_iter, bad_ut, bad_gamma, neg_rho, neg_u, neg_rhou};
+enum class Status{success=0, neg_input, max_iter, bad_ut, bad_gamma, neg_rho, neg_u, neg_rhou, floor, bad_velocity};
 
 static const std::map<int, std::string> status_names = {
     {(int) Status::neg_input, "Negative input"},
@@ -59,7 +59,9 @@ static const std::map<int, std::string> status_names = {
     {(int) Status::bad_gamma, "Gamma invalid"},
     {(int) Status::neg_rho, "Negative rho"},
     {(int) Status::neg_u, "Negative U"},
-    {(int) Status::neg_rhou, "Negative rho & U"}
+    {(int) Status::neg_rhou, "Negative rho & U"},
+    {(int) Status::floor, "Floor during inversion"},
+    {(int) Status::bad_velocity, "No velocity solution"}
 };
 
 template <typename T>
@@ -79,13 +81,13 @@ KOKKOS_INLINE_FUNCTION bool valid(T status_flag)
 /**
  * Recover local primitive variables, with a one-dimensional Newton-Raphson iterative solver.
  * Iteration starts from the current primitive values, and otherwse may *fail to converge*
- * 
+ *
  * Returns a code indicating whether the solver converged (success), failed (max_iter), or
  * indicating that the converged solution was unphysical (bad_ut, neg_rhou, neg_rho, neg_u)
- * 
+ *
  * On error, will not write replacement values, leaving the previous step's values in place
  * These are fixed later, in FixUtoP
- * 
+ *
  * This is the function template: implementations are filled in in their own headers.
  * Be VERY CAREFUL to define any specializations by including those headers,
  * BEFORE you instantiate the template.

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -84,10 +84,20 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     }
 
     // Fixup options
-    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
+    // Whether hitting a floor in the Kastaun inverter counts as a "failure"
+    // Avoids using the floors applied during the Kastaun solve, since they can be temperamental
+    bool floors_are_failures = pin->GetOrAddBoolean("inverter", "floors_are_failures", false);
+    params.Add("floors_are_failures", floors_are_failures);
+    // Whether the Kastaun inverter returns failure if it has revised rho or u due to floors,
+    // but can't find a new consistent solution to return sensible velocities.
+    bool bad_vels_are_failures = pin->GetOrAddBoolean("inverter", "bad_vels_are_failures", true);
+    params.Add("bad_vels_are_failures", bad_vels_are_failures);
+
+    // Fix by averaging neighboring cells.  Enabled by default; may want to disable if configuring Kastaun solver never to fail
+    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", true);
     params.Add("fix_average_neighbors", fix_average_neighbors);
     // Fix by replacing with floors, uvec=0. Usually a fallback for no neighbors,
-    // but also used if Kastaun hits max_iter
+    // but also used if Kastaun ever fails for some reason (negative input, usually, or hitting max_iter)
     bool fix_atmosphere = pin->GetOrAddBoolean("inverter", "fix_atmosphere", true);
     params.Add("fix_atmosphere", fix_atmosphere);
     // TODO add version attempting to recover from entropy, stuff like that
@@ -158,6 +168,8 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
     auto &pars = pmb->packages.Get("Inverter")->AllParams();
     const Real err_tol = pars.Get<Real>("err_tol");
     const int iter_max = pars.Get<int>("iter_max");
+    const bool floors_are_fails = pars.Get<bool>("floors_are_failures");
+    const bool bad_vels_are_fails = pars.Get<bool>("bad_vels_are_failures");
     const Floors::Prescription inverter_floors       = pars.Get<Floors::Prescription>("inverter_prescription");
     const Floors::Prescription inverter_floors_inner = pars.Get<Floors::Prescription>("inverter_prescription_inner");
     const bool radius_dependent_floors = inverter_floors.radius_dependent_floors;
@@ -180,6 +192,16 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
             pflag(0, k, j, i) = pflagl % Floors::FFlag::MINIMUM;
             int fflagl = (pflagl / Floors::FFlag::MINIMUM) * Floors::FFlag::MINIMUM;
             fflag(0, k, j, i) = fflagl;
+            // If bad/zeroed velocities shouldn't count as failures, set them back to 'success'
+            if (!bad_vels_are_fails && (pflagl % Floors::FFlag::MINIMUM == static_cast<int>(Inverter::Status::bad_velocity)))
+                pflag(0, k, j, i) = static_cast<double>(Inverter::Status::success);
+            // Optionally mark floored zones as "failed" to trigger averaging
+            if (floors_are_fails &&
+               (fflagl & Floors::FFlag::INVERTER_GAMMA ||
+                fflagl & Floors::FFlag::INVERTER_RHO ||
+                fflagl & Floors::FFlag::INVERTER_U ||
+                fflagl & Floors::FFlag::INVERTER_U_MAX))
+                pflag(0, k, j, i) = static_cast<double>(Inverter::Status::floor);
             // Generally after inversion we manipulate P and call this ourselves
             // Enable this if that doesn't stay true
             // if (fflagl) {

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -93,11 +93,11 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     bool bad_vels_are_failures = pin->GetOrAddBoolean("inverter", "bad_vels_are_failures", true);
     params.Add("bad_vels_are_failures", bad_vels_are_failures);
 
-    // Fix by averaging neighboring cells.  Enabled by default; may want to disable if configuring Kastaun solver never to fail
-    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", true);
+    // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun failures are more dire
+    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
     params.Add("fix_average_neighbors", fix_average_neighbors);
     // Fix by replacing with floors, uvec=0. Usually a fallback for no neighbors,
-    // but also used if Kastaun ever fails for some reason (negative input, usually, or hitting max_iter)
+    // but also used if Kastaun ever fails for some reason (generally negative or near-negative input, so atmo makes sense)
     bool fix_atmosphere = pin->GetOrAddBoolean("inverter", "fix_atmosphere", true);
     params.Add("fix_atmosphere", fix_atmosphere);
     // TODO add version attempting to recover from entropy, stuff like that

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: kastaun.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -163,12 +163,11 @@ class KastaunResidual {
             const Real vhatsq = vhatsq_mu(mu, rbarsq);
             const Real iWhat = iWhat_mu(vhatsq);
             const Real What = 1.0 / iWhat;
-            Real rhohat = rhohat_mu(iWhat);
-            Real ehat = ehat_mu(mu, qbar, rbarsq, vhatsq, What);
+            const Real rhohat = rhohat_mu(iWhat);
+            const Real ehat = ehat_mu(mu, qbar, rbarsq, vhatsq, What);
+            // TODO this is ideal-only
             const Real Phat = ehat * rhohat * (gam_ - 1.0);
-            Real hhat = rhohat * (1.0 + ehat) + Phat;
-            const Real ahat = Phat / (hhat - Phat); // TODO robust this
-            hhat /= rhohat;
+            const Real ahat = Phat / (rhohat * (1.0 + ehat));
 
             const Real nua = (1.0 + ahat) * (1.0 + ehat) * iWhat;
             const Real nub = (1.0 + ahat) * (1.0 + qbar - mu * rbarsq);
@@ -223,15 +222,19 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     // int num_nans = std::isnan(U(m_u.RHO, k, j, i)) + std::isnan(U(m_u.U1, k, j, i)) + std::isnan(U(m_u.UU, k, j, i));
     // if (num_nans > 0) return static_cast<int>(Status::neg_input);
 
+    // Conserved particle number rho*u0 > 0.  Just floor instead of yelling?
+    if (U(m_u.RHO, k, j, i) <= 0.) {
+        return static_cast<int>(Status::neg_input);
+    }
+
     // Transform GRMHD variables for the SRMHD Kastaun solver
     const Real alpha  = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
     const Real a_over_g = alpha / G.gdet(loc, j, i);
 
-    const Real D = U(m_u.RHO, k, j, i) * a_over_g;
+    const Real &Urho = U(m_u.RHO, k, j, i);
+    const Real D = Urho * a_over_g;
 
-    const Real D_fl = std::max(D, floors.rho_min_const);
-
-    Real Qcov[GR_DIM] = {(U(m_u.UU, k, j, i) - U(m_u.RHO, k, j, i)) * a_over_g,
+    Real Qcov[GR_DIM] = {(U(m_u.UU, k, j, i) - Urho) * a_over_g,
                     U(m_u.U1, k, j, i) * a_over_g,
                     U(m_u.U2, k, j, i) * a_over_g,
                     U(m_u.U3, k, j, i) * a_over_g};
@@ -242,10 +245,9 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     const Real q = (-dot(Qcov, ncon) - D) / D;
 
     // r_i
-    // TODO max w/0 or +small
-    Real rcov[3] = {U(m_u.U1, k, j, i) / U(m_u.RHO, k, j, i),
-                    U(m_u.U2, k, j, i) / U(m_u.RHO, k, j, i),
-                    U(m_u.U3, k, j, i) / U(m_u.RHO, k, j, i)};
+    Real rcov[3] = {U(m_u.U1, k, j, i) / Urho,
+                    U(m_u.U2, k, j, i) / Urho,
+                    U(m_u.U3, k, j, i) / Urho};
     Real rcon[3];
     Real gupper[GR_DIM][GR_DIM];
     G.gcon(loc, j, i, gupper);
@@ -276,7 +278,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     Real bdotr = 0.0;
     Real bu[] = {0.0, 0.0, 0.0};
     if (m_u.B1 >= 0) {
-        const Real sD = 1.0 / m::sqrt(D_fl);
+        const Real sD = 1.0 / m::sqrt(D);
         // b^i
         SPACELOOP(ii) {
             bu[ii] = (U(m_u.B1 + ii, k, j, i) * a_over_g) * sD;
@@ -293,8 +295,9 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     const Real v0sq = std::min(zsq / (1.0 + zsq), 1.0 - 1.0 / SQR(floors.gamma_max));
 
     // residual object. Caches most arguments/floors so calls are single-argument
+    // TODO second arg is technically floor on specific energy, should be split...
     KastaunResidual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, gam,
-                        floors.rho_min_const, floors.u_min_const / D_fl,
+                        floors.rho_min_const, floors.u_min_const,
                         floors.gamma_max, floors.u_over_rho_max);
 
     // SOLVE
@@ -316,7 +319,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     Real z = 0.5*(zm + zp);
 
     int iter;
-    for (iter=0; iter<iterations; ++iter) {
+    for (iter = 0; iter < iterations; ++iter) {
         z =  (zm*fp - zp*fm)/(fp-fm);  // linear interpolation to point f(z)=0
         Real f = res.aux_func(z);
         // Quit if convergence reached
@@ -336,7 +339,6 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
             fp = f;
         }
     }
-    // TODO keep track of bracket iter?
 
     // Found brackets. Now find solution in bounded interval, again using the
     // false position method
@@ -353,7 +355,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     }
     z = 0.5*(zm + zp);
 
-    for (iter=0; iter<iterations; ++iter) {
+    for (iter = 0; iter < iterations; ++iter) {
         z = (zm*fp - zp*fm)/(fp-fm);  // linear interpolation to point f(z)=0
         Real f = res(z);
         // Quit if convergence reached
@@ -377,30 +379,118 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
 
     // check if convergence is established within max_iterations.  If not, return
     // failure without replacing prims, for consistency w/1Dw solver.
-    // We generally replace failed zones with atmosphere later, at user option
+    // We generally replace failed zones with neighbors or atmosphere later, at user option
     if (iter == max_iterations) {
         return static_cast<int>(Status::max_iter);
     }
 
+    int fflag = 0;
     // Now unwrap everything into primitive vars...
-    const Real mu = z;
-    const Real x = res.x_mu(mu);
-    const Real rbarsq = res.rbarsq_mu(mu, x);
-    const Real vsq = res.vhatsq_mu(mu, rbarsq);
-    const Real iW = res.iWhat_mu(vsq);
-    const Real W = 1. / iW;
+    Real mu = z;
+    Real x = res.x_mu(mu);
+    Real rbarsq = res.rbarsq_mu(mu, x);
+    Real vsq = res.vhatsq_mu(mu, rbarsq);
+    Real iW = res.iWhat_mu(vsq);
+    Real W = 1.0 / iW;
     P(m_p.RHO, k, j, i) = res.rhohat_mu(iW);
+
+    // Correct mu if we used rho floor
+    if (res.used_density_floor()) {
+        // Mark the flag
+        fflag |= Floors::FFlag::INVERTER_RHO;
+        // New W determined from rho
+        W = D / P(m_p.RHO, k, j, i);
+        iW = 1.0 / W;
+        vsq = 1.0 - SQR(iW);
+        // Analytic solution for x, mu given new W
+        double A = rsq - rbsq / bsq;
+        double B = rbsq / bsq;
+        double C = vsq * bsq;
+        double coeff = -A*A + 3*A*B + 3*A*C;
+        double coeff3 = coeff * coeff * coeff;
+        double coeff_2 = -2*A*A*A - 18*A*A*B + 9*A*A*C;
+        double det = m::sqrt(4 * coeff3 + SQR(coeff_2));
+        double cbrt_det = m::cbrt(coeff_2 + det);
+        x = m::cbrt(2) * coeff / (3 * A * cbrt_det)
+        - cbrt_det / (3 * A * m::cbrt(2)) + 1/3;
+        mu = (1./x - 1) / bsq;
+        rbarsq = res.rbarsq_mu(mu, x);
+    }
+
     const Real qbar = res.qbar_mu(mu, x);
+    // Use the floored density in energy calc, we corrected mu for it
     P(m_p.UU, k, j, i) = res.ehat_mu(mu, qbar, rbarsq, vsq, W) * P(m_p.RHO, k, j, i);
+    // We applied this floor to the ratio u/rho, but not the value u
+    if(P(m_p.UU, k, j, i) < floors.u_min_const) {
+        fflag |= Floors::FFlag::INVERTER_U;
+        P(m_p.UU, k, j, i) = floors.u_min_const;
+    }
+
+    // Try to correct mu if we used the e floor
+    bool ret_momentum_failure = false;
+    if (res.used_energy_floor() || (fflag & Floors::FFlag::INVERTER_U)) {
+        // Record flag
+        fflag |= Floors::FFlag::INVERTER_U;
+
+        // Function e(mu) - e_actual so we can rootfind
+        auto f = [&] (Real mu) {
+            Real x = res.x_mu(mu);
+            Real rbarsq = res.rbarsq_mu(mu, x);
+            Real vsq = res.vhatsq_mu(mu, rbarsq);
+            Real W = 1. / res.iWhat_mu(vsq);
+            Real qbar = res.qbar_mu(mu, x);
+            return (W * (qbar - mu * rbarsq) + vsq * W * W /
+                        (1.0 + W)) * P(m_p.RHO, k, j, i)
+                    - P(m_p.UU, k, j, i);
+        };
+        // Rootfind for mu that would have produced our floored e
+        Real mum = 0., mup = 1.;
+        if (f(mum) * f(mup) > 0.) {
+            mu = 0.;
+            x = 0.;
+            W = 0.;
+        } else {
+            while (1) {
+                Real muc = (mum + mup) / 2.;
+                if (m::abs(f(muc)) < 1e-8 || m::abs((mup - mum) / 2) < 1e-8) {
+                    mu = muc;
+                    if (m::abs(f(mu)) < 1e-8) {
+                        // If we're solved set the solution
+                        x = res.x_mu(mu);
+                        rbarsq = res.rbarsq_mu(mu, x);
+                        vsq = res.vhatsq_mu(mu, rbarsq);
+                        iW = res.iWhat_mu(vsq);
+                        W = 1. / iW;
+                    } else {
+                        // Else defaults
+                        x = 0.;
+                        W = 0.;
+                        // Mark momentum failure
+                        ret_momentum_failure = true;
+                    }
+                    // printf("Solution mu %g x %g rsq %g rbsq %g rbarsq %g vsq %g W %g\n",
+                    //         mu, x, rsq, rbsq, rbarsq, vsq, W);
+                    // SPACELOOP(ii)
+                    //     printf("New U%d: %g\n", ii, W * mu * x * (rcon[ii] + mu * bdotr * bu[ii]));
+                    break;
+                }
+                // Same sign as left side -> center now left side
+                if (f(muc) * f(mum) > 0.)
+                    mum = muc;
+                else
+                    mup = muc;
+            }
+        }
+    }
+
+    // Set velocity with corrected values from rho+e floors
     SPACELOOP(ii) P(m_p.U1 + ii, k, j, i) = W * mu * x * (rcon[ii] + mu * bdotr * bu[ii]);
 
-    // ...and record flags
-    int fflag = 0;
-    if (res.used_density_floor()) fflag |= Floors::FFlag::INVERTER_RHO;
-    if (res.used_energy_floor())  fflag |= Floors::FFlag::INVERTER_U;
+    // Record other flags
     if (res.used_gamma_max())     fflag |= Floors::FFlag::INVERTER_GAMMA;
     if (res.used_energy_max())    fflag |= Floors::FFlag::INVERTER_U_MAX;
-    return fflag;
+
+    return fflag + (ret_momentum_failure) ? static_cast<int>(Status::bad_velocity) : 0 ;
 }
 
 }

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -453,9 +453,10 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
         } else {
             while (1) {
                 Real muc = (mum + mup) / 2.;
-                if (m::abs(f(muc)) < 1e-8 || m::abs((mup - mum) / 2) < 1e-8) {
+                Real resv = m::abs(f(muc));
+                if (resv < 1e-8 || m::abs((mup - mum) / 2) < 1e-10) {
                     mu = muc;
-                    if (m::abs(f(mu)) < 1e-8) {
+                    if (resv < 1e-8) {
                         // If we're solved set the solution
                         x = res.x_mu(mu);
                         rbarsq = res.rbarsq_mu(mu, x);
@@ -491,7 +492,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     if (res.used_gamma_max())     fflag |= Floors::FFlag::INVERTER_GAMMA;
     if (res.used_energy_max())    fflag |= Floors::FFlag::INVERTER_U_MAX;
 
-    return fflag + (ret_momentum_failure) ? static_cast<int>(Status::bad_velocity) : 0 ;
+    return fflag + ((ret_momentum_failure) ? static_cast<int>(Status::bad_velocity) : 0);
 }
 
 }

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -449,6 +449,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
             mu = 0.;
             x = 0.;
             W = 0.;
+            ret_momentum_failure = true;
         } else {
             while (1) {
                 Real muc = (mum + mup) / 2.;


### PR DESCRIPTION
When floors are applied as a part of the primitive variable inversion, this is traditionally done inconsistently, from the point of view of the conserved variables: a density floor will not reduce the internal energy, and crucially neither floor will reduce the velocity.  When one value is updated, the others are still set with the old solution, as if the floored variable were still the old value.

This isn't just a matter of which frame the injected material uses.  Say the density is small, and the initial internal energy is well below the floor.  The matching velocities required to conserve momentum for such a small packet are very large.  But then we reset the internal energy upward significantly, and never correct the high velocities: zoom!

This is an attempt to make the floors consistent -- to the extent it is meaningful to say such things, it also moves them to the normal observer frame.

The method is tedious but straightforward: first, if the density is floored, we recalculate the solution mu given the new density, using the analytic solution to the cubic equation. The resulting `mu` is then used to calculate the internal energy, as if the solver had produced that as the solution, and not the value it did.

Next, if the internal energy is floored (regardless of the density stuff), we attempt to solve for `mu` again, numerically, to match the new internal energy target (though now we ignore whether the result is consistent with the existing density, which we already set). If a solution with our energy does exist, we set the velocities using it -- if not, the conserved state is unphysical; we set the velocities to zero to be minimally disruptive.

By default, unsolvable velocities are considered failures and the whole cell is replaced with the average of neighbors, but this can be disabled.  If you read this and decide inverter floors are not for you, you may also count any floor hit as a failure, skipping all this code entirely in favor of just averaging neighbors.