### PR TITLE
Papercuts before release

### DIFF
--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -298,9 +298,6 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                 default:
                     break;
                 }
-                if (pin->GetInteger("parthenon/mesh", "nx3") != pin->GetInteger("parthenon/meshblock", "nx3") ||
-                    pin->GetInteger("parthenon/mesh", "nx3") == 1)
-                    throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
                 if (pin->GetString("coordinates", "transform") == "fmks" || pin->GetString("coordinates", "transform") == "funky")
                     throw std::runtime_error("Transmitting polar boundary conditions require coordinates symmetric about theta=0!");
                 // TODO also check for wedge simulations x3<2pi
@@ -356,6 +353,19 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
                 throw std::runtime_error("Unknown boundary type: "+btype);
             }
         }
+    }
+
+    // If we've split in the phi direction or we're running in 2D
+    if (pin->GetInteger("parthenon/mesh", "nx3") != pin->GetInteger("parthenon/meshblock", "nx3") ||
+        pin->GetInteger("parthenon/mesh", "nx3") == 1) {
+        if (pin->GetString("boundaries", "inner_x3") == "transmitting" || pin->GetString("boundaries", "outer_x3") == "transmitting")
+            throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
+        if (params.Get<bool>("cancel_U3_inner_x3") || params.Get<bool>("cancel_U3_outer_x3") ||
+            params.Get<bool>("cancel_T3_inner_x3") || params.Get<bool>("cancel_T3_outer_x3"))
+            throw std::runtime_error("Polar cancellations require 3D with one block in x3!");
+        if (packages->AllPackages().count("B_CT") &&
+            (params.Get<bool>("reconnect_B3_inner_x3") || params.Get<bool>("reconnect_B3_outer_x3")))
+            throw std::runtime_error("Polar reconnections require 3D with one block in x3!");
     }
 
     // Callbacks

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -451,8 +451,8 @@ void Flux::AddGeoSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain d
 
 TaskStatus Flux::CheckCtop(MeshData<Real> *md)
 {
-    Reductions::DomainReduction<Reductions::Var::nan_ctop, int>(md, UserHistoryOperation::sum, 0);
-    Reductions::DomainReduction<Reductions::Var::zero_ctop, int>(md, UserHistoryOperation::sum, 1);
+    Reductions::DomainReduction<Reductions::Var::nan_ctop, UserHistoryOperation::sum, int>(md, 0);
+    Reductions::DomainReduction<Reductions::Var::zero_ctop, UserHistoryOperation::sum, int>(md, 1);
     return TaskStatus::complete;
 }
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -453,9 +453,9 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
         // Not sure when I'd do the check to hide latency, it's a step-end sort of deal
         // Just as well it's behind extra_checks 2
         // This may happen while ch0-1 are in flight from floors, but ch2-4 are now reusable
-        Reductions::DomainReduction<Reductions::Var::neg_rho, int>(md, UserHistoryOperation::sum, 2);
-        Reductions::DomainReduction<Reductions::Var::neg_u, int>(md, UserHistoryOperation::sum, 3);
-        Reductions::DomainReduction<Reductions::Var::neg_rhout, int>(md, UserHistoryOperation::sum, 4);
+        Reductions::DomainReduction<Reductions::Var::neg_rho, UserHistoryOperation::sum, int>(md, 2);
+        Reductions::DomainReduction<Reductions::Var::neg_u, UserHistoryOperation::sum, int>(md, 3);
+        Reductions::DomainReduction<Reductions::Var::neg_rhout, UserHistoryOperation::sum, int>(md, 4);
         int nless_rho = Reductions::Check<int>(md, 2);
         int nless_u = Reductions::Check<int>(md, 3);
         int nless_rhout = Reductions::Check<int>(md, 4);

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -84,17 +84,19 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     }
 
     // Fixup options
-    // Whether hitting a floor in the Kastaun inverter counts as a "failure"
-    // Avoids using the floors applied during the Kastaun solve, since they can be temperamental
-    bool floors_are_failures = pin->GetOrAddBoolean("inverter", "floors_are_failures", false);
-    params.Add("floors_are_failures", floors_are_failures);
-    // Whether the Kastaun inverter returns failure if it has revised rho or u due to floors,
-    // but can't find a new consistent solution to return sensible velocities.
-    bool bad_vels_are_failures = pin->GetOrAddBoolean("inverter", "bad_vels_are_failures", true);
-    params.Add("bad_vels_are_failures", bad_vels_are_failures);
+    if (use_kastaun) {
+        // Whether hitting a floor in the Kastaun inverter counts as a "failure"
+        // Avoids using the floors applied during the Kastaun solve, since they can be temperamental
+        bool floors_are_failures = pin->GetOrAddBoolean("inverter", "floors_are_failures", false);
+        params.Add("floors_are_failures", floors_are_failures);
+        // Whether the Kastaun inverter returns failure if it has revised rho or u due to floors,
+        // but can't find a new consistent solution to return sensible velocities.
+        bool bad_vels_are_failures = pin->GetOrAddBoolean("inverter", "bad_vels_are_failures", true);
+        params.Add("bad_vels_are_failures", bad_vels_are_failures);
+    }
 
     // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun failures are more dire
-    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
+    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", true);
     params.Add("fix_average_neighbors", fix_average_neighbors);
     // Fix by replacing with floors, uvec=0. Usually a fallback for no neighbors,
     // but also used if Kastaun ever fails for some reason (generally negative or near-negative input, so atmo makes sense)

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -209,8 +209,9 @@ void KHARMA::FixParameters(ParameterInput *pin, bool is_parthenon_restart)
                     }
                 } else {
                     int nx1 = pin->GetInteger("parthenon/mesh", "nx1");
-                    // Allow overriding Rhor for bondi_viscous problem
-                    const GReal Rhor = pin->GetOrAddReal("coordinates", "Rhor", tmp_coords.get_horizon());
+                    const GReal Rhor = tmp_coords.get_horizon();
+                    // Record event horizon so we don't always have to get it from coordinates
+                    pin->SetReal("coordinates", "r_eh", Rhor);
                     const GReal x1hor = tmp_coords.r_to_native(Rhor);
 
                     // Set Rin such that we have 5 zones completely inside the event horizon

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -67,15 +67,15 @@ inline T MPIReduce_once(T f, MPI_Op O)
 // Shorter names for the reductions we use here
 Real MaxBsq(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<Reductions::Var::bsq, Real>(md, UserHistoryOperation::max);
+    return Reductions::DomainReduction<Reductions::Var::bsq, UserHistoryOperation::max, Real>(md);
 }
 Real MaxPressure(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<Reductions::Var::gas_pressure, Real>(md, UserHistoryOperation::max);
+    return Reductions::DomainReduction<Reductions::Var::gas_pressure, UserHistoryOperation::max, Real>(md);
 }
 Real MinBeta(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<Reductions::Var::beta, Real>(md, UserHistoryOperation::min);
+    return Reductions::DomainReduction<Reductions::Var::beta, UserHistoryOperation::min, Real>(md);
 }
 
 

--- a/kharma/reductions/reductions.cpp
+++ b/kharma/reductions/reductions.cpp
@@ -67,6 +67,7 @@ std::shared_ptr<KHARMAPackage> Reductions::Initialize(ParameterInput *pin, std::
 
     // Reductions sometimes need global elements of the simulation we don't otherwise keep
     params.Add("domain_r_in", (GReal) pin->GetReal("coordinates", "r_in"));
+    params.Add("domain_r_eh", (GReal) pin->GetReal("coordinates", "r_eh"));
 
     return pkg;
 }

--- a/kharma/reductions/reductions.hpp
+++ b/kharma/reductions/reductions.hpp
@@ -57,43 +57,45 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
  * This should be used for all 2D shell sums not around the EH:
  * Just set equal min/max, 2D slices are detected
  */
-template<Var var, typename T>
-T DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const GReal startx[3], const GReal stopx[3], int channel=-1);
-template<Var var, typename T>
-T DomainReduction(MeshData<Real> *md, UserHistoryOperation op, int channel=-1) {
-    const GReal startx[3] = {std::numeric_limits<GReal>::min(), std::numeric_limits<GReal>::min(), std::numeric_limits<GReal>::min()};
-    const GReal stopx[3] = {std::numeric_limits<GReal>::max(), std::numeric_limits<GReal>::max(), std::numeric_limits<GReal>::max()};
-    return DomainReduction<var, T>(md, op, startx, stopx, channel);
+template<Var var, UserHistoryOperation op, typename T>
+T DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel=-1);
+// Defaults -- use numeric limits to set some indices unrestricted
+static constexpr Real real_max = std::numeric_limits<GReal>::max();
+template<Var var, UserHistoryOperation op, typename T>
+T DomainReduction(MeshData<Real> *md, int channel=-1) {
+    const GReal startx[3] = {-real_max, -real_max, -real_max};
+    const GReal stopx[3] = {real_max, real_max, real_max};
+    return DomainReduction<var, op, T>(md, startx, stopx, channel);
 }
-template<Var var, typename T>
-T ShellReduction(MeshData<Real> *md, UserHistoryOperation op, GReal r, int channel=-1) {
-    const GReal startx[3] = {r, std::numeric_limits<GReal>::min(), std::numeric_limits<GReal>::min()};
-    const GReal stopx[3] = {r, std::numeric_limits<GReal>::max(), std::numeric_limits<GReal>::max()};
-    return DomainReduction<var, T>(md, op, startx, stopx, channel);
+template<Var var, UserHistoryOperation op, typename T>
+T ShellReduction(MeshData<Real> *md, GReal r, int channel=-1) {
+    const GReal startx[3] = {r, -real_max, -real_max};
+    const GReal stopx[3] = {r, real_max, real_max};
+    return DomainReduction<var, op, T>(md, startx, stopx, channel);
 }
 
 // Parthenon doesn't allow taking options, so we define some common reductions
 template<Var var>
 Real SumAt0(MeshData<Real> *md)
 {
-    const GReal r_in = md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in");
-    return Reductions::ShellReduction<var, Real>(md, UserHistoryOperation::sum, r_in);
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
+        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in"));
 }
 template<Var var>
 Real SumAtEH(MeshData<Real> *md)
 {
-    const GReal r_eh = md->GetMeshPointer()->block_list[0]->coords.coords.get_horizon();
-    return Reductions::ShellReduction<var, Real>(md, UserHistoryOperation::sum, r_eh);
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
+        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_eh"));
 }
 template<Var var>
 Real SumAt5M(MeshData<Real> *md)
 {
-    return Reductions::ShellReduction<var, Real>(md, UserHistoryOperation::sum, 5.);
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md, 5.);
 }
 template<Var var>
 Real Total(MeshData<Real> *md)
 {
-    return Reductions::DomainReduction<var, Real>(md, UserHistoryOperation::sum);
+    return Reductions::DomainReduction<var, UserHistoryOperation::sum, Real>(md);
 }
 
 /**

--- a/kharma/reductions/reductions_impl.hpp
+++ b/kharma/reductions/reductions_impl.hpp
@@ -118,14 +118,14 @@ T Reductions::CheckOnAll(MeshData<Real> *md, int channel)
     return reducer.val;
 }
 
-#define INSIDE (x[1] > startx1 && x[2] > startx2 && x[3] > startx3) && \
-                (trivial1 ? xin[1] < startx1 : x[1] < stopx1) && \
-                (trivial2 ? xin[2] < startx2 : x[2] < stopx2) && \
-                (trivial3 ? xin[3] < startx3 : x[3] < stopx3)
+#define INSIDE (x[1] >= startx1 && x[2] >= startx2 && x[3] >= startx3) && \
+                (trivial1 ? xin[1] < startx1 : x[1] <= stopx1) && \
+                (trivial2 ? xin[2] < startx2 : x[2] <= stopx2) && \
+                (trivial3 ? xin[3] < startx3 : x[3] <= stopx3)
 
 // TODO additionally template on return type to avoid counting flags with Reals
-template<Reductions::Var var, typename T>
-T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const GReal startx[3], const GReal stopx[3], int channel)
+template<Reductions::Var var, UserHistoryOperation op, typename T>
+T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel)
 {
     Flag("DomainReduction");
     auto pmesh = md->GetMeshPointer();
@@ -149,9 +149,7 @@ T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const
     IndexRange block = IndexRange{0, U.GetDim(5) - 1};
 
     bool trivial_tmp[3] = {false, false, false};
-    VLOOP if(startx[v] == stopx[v]) {
-        trivial_tmp[v] = true;
-    }
+    VLOOP trivial_tmp[v] = (startx[v] == stopx[v]);
 
     // Pull values to pass to device, because passing views is cumbersome
     const bool trivial1 = trivial_tmp[0];
@@ -164,6 +162,7 @@ T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const
     const GReal stopx2 = stopx[1];
     const GReal stopx3 = stopx[2];
 
+    // TODO is 'if constexpr' faster now op is compile-time?
     T result = 0.;
     MPI_Op mop;
     switch(op) {
@@ -230,6 +229,8 @@ T Reductions::DomainReduction(MeshData<Real> *md, UserHistoryOperation op, const
     if (channel >= 0) {
         Start<T>(md, channel, result, mop);
     }
+
+    //fprintf(stderr, "r: %f trivial: %d %d %d result: %f\n", startx1, trivial1, trivial2, trivial3, result);
 
     EndFlag();
     return result;


### PR DESCRIPTION
This PR fixes a number of small bugs lying around -- yelling about unsupported configurations, and turning on averaging even for Kastaun floors, which has proven useful for really difficult integrations.

Notably it finally properly fixes #130, which was actually a bug in planar reductions *exactly* at zone centers.

Probably will modify some default parameters here before merging, after getting the NOF/Kastaun floors right.