### PR TITLE
Fixed non initialized variable causing NaNs on corrected connection coefficients. 

### DIFF
--- a/kharma/coordinates/gr_coordinates.cpp
+++ b/kharma/coordinates/gr_coordinates.cpp
@@ -225,7 +225,8 @@ void init_GRCoordinates(GRCoordinates& G) {
 
                         // Then sum the coefficients and record nonzero ones for modification
                         GReal test_sum = 0;
-                        GReal sum_portions, portions[GR_DIM] = {0};
+                        GReal sum_portions = 0;
+                        GReal portions[GR_DIM] = {0};
                         DLOOP1 {
                             test_sum += gdet_conn_local(j, i, mu, mu, lam);
                             portions[mu] = m::abs(gdet_conn_local(j, i, mu, mu, lam));


### PR DESCRIPTION
A non-initialized variable was causing NaNs in the corrected connection coefficients when enforcing that the derivative of the metric determinant equals the connection coefficients.

This issue only affects runs where
`<coordinates> correct_connections = on`.

The error was catastrophic, causing the disk to evaporate, and would be clearly noticeable in the affected simulations.