### PR TITLE
Added machine profile for macos compilation

### DIFF
--- a/machines/macos.sh
+++ b/machines/macos.sh
@@ -1,0 +1,6 @@
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    BREW_LLVM="$(brew --prefix llvm)"
+    export LDFLAGS="$LDFLAGS -L$BREW_LLVM/lib/c++"
+    C_NATIVE="$BREW_LLVM/bin/clang"
+    CXX_NATIVE="$BREW_LLVM/bin/clang++"
+fi


### PR DESCRIPTION
Added a machines profile for homebrew clang on macos.

Tested by running pars/tests/orszag_tang.par

Apple M4 Pro
MacOS Tahoe Version 26.2
Homebrew 5.0.10
Homebrew clang version 21.1.6
Target: arm64-apple-darwin25.2.0
Thread model: posix

`brew list --version`
```
brotli 1.2.0
c-ares 1.34.6
ca-certificates 2025-11-04 2025-12-02
cmake 4.2.0
gcc 15.2.0
gettext 0.26_1
gmp 6.3.0
gnu-sed 4.9
hdf5 1.14.6
htop 3.4.1
icu4c@78 78.2
isl 0.27
libaec 1.1.4
libidn2 2.3.8
libmpc 1.3.1
libnghttp2 1.68.0
libnghttp3 1.14.0
libngtcp2 1.19.0
libsodium 1.0.20
libunistring 1.4.1
libuv 1.51.0
libyaml 0.2.5
llvm 21.1.6
lua 5.4.8
lz4 1.10.0
mpdecimal 4.0.1
mpfr 4.2.2
ncurses 6.5
node 25.2.1
openssl@3 3.6.0
pkgconf 2.5.1
python@3.14 3.14.0_1
readline 8.3.3 8.3.1
ruby 3.4.7
simdjson 4.2.4
sqlite 3.51.2 3.51.0
uvwasi 0.0.23
vim 9.1.1900
watch 4.0.5
wget 1.25.0
xz 5.8.1
z3 4.15.4
zlib 1.3.1
zstd 1.5.7
```