### PR TITLE
Kastaun inverter for NOF floors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ shock_soln_*.txt
 .cproject
 .ptp-sync
 .vscode/
+.cache/
 
 # C++ excludes
 # Build directory

--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -36,6 +36,7 @@
 #include "decs.hpp"
 #include "domain.hpp"
 #include "floors.hpp"
+#include "floors_functions.hpp"
 #include "grmhd.hpp"
 #include "grmhd_functions.hpp"
 #include "inverter.hpp"

--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -339,7 +339,7 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
 
                     // Recover primitive GRMHD variables from our modified U
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              floors, 8, 1e-8);
+                                                              floors, 25, 1e-12);
                     // Floor them
                     int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Recalculate U on anything we floored

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -298,9 +298,6 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                 default:
                     break;
                 }
-                if (pin->GetInteger("parthenon/mesh", "nx3") != pin->GetInteger("parthenon/meshblock", "nx3") ||
-                    pin->GetInteger("parthenon/mesh", "nx3") == 1)
-                    throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
                 if (pin->GetString("coordinates", "transform") == "fmks" || pin->GetString("coordinates", "transform") == "funky")
                     throw std::runtime_error("Transmitting polar boundary conditions require coordinates symmetric about theta=0!");
                 // TODO also check for wedge simulations x3<2pi
@@ -356,6 +353,19 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                 throw std::runtime_error("Unknown boundary type: "+btype);
             }
         }
+    }
+
+    // If we've split in the phi direction or we're running in 2D
+    if (pin->GetInteger("parthenon/mesh", "nx3") != pin->GetInteger("parthenon/meshblock", "nx3") ||
+        pin->GetInteger("parthenon/mesh", "nx3") == 1) {
+        if (pin->GetString("boundaries", "inner_x3") == "transmitting" || pin->GetString("boundaries", "outer_x3") == "transmitting")
+            throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
+        if (params.Get<bool>("cancel_U3_inner_x3") || params.Get<bool>("cancel_U3_outer_x3") ||
+            params.Get<bool>("cancel_T3_inner_x3") || params.Get<bool>("cancel_T3_outer_x3"))
+            throw std::runtime_error("Polar cancellations require 3D with one block in x3!");
+        if (packages->AllPackages().count("B_CT") &&
+            (params.Get<bool>("reconnect_B3_inner_x3") || params.Get<bool>("reconnect_B3_outer_x3")))
+            throw std::runtime_error("Polar reconnections require 3D with one block in x3!");
     }
 
     // Callbacks

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -65,10 +65,15 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // TODO(BSP) automate/standardize parsing enums like this: classes w/tables like the flags?
     std::vector<std::string> allowed_floor_frames = {"normal", "fluid", "mixed",
                                                      "mixed_fluid_normal", "mixed_normal_drift", "drift"};
-    std::string frame_s = pin->GetOrAddString("floors", "frame", "drift", allowed_floor_frames);
+    std::string frame_s = pin->GetOrAddString("floors", "frame", "normal", allowed_floor_frames);
     InjectionFrame frame;
     if (frame_s == "normal") {
-        frame = InjectionFrame::normal;
+        if (pin->GetOrAddString("inverter", "type", "kastaun") == "onedw") {
+            frame = InjectionFrame::normal_onedw;
+        } else {
+            // Use Kastaun unless we specified onedw inverter
+            frame = InjectionFrame::normal_kastaun;
+        }
     } else if (frame_s == "fluid") {
         frame = InjectionFrame::fluid;
     } else if (frame_s == "mixed" || frame_s == "mixed_fluid_normal") {
@@ -234,8 +239,10 @@ TaskStatus Floors::ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain)
 {
     auto pmesh = md->GetMeshPointer();
     const auto& pars = pmesh->packages.Get("Floors")->AllParams();
-    if (pars.Get<InjectionFrame>("frame") == InjectionFrame::normal) {
-        return ApplyFloorsInFrame<InjectionFrame::normal>(md, domain);
+    if (pars.Get<InjectionFrame>("frame") == InjectionFrame::normal_kastaun) {
+        return ApplyFloorsInFrame<InjectionFrame::normal_kastaun>(md, domain);
+    } else if (pars.Get<InjectionFrame>("frame") == InjectionFrame::normal_onedw) {
+        return ApplyFloorsInFrame<InjectionFrame::normal_onedw>(md, domain);
     } else if (pars.Get<InjectionFrame>("frame") == InjectionFrame::fluid) {
         return ApplyFloorsInFrame<InjectionFrame::fluid>(md, domain);
     } else if (pars.Get<InjectionFrame>("frame") == InjectionFrame::mixed_fluid_normal) {

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -182,7 +182,7 @@ TaskStatus Floors::ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *
             // Initial floors, so the radius-dependence of floors don't matter that much. 
             int fflag = determine_floors(G, P, m_p, gam, k, j, i, floors, floors, rhoflr_max, uflr_max);
             if (fflag) {
-                apply_floors<InjectionFrame::fluid>(G, P, m_p, gam, k, j, i, rhoflr_max, uflr_max, U, m_u);
+                apply_floors<InjectionFrame::fluid>(G, P, m_p, gam, k, j, i, rhoflr_max, uflr_max, floors, U, m_u);
                 apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors, U, m_u);
                 // P->U for any modified zones
                 Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, j, i, U, m_u, Loci::center);

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -90,7 +90,7 @@ static const std::map<int, std::string> flag_names = {
 };
 }
 
-enum class InjectionFrame{fluid=0, normal, mixed_fluid_normal, mixed_normal_drift, drift};
+enum class InjectionFrame{fluid=0, normal_onedw, normal_kastaun, mixed_fluid_normal, mixed_normal_drift, drift};
 
 /**
  * Struct to hold floor values without cumbersome dictionary/string logistics.

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -34,7 +34,7 @@
 #pragma once
 
 #include "floors.hpp"
-#include "onedw.hpp"
+#include "kastaun.hpp"
 
 /**
  * Device-side functions for applying GRMHD floors
@@ -161,6 +161,7 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
 
 #define FLOOR_ONE_ARGS const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p, const Real& gam, \
                         const int& k, const int& j, const int& i, const Real& rhoflr_max, const Real& uflr_max, \
+                        const Floors::Prescription& floors, \
                         const VariablePack<Real>& U, const VarMap& m_u
 
 /**
@@ -280,12 +281,10 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal>(FLOOR_ONE_ARGS)
     U(m_u.U1, k, j, i)  += T[1];
     U(m_u.U2, k, j, i)  += T[2];
     U(m_u.U3, k, j, i)  += T[3];
-    
-    // Recover primitive variables from conserved versions
-    // Kastaun would need real vals here...
-    const Floors::Prescription floor_tmp = {0}; 
-    return Inverter::u_to_p<Inverter::Type::onedw>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                     floor_tmp, 8, 1e-8);
+
+    // Recover primitive variables from conserved versions.  Use Kastaun with safe parameters so we don't fail often
+    return Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
+                                                     floors, 20, 1e-12);
 }
 
 /**

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -34,7 +34,9 @@
 #pragma once
 
 #include "floors.hpp"
+// For template specializations since inverter needs floors too
 #include "kastaun.hpp"
+#include "onedw.hpp"
 
 /**
  * Device-side functions for applying GRMHD floors
@@ -257,8 +259,40 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::drift>(FLOOR_ONE_ARGS)
     return 0;
 }
 
+// There's a way to avoid code duplication here, but it imposes more template madness
+// on everyone else by templating floors *again*, and we don't need the convex set
 template<>
-KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal>(FLOOR_ONE_ARGS)
+KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_onedw>(FLOOR_ONE_ARGS)
+{
+    // Add the material in the normal observer frame.
+    // 1. Calculate how much material we're adding.
+    // This is an estimate, as it's what we'd have to do in fluid frame
+    const Real rho_add    = m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
+    const Real u_add      = m::max(0., uflr_max - P(m_p.UU, k, j, i));
+    const Real uvec[NVEC] = {0}, B[NVEC] = {0};
+
+    // 2. Calculate the increase in conserved mass/energy corresponding to the new material.
+    Real rho_ut, T[GR_DIM];
+    GRMHD::p_to_u_mhd(G, rho_add, u_add, uvec, B, gam, k, j, i, rho_ut, T, Loci::center);
+
+    // 3. Add new conserved mass/energy to the current "conserved" state.
+    // Also add to the local primitives as a guess
+    P(m_p.RHO, k, j, i) += rho_add;
+    P(m_p.UU, k, j, i)  += u_add;
+    // Add any velocity here
+    U(m_u.RHO, k, j, i) += rho_ut;
+    U(m_u.UU, k, j, i)  += T[0]; // Note that m_u.U1 != m_u.UU + 1 necessarily
+    U(m_u.U1, k, j, i)  += T[1];
+    U(m_u.U2, k, j, i)  += T[2];
+    U(m_u.U3, k, j, i)  += T[3];
+
+    // Recover primitive variables from conserved versions.  Use Kastaun with safe parameters so we don't fail often
+    return Inverter::u_to_p<Inverter::Type::onedw>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
+                                                     floors, 8, 1e-8);
+}
+
+template<>
+KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_kastaun>(FLOOR_ONE_ARGS)
 {
     // Add the material in the normal observer frame.
     // 1. Calculate how much material we're adding.
@@ -284,7 +318,7 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal>(FLOOR_ONE_ARGS)
 
     // Recover primitive variables from conserved versions.  Use Kastaun with safe parameters so we don't fail often
     return Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                     floors, 20, 1e-12);
+                                                     floors, 25, 1e-12);
 }
 
 /**

--- a/kharma/floors/floors_impl.hpp
+++ b/kharma/floors/floors_impl.hpp
@@ -87,7 +87,9 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
                                             floors, U(b), m_u);
                     } else {
-                        pflag_l = apply_floors<InjectionFrame::normal>(G, P(b), m_p, gam, k, j, i,
+                        // TODO should mixed frames respect Kastaun vs 1Dw?
+                        // Since no prior simulations use mixed frames thus requiring back-compat, I said no
+                        pflag_l = apply_floors<InjectionFrame::normal_kastaun>(G, P(b), m_p, gam, k, j, i,
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
                                             floors, U(b), m_u);
                     }
@@ -101,7 +103,7 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
                                             floors, U(b), m_u);
                     } else {
-                        pflag_l = apply_floors<InjectionFrame::normal>(G, P(b), m_p, gam, k, j, i,
+                        pflag_l = apply_floors<InjectionFrame::normal_kastaun>(G, P(b), m_p, gam, k, j, i,
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
                                             floors, U(b), m_u);
                     }

--- a/kharma/floors/floors_impl.hpp
+++ b/kharma/floors/floors_impl.hpp
@@ -85,11 +85,11 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                     if (G.r(k, j, i) > switch_r) {
                         pflag_l = apply_floors<InjectionFrame::fluid>(G, P(b), m_p, gam, k, j, i,
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                                            floors, U(b), m_u);
                     } else {
                         pflag_l = apply_floors<InjectionFrame::normal>(G, P(b), m_p, gam, k, j, i,
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                                            floors, U(b), m_u);
                     }
                 } else if (frame == InjectionFrame::mixed_normal_drift) {
                     FourVectors Dtmp;
@@ -99,16 +99,16 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                     if (mag_switch < switch_beta) {
                         pflag_l = apply_floors<InjectionFrame::drift>(G, P(b), m_p, gam, k, j, i,
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                                            floors, U(b), m_u);
                     } else {
                         pflag_l = apply_floors<InjectionFrame::normal>(G, P(b), m_p, gam, k, j, i,
                                             floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                                            floors, U(b), m_u);
                     }
                 } else {
                     pflag_l = apply_floors<frame>(G, P(b), m_p, gam, k, j, i,
                                         floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                        U(b), m_u);
+                                        floors, U(b), m_u);
                 }
 
                 // Record the pflag if nonzero, that is, if *either* the initial inversion or

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -193,7 +193,7 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         params.Add("fofc_polar_cells", fofc_polar_cells);
         // Usually we use LLF everywhere and this fallback is optional.
         // If we use HLLE outside EH, we need to fall back to LLF/donor-cell inside.
-        const bool use_eh_buffer = pin->GetOrAddReal("fofc", "use_eh_buffer", (flux != "llf"));
+        const bool use_eh_buffer = pin->GetOrAddBoolean("fofc", "use_eh_buffer", (flux != "llf"));
         params.Add("fofc_use_eh_buffer", use_eh_buffer);
         if (use_eh_buffer) {
             const GReal eh_buffer = pin->GetOrAddReal("fofc", "eh_buffer", 0.1);

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -451,8 +451,8 @@ void Flux::AddGeoSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain d
 
 TaskStatus Flux::CheckCtop(MeshData<Real> *md)
 {
-    Reductions::DomainReduction<Reductions::Var::nan_ctop, int>(md, UserHistoryOperation::sum, 0);
-    Reductions::DomainReduction<Reductions::Var::zero_ctop, int>(md, UserHistoryOperation::sum, 1);
+    Reductions::DomainReduction<Reductions::Var::nan_ctop, UserHistoryOperation::sum, int>(md, 0);
+    Reductions::DomainReduction<Reductions::Var::zero_ctop, UserHistoryOperation::sum, int>(md, 1);
     return TaskStatus::complete;
 }
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -453,9 +453,9 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
         // Not sure when I'd do the check to hide latency, it's a step-end sort of deal
         // Just as well it's behind extra_checks 2
         // This may happen while ch0-1 are in flight from floors, but ch2-4 are now reusable
-        Reductions::DomainReduction<Reductions::Var::neg_rho, int>(md, UserHistoryOperation::sum, 2);
-        Reductions::DomainReduction<Reductions::Var::neg_u, int>(md, UserHistoryOperation::sum, 3);
-        Reductions::DomainReduction<Reductions::Var::neg_rhout, int>(md, UserHistoryOperation::sum, 4);
+        Reductions::DomainReduction<Reductions::Var::neg_rho, UserHistoryOperation::sum, int>(md, 2);
+        Reductions::DomainReduction<Reductions::Var::neg_u, UserHistoryOperation::sum, int>(md, 3);
+        Reductions::DomainReduction<Reductions::Var::neg_rhout, UserHistoryOperation::sum, int>(md, 4);
         int nless_rho = Reductions::Check<int>(md, 2);
         int nless_u = Reductions::Check<int>(md, 3);
         int nless_rhout = Reductions::Check<int>(md, 4);

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -516,7 +516,7 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                 parthenon::par_for_inner(member, bi.ks, bi.ke,
                     [&](const int& k) {
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                                floors, 8, 1e-8);
+                                                                floors, 25, 1e-12);
                     }
                 );
             }
@@ -613,7 +613,7 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                     U(m_u.U3, k, jf, i) -= T3_avg;
                     // Recover primitive GRMHD variables from our modified U
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              floors, 8, 1e-8);
+                                                              floors, 25, 1e-12);
                     // Floor them
                     int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Recalculate U on anything we floored

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -42,6 +42,7 @@
 #include "boundaries.hpp"
 #include "current.hpp"
 #include "floors.hpp"
+#include "floors_functions.hpp"
 #include "flux.hpp"
 #include "gr_coordinates.hpp"
 #include "grmhd_functions.hpp"

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -84,17 +84,19 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     }
 
     // Fixup options
-    // Whether hitting a floor in the Kastaun inverter counts as a "failure"
-    // Avoids using the floors applied during the Kastaun solve, since they can be temperamental
-    bool floors_are_failures = pin->GetOrAddBoolean("inverter", "floors_are_failures", false);
-    params.Add("floors_are_failures", floors_are_failures);
-    // Whether the Kastaun inverter returns failure if it has revised rho or u due to floors,
-    // but can't find a new consistent solution to return sensible velocities.
-    bool bad_vels_are_failures = pin->GetOrAddBoolean("inverter", "bad_vels_are_failures", true);
-    params.Add("bad_vels_are_failures", bad_vels_are_failures);
+    if (use_kastaun) {
+        // Whether hitting a floor in the Kastaun inverter counts as a "failure"
+        // Avoids using the floors applied during the Kastaun solve, since they can be temperamental
+        bool floors_are_failures = pin->GetOrAddBoolean("inverter", "floors_are_failures", false);
+        params.Add("floors_are_failures", floors_are_failures);
+        // Whether the Kastaun inverter returns failure if it has revised rho or u due to floors,
+        // but can't find a new consistent solution to return sensible velocities.
+        bool bad_vels_are_failures = pin->GetOrAddBoolean("inverter", "bad_vels_are_failures", true);
+        params.Add("bad_vels_are_failures", bad_vels_are_failures);
+    }
 
     // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun failures are more dire
-    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
+    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", true);
     params.Add("fix_average_neighbors", fix_average_neighbors);
     // Fix by replacing with floors, uvec=0. Usually a fallback for no neighbors,
     // but also used if Kastaun ever fails for some reason (generally negative or near-negative input, so atmo makes sense)

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -62,7 +62,7 @@
 #include "invert_template.hpp"
 
 #include "coordinate_utils.hpp"
-#include "floors_functions.hpp"
+//#include "floors_functions.hpp"
 #include "grmhd_functions.hpp"
 #include "kharma_utils.hpp"
 

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -209,8 +209,9 @@ void KHARMA::FixParameters(ParameterInput *pin, bool is_parthenon_restart)
                     }
                 } else {
                     int nx1 = pin->GetInteger("parthenon/mesh", "nx1");
-                    // Allow overriding Rhor for bondi_viscous problem
-                    const GReal Rhor = pin->GetOrAddReal("coordinates", "Rhor", tmp_coords.get_horizon());
+                    const GReal Rhor = tmp_coords.get_horizon();
+                    // Record event horizon so we don't always have to get it from coordinates
+                    pin->SetReal("coordinates", "r_eh", Rhor);
                     const GReal x1hor = tmp_coords.r_to_native(Rhor);
 
                     // Set Rin such that we have 5 zones completely inside the event horizon

--- a/kharma/prob/resize_restart.cpp
+++ b/kharma/prob/resize_restart.cpp
@@ -266,7 +266,9 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
                 pin->GetInteger("parthenon/mesh", "nx1"),
                 pin->GetInteger("parthenon/mesh", "nx2"),
                 pin->GetInteger("parthenon/mesh", "nx3"),
-                n1tot, n2tot, n3tot);
+                static_cast<unsigned long long>(n1tot),
+                static_cast<unsigned long long>(n2tot),
+                static_cast<unsigned long long>(n3tot));
         }
 
         if (!close_to(pin->GetReal("parthenon/mesh", "x1min"), startx[1]) ||

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -67,15 +67,15 @@ inline T MPIReduce_once(T f, MPI_Op O)
 // Shorter names for the reductions we use here
 Real MaxBsq(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<Reductions::Var::bsq, Real>(md, UserHistoryOperation::max);
+    return Reductions::DomainReduction<Reductions::Var::bsq, UserHistoryOperation::max, Real>(md);
 }
 Real MaxPressure(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<Reductions::Var::gas_pressure, Real>(md, UserHistoryOperation::max);
+    return Reductions::DomainReduction<Reductions::Var::gas_pressure, UserHistoryOperation::max, Real>(md);
 }
 Real MinBeta(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<Reductions::Var::beta, Real>(md, UserHistoryOperation::min);
+    return Reductions::DomainReduction<Reductions::Var::beta, UserHistoryOperation::min, Real>(md);
 }
 
 

--- a/kharma/prob/utils/hdf5_utils.cpp
+++ b/kharma/prob/utils/hdf5_utils.cpp
@@ -397,11 +397,32 @@ int hdf5_read_array(void *data, const char *name, size_t rank,
 
   if(DEBUG) {
     fprintf(stderr,"Reading arr %s:\n", path);
-    fprintf(stderr,"Total file size: %llu %llu %llu %llu\n", fdims[0], fdims[1], fdims[2], fdims[3]);
-    fprintf(stderr,"File start: %llu %llu %llu %llu\n", fstart[0], fstart[1], fstart[2], fstart[3]);
-    fprintf(stderr,"File read size: %llu %llu %llu %llu\n", fcount[0], fcount[1], fcount[2], fcount[3]);
-    fprintf(stderr,"Total memory size: %llu %llu %llu %llu\n", mdims[0], mdims[1], mdims[2], mdims[3]);
-    fprintf(stderr,"Memory start: %llu %llu %llu %llu\n\n", mstart[0], mstart[1], mstart[2], mstart[3]);
+    // Prevent compiler complaining when hsize_t changes on different platforms
+    fprintf(stderr,"Total file size: %llu %llu %llu %llu\n",
+        static_cast<unsigned long long>(fdims[0]),
+        static_cast<unsigned long long>(fdims[1]),
+        static_cast<unsigned long long>(fdims[2]),
+        static_cast<unsigned long long>(fdims[3]));
+    fprintf(stderr,"File start: %llu %llu %llu %llu\n", 
+        static_cast<unsigned long long>(fstart[0]),
+        static_cast<unsigned long long>(fstart[1]),
+        static_cast<unsigned long long>(fstart[2]),
+        static_cast<unsigned long long>(fstart[3]));
+    fprintf(stderr,"File read size: %llu %llu %llu %llu\n",
+        static_cast<unsigned long long>(fcount[0]),
+        static_cast<unsigned long long>(fcount[1]),
+        static_cast<unsigned long long>(fcount[2]),
+        static_cast<unsigned long long>(fcount[3]));
+    fprintf(stderr,"Total memory size: %llu %llu %llu %llu\n",
+        static_cast<unsigned long long>(mdims[0]),
+        static_cast<unsigned long long>(mdims[1]),
+        static_cast<unsigned long long>(mdims[2]),
+        static_cast<unsigned long long>(mdims[3]));
+    fprintf(stderr,"Memory start: %llu %llu %llu %llu\n\n",
+        static_cast<unsigned long long>(mstart[0]),
+        static_cast<unsigned long long>(mstart[1]),
+        static_cast<unsigned long long>(mstart[2]),
+        static_cast<unsigned long long>(mstart[3]));
   }
 
   hid_t dset_id = H5Dopen(file_id, path, H5P_DEFAULT);

--- a/kharma/reductions/reductions.cpp
+++ b/kharma/reductions/reductions.cpp
@@ -67,6 +67,7 @@ std::shared_ptr<KHARMAPackage> Reductions::Initialize(ParameterInput *pin, std::
 
     // Reductions sometimes need global elements of the simulation we don't otherwise keep
     params.Add("domain_r_in", (GReal) pin->GetReal("coordinates", "r_in"));
+    params.Add("domain_r_eh", (GReal) pin->GetReal("coordinates", "r_eh"));
 
     return pkg;
 }

--- a/kharma/reductions/reductions.hpp
+++ b/kharma/reductions/reductions.hpp
@@ -57,43 +57,45 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
  * This should be used for all 2D shell sums not around the EH:
  * Just set equal min/max, 2D slices are detected
  */
-template<Var var, typename T>
-T DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const GReal startx[3], const GReal stopx[3], int channel=-1);
-template<Var var, typename T>
-T DomainReduction(MeshData<Real> *md, UserHistoryOperation op, int channel=-1) {
-    const GReal startx[3] = {std::numeric_limits<GReal>::min(), std::numeric_limits<GReal>::min(), std::numeric_limits<GReal>::min()};
-    const GReal stopx[3] = {std::numeric_limits<GReal>::max(), std::numeric_limits<GReal>::max(), std::numeric_limits<GReal>::max()};
-    return DomainReduction<var, T>(md, op, startx, stopx, channel);
+template<Var var, UserHistoryOperation op, typename T>
+T DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel=-1);
+// Defaults -- use numeric limits to set some indices unrestricted
+static constexpr Real real_max = std::numeric_limits<GReal>::max();
+template<Var var, UserHistoryOperation op, typename T>
+T DomainReduction(MeshData<Real> *md, int channel=-1) {
+    const GReal startx[3] = {-real_max, -real_max, -real_max};
+    const GReal stopx[3] = {real_max, real_max, real_max};
+    return DomainReduction<var, op, T>(md, startx, stopx, channel);
 }
-template<Var var, typename T>
-T ShellReduction(MeshData<Real> *md, UserHistoryOperation op, GReal r, int channel=-1) {
-    const GReal startx[3] = {r, std::numeric_limits<GReal>::min(), std::numeric_limits<GReal>::min()};
-    const GReal stopx[3] = {r, std::numeric_limits<GReal>::max(), std::numeric_limits<GReal>::max()};
-    return DomainReduction<var, T>(md, op, startx, stopx, channel);
+template<Var var, UserHistoryOperation op, typename T>
+T ShellReduction(MeshData<Real> *md, GReal r, int channel=-1) {
+    const GReal startx[3] = {r, -real_max, -real_max};
+    const GReal stopx[3] = {r, real_max, real_max};
+    return DomainReduction<var, op, T>(md, startx, stopx, channel);
 }
 
 // Parthenon doesn't allow taking options, so we define some common reductions
 template<Var var>
 Real SumAt0(MeshData<Real> *md)
 {
-    const GReal r_in = md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in");
-    return Reductions::ShellReduction<var, Real>(md, UserHistoryOperation::sum, r_in);
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
+        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in"));
 }
 template<Var var>
 Real SumAtEH(MeshData<Real> *md)
 {
-    const GReal r_eh = md->GetMeshPointer()->block_list[0]->coords.coords.get_horizon();
-    return Reductions::ShellReduction<var, Real>(md, UserHistoryOperation::sum, r_eh);
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
+        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_eh"));
 }
 template<Var var>
 Real SumAt5M(MeshData<Real> *md)
 {
-    return Reductions::ShellReduction<var, Real>(md, UserHistoryOperation::sum, 5.);
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md, 5.);
 }
 template<Var var>
 Real Total(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<var, Real>(md, UserHistoryOperation::sum);
+    return Reductions::DomainReduction<var, UserHistoryOperation::sum, Real>(md);
 }
 
 /**

--- a/kharma/reductions/reductions_impl.hpp
+++ b/kharma/reductions/reductions_impl.hpp
@@ -118,14 +118,14 @@ T Reductions::CheckOnAll(MeshData<Real> *md, int channel)
     return reducer.val;
 }
 
-#define INSIDE (x[1] > startx1 && x[2] > startx2 && x[3] > startx3) && \
-                (trivial1 ? xin[1] < startx1 : x[1] < stopx1) && \
-                (trivial2 ? xin[2] < startx2 : x[2] < stopx2) && \
-                (trivial3 ? xin[3] < startx3 : x[3] < stopx3)
+#define INSIDE (x[1] >= startx1 && x[2] >= startx2 && x[3] >= startx3) && \
+                (trivial1 ? xin[1] < startx1 : x[1] <= stopx1) && \
+                (trivial2 ? xin[2] < startx2 : x[2] <= stopx2) && \
+                (trivial3 ? xin[3] < startx3 : x[3] <= stopx3)
 
 // TODO additionally template on return type to avoid counting flags with Reals
-template<Reductions::Var var, typename T>
-T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const GReal startx[3], const GReal stopx[3], int channel)
+template<Reductions::Var var, UserHistoryOperation op, typename T>
+T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel)
 {
     Flag("DomainReduction");
     auto pmesh = md->GetMeshPointer();
@@ -149,9 +149,7 @@ T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const
     IndexRange block = IndexRange{0, U.GetDim(5) - 1};
 
     bool trivial_tmp[3] = {false, false, false};
-    VLOOP if(startx[v] == stopx[v]) {
-        trivial_tmp[v] = true;
-    }
+    VLOOP trivial_tmp[v] = (startx[v] == stopx[v]);
 
     // Pull values to pass to device, because passing views is cumbersome
     const bool trivial1 = trivial_tmp[0];
@@ -164,6 +162,7 @@ T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const
     const GReal stopx2 = stopx[1];
     const GReal stopx3 = stopx[2];
 
+    // TODO is 'if constexpr' faster now op is compile-time?
     T result = 0.;
     MPI_Op mop;
     switch(op) {
@@ -230,6 +229,8 @@ T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const
     if (channel >= 0) {
         Start<T>(md, channel, result, mop);
     }
+
+    //fprintf(stderr, "r: %f trivial: %d %d %d result: %f\n", startx1, trivial1, trivial2, trivial3, result);
 
     EndFlag();
     return result;


### PR DESCRIPTION
Switch to the robust inverter for NOF floors, so that when you're using the robust inverter, it's not undermined by the floors using an inverter that just fails instead.

Still uses 1Dw for backward compatibility when that's the inverter specified by the input, but in most runs the floors should now call the new robust inverter and it is now the default.