### PR TITLE
Formatpocalypse

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,288 @@
+---
+BasedOnStyle: Mozilla
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: None
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: true
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: None
+BreakArrays: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+ColumnLimit: 90
+CommentPragmas: "^ IWYU pragma:"
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: ^"(llvm|llvm-c|clang|clang-c)/
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: ^(<|"(gtest|gmock|isl|json)/)
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: .*
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: (Test)?$
+IncludeIsMainSourceRegex: ""
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: true
+  AtStartOfFile: true
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PPIndentWidth: -1
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes: CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 4
+TableGenBreakInsideDAGArg: DontBreak
+UseTab: Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+  - VLOOP
+  - VLOOP2
+  - VLOOP3
+  - DLOOP1
+  - DLOOP2
+  - DLOOP3
+  - DLOOP4
+  - PLOOP
+Macros:
+  - KOKKOS_LAMBDA(a)=[](a)
+  - KOKKOS_LAMBDA(a, b)=[](a, b)
+  - KOKKOS_LAMBDA(a, b, c)=[](a, b, c)
+  - KOKKOS_LAMBDA(a, b, c, d)=[](a, b, c, d)
+  - KOKKOS_LAMBDA(a, b, c, d, e)=[](a, b, c, d, e)
+  - KOKKOS_LAMBDA(a, b, c, d, e, f)=[](a, b, c, d, e, f)
+  - KOKKOS_LAMBDA(a, b, c, d, e, f, g)=[](a, b, c, d, e, f, g)

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,28 @@
+name: Check Formatting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+    formatting:
+      name: Check Formatting
+      runs-on: ubuntu-latest
+
+      steps:      
+        - name: Checkout code
+          uses: actions/checkout@v2
+        - name: Set system to non-interactive mode
+          run: export DEBIAN_FRONTEND=noninteractive
+        - name: install dependencies
+          run: |
+            sudo apt-get install -y --force-yes -qq git
+        - name: Install pip, clang-format
+          uses: BSFishy/pip-action@v1
+          with:
+            packages: |
+               clang-format==19.1.7
+        - name: check formatting
+          run: find . -regex '.*\.\(cpp\|hpp\)' | xargs clang-format -style=file -i && git diff --exit-code --ignore-submodules

--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -51,10 +51,11 @@ using namespace parthenon;
 namespace B_CD
 {
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("B_CD");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Constraint damping options
     // Factor "lambda" in Dedner TODO tune
@@ -71,22 +72,26 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // B field as usual
     // TODO allow for implicit B here
-    Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Independent, Metadata::FillGhost,
-                 Metadata::Restart, Metadata::Conserved, Metadata::Conserved,
-                 Metadata::WithFluxes, Metadata::Vector}, s_vector);
+    Metadata m =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Independent,
+                     Metadata::FillGhost, Metadata::Restart, Metadata::Conserved,
+                     Metadata::Conserved, Metadata::WithFluxes, Metadata::Vector},
+            s_vector);
     pkg->AddField("cons.B", m);
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
-                  Metadata::Restart, Metadata::GetUserFlag("Primitive"), Metadata::Vector}, s_vector);
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::Restart,
+                     Metadata::GetUserFlag("Primitive"), Metadata::Vector},
+        s_vector);
     pkg->AddField("prims.B", m);
 
-    // Constraint damping scalar field psi.  Prim and cons forms correspond to B field forms,
-    // i.e. differ by a factor of gdet.  This is apparently marginally more stable in some
-    // circumstances.
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Independent, Metadata::FillGhost,
-                  Metadata::Restart, Metadata::Conserved, Metadata::Conserved, Metadata::WithFluxes});
+    // Constraint damping scalar field psi.  Prim and cons forms correspond to B field
+    // forms, i.e. differ by a factor of gdet.  This is apparently marginally more stable
+    // in some circumstances.
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Independent,
+        Metadata::FillGhost, Metadata::Restart, Metadata::Conserved, Metadata::Conserved,
+        Metadata::WithFluxes});
     pkg->AddField("cons.psi_cd", m);
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
-                  Metadata::Restart, Metadata::GetUserFlag("Primitive")});
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::Restart,
+        Metadata::GetUserFlag("Primitive")});
     pkg->AddField("prims.psi_cd", m);
 
     // We only update the divB field for output
@@ -102,20 +107,24 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // List (vector) of HistoryOutputVar that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
-    // The definition of MaxDivB we care about actually changes per-transport. Use our function.
-    hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::max, B_CD::MaxDivB, "MaxDivB"));
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    // The definition of MaxDivB we care about actually changes per-transport. Use our
+    // function.
+    hst_vars.emplace_back(
+        parthenon::HistoryOutputVar(UserHistoryOperation::max, B_CD::MaxDivB, "MaxDivB"));
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     // Throw down here, like this, to avoid inaccessible code warnings
     if (1) {
-        throw std::runtime_error("Constraint-damping transport is not functional with modern B field initialization!");
+        throw std::runtime_error("Constraint-damping transport is not functional with "
+                                 "modern B field initialization!");
     } else {
         return pkg;
     }
 }
 
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -131,17 +140,18 @@ void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     IndexRange jb = bounds.GetBoundsJ(domain);
     IndexRange kb = bounds.GetBoundsK(domain);
     pmb->par_for("UtoP_B_CD", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             // Update the primitive B-fields
             Real gdet = G.gdet(Loci::center, j, i);
-            VLOOP B_P(v, k, j, i) = B_U(v, k, j, i) / gdet;
+            VLOOP
+                B_P(v, k, j, i) = B_U(v, k, j, i) / gdet;
             // Update psi as well
             psi_P(k, j, i) = psi_U(k, j, i) / gdet;
-        }
-    );
+        });
 }
 
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -162,49 +172,72 @@ TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain doma
     const IndexRange ib = md->GetBoundsI(domain);
     const IndexRange jb = md->GetBoundsJ(domain);
     const IndexRange kb = md->GetBoundsK(domain);
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     pmb0->par_for("AddSource_B_CD", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = B_U.GetCoords(b);
             // Add a source term to B based on psi
             GReal alpha_c = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
             GReal gdet_c = G.gdet(Loci::center, j, i);
 
-            double divB = ((B_U(b).flux(X1DIR, V1, k, j, i+1) - B_U(b).flux(X1DIR, V1, k, j, i)) / G.Dxc<1>(i) +
-                           (B_U(b).flux(X2DIR, V2, k, j+1, i) - B_U(b).flux(X2DIR, V2, k, j, i)) / G.Dxc<2>(j));
-            if (ndim > 2) divB += (B_U(b).flux(X3DIR, V3, k+1, j, i) - B_U(b).flux(X3DIR, V3, k, j, i)) / G.Dxc<3>(k);
+            double divB =
+                ((B_U(b).flux(X1DIR, V1, k, j, i + 1) - B_U(b).flux(X1DIR, V1, k, j, i)) /
+                        G.Dxc<1>(i) +
+                    (B_U(b).flux(X2DIR, V2, k, j + 1, i) -
+                        B_U(b).flux(X2DIR, V2, k, j, i)) /
+                        G.Dxc<2>(j));
+            if (ndim > 2)
+                divB += (B_U(b).flux(X3DIR, V3, k + 1, j, i) -
+                            B_U(b).flux(X3DIR, V3, k, j, i)) /
+                        G.Dxc<3>(k);
             // TODO this needs to include the time derivative right?
 
             VLOOP {
                 // First term: gradient of psi
-                B_DU(b, v, k, j, i) += alpha_c * G.gcon(Loci::center, j, i, v+1, 1) *
-                                       (psi_U(b).flux(X1DIR, 0, k, j, i+1) - psi_U(b).flux(X1DIR, 0, k, j, i)) / G.Dxc<1>(i) +
-                                       alpha_c * G.gcon(Loci::center, j, i, v+1, 2) *
-                                       (psi_U(b).flux(X2DIR, 0, k, j+1, i) - psi_U(b).flux(X2DIR, 0, k, j, i)) / G.Dxc<2>(j);
+                B_DU(b, v, k, j, i) += alpha_c * G.gcon(Loci::center, j, i, v + 1, 1) *
+                                           (psi_U(b).flux(X1DIR, 0, k, j, i + 1) -
+                                               psi_U(b).flux(X1DIR, 0, k, j, i)) /
+                                           G.Dxc<1>(i) +
+                                       alpha_c * G.gcon(Loci::center, j, i, v + 1, 2) *
+                                           (psi_U(b).flux(X2DIR, 0, k, j + 1, i) -
+                                               psi_U(b).flux(X2DIR, 0, k, j, i)) /
+                                           G.Dxc<2>(j);
                 if (ndim > 2)
-                    B_DU(b, v, k, j, i) += alpha_c * G.gcon(Loci::center, j, i, v+1, 3) *
-                                        (psi_U(b).flux(X3DIR, 0, k+1, j, i) - psi_U(b).flux(X3DIR, 0, k, j, i)) / G.Dxc<3>(k);
+                    B_DU(b, v, k, j, i) += alpha_c *
+                                           G.gcon(Loci::center, j, i, v + 1, 3) *
+                                           (psi_U(b).flux(X3DIR, 0, k + 1, j, i) -
+                                               psi_U(b).flux(X3DIR, 0, k, j, i)) /
+                                           G.Dxc<3>(k);
 
                 // Second term: beta^i divB
-                B_DU(b, v, k, j, i) += G.gcon(Loci::center, j, i, 0, v+1) * alpha_c * alpha_c * divB;
+                B_DU(b, v, k, j, i) +=
+                    G.gcon(Loci::center, j, i, 0, v + 1) * alpha_c * alpha_c * divB;
             }
             // Update psi using the analytic solution for the source term
-            GReal dalpha1 = ( (1. / m::sqrt(-G.gcon(Loci::face1, j, i+1, 0, 0))) / G.gdet(Loci::face1, j, i+1)
-                            - (1. / m::sqrt(-G.gcon(Loci::face1, j, i, 0, 0))) / G.gdet(Loci::face1, j, i)) / G.Dxc<1>(i);
-            GReal dalpha2 = ( (1. / m::sqrt(-G.gcon(Loci::face2, j+1, i, 0, 0))) / G.gdet(Loci::face2, j+1, i)
-                            - (1. / m::sqrt(-G.gcon(Loci::face2, j, i, 0, 0))) / G.gdet(Loci::face2, j, i)) / G.Dxc<2>(i);
+            GReal dalpha1 = ((1. / m::sqrt(-G.gcon(Loci::face1, j, i + 1, 0, 0))) /
+                                    G.gdet(Loci::face1, j, i + 1) -
+                                (1. / m::sqrt(-G.gcon(Loci::face1, j, i, 0, 0))) /
+                                    G.gdet(Loci::face1, j, i)) /
+                            G.Dxc<1>(i);
+            GReal dalpha2 = ((1. / m::sqrt(-G.gcon(Loci::face2, j + 1, i, 0, 0))) /
+                                    G.gdet(Loci::face2, j + 1, i) -
+                                (1. / m::sqrt(-G.gcon(Loci::face2, j, i, 0, 0))) /
+                                    G.gdet(Loci::face2, j, i)) /
+                            G.Dxc<2>(i);
             // There is not dalpha3, the coordinate system is symmetric along x3
-            psi_DU(b, 0, k, j, i) += B_U(b, V1, k, j, i) * dalpha1 + B_U(b, V2, k, j, i) * dalpha2 - alpha_c * lambda * psi_U(b, 0, k, j, i);
-        }
-    );
+            psi_DU(b, 0, k, j, i) += B_U(b, V1, k, j, i) * dalpha1 +
+                                     B_U(b, V2, k, j, i) * dalpha2 -
+                                     alpha_c * lambda * psi_U(b, 0, k, j, i);
+        });
 
     return TaskStatus::complete;
 }
 
 // TODO figure out what divB from psi looks like?
 
-Real MaxDivB(MeshData<Real> *md)
+Real MaxDivB(MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -216,7 +249,7 @@ Real MaxDivB(MeshData<Real> *md)
     const IndexRange ib = md->GetBoundsI(IndexDomain::interior);
     const IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
     const IndexRange kb = md->GetBoundsK(IndexDomain::interior);
-    const IndexRange block = IndexRange{0, B.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B.GetDim(5) - 1};
     // We only care about interior cells, and our stencil extends 1 zone *right*
     const IndexRange il = IndexRange{ib.s, ib.e - 1};
     const IndexRange jl = IndexRange{jb.s, jb.e - 1};
@@ -224,27 +257,36 @@ Real MaxDivB(MeshData<Real> *md)
 
     Real bsq_max;
     Kokkos::Max<Real> bsq_max_reducer(bsq_max);
-    pmb0->par_reduce("B_field_bsqmax", block.s, block.e, kl.s, kl.e, jl.s, jl.e, il.s, il.e,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, double &local_result) {
+    pmb0->par_reduce(
+        "B_field_bsqmax", block.s, block.e, kl.s, kl.e, jl.s, jl.e, il.s, il.e,
+        KOKKOS_LAMBDA(
+            const int& b, const int& k, const int& j, const int& i, double& local_result)
+        {
             const auto& G = B.GetCoords(b);
-            double divb_local = ((B(b).flux(1, V1, k, j, i+1) - B(b).flux(1, V1, k, j, i)) / G.Dxc<1>(i)+
-                                 (B(b).flux(2, V2, k, j+1, i) - B(b).flux(2, V2, k, j, i)) / G.Dxc<2>(j));
-            if (ndim > 2) divb_local += (B(b).flux(3, V3, k+1, j, i) - B(b).flux(3, V3, k, j, i)) / G.Dxc<3>(k);
+            double divb_local =
+                ((B(b).flux(1, V1, k, j, i + 1) - B(b).flux(1, V1, k, j, i)) /
+                        G.Dxc<1>(i) +
+                    (B(b).flux(2, V2, k, j + 1, i) - B(b).flux(2, V2, k, j, i)) /
+                        G.Dxc<2>(j));
+            if (ndim > 2)
+                divb_local +=
+                    (B(b).flux(3, V3, k + 1, j, i) - B(b).flux(3, V3, k, j, i)) /
+                    G.Dxc<3>(k);
 
-            if(divb_local > local_result) local_result = divb_local;
-        }
-    , bsq_max_reducer);
+            if (divb_local > local_result) local_result = divb_local;
+        },
+        bsq_max_reducer);
     return bsq_max;
 }
 
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     // TODO. Unify w/other B?
 
     return TaskStatus::complete;
 }
 
-void FillOutput(MeshBlock *pmb, ParameterInput *pin)
+void FillOutput(MeshBlock* pmb, ParameterInput* pin)
 {
     auto rc = pmb->meshblock_data.Get("base").get();
     IndexDomain domain = IndexDomain::interior;
@@ -271,17 +313,20 @@ void FillOutput(MeshBlock *pmb, ParameterInput *pin)
     const auto& G = pmb->coords;
 
     pmb->par_for("B_field_bsqmax", kl.s, kl.e, jl.s, jl.e, il.s, il.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-            // double divb_local = ((F1(V1, k, j, i+1) - F1(V1, k, j, i)) / G.Dxc<1>(i) +
-            //                      (F2(V2, k, j+1, i) - F2(V2, k, j, i)) / G.Dxc<2>(j));
-            // if (ndim > 2) divb_local += (F3(V3, k+1, j, i) - F3(V3, k, j, i)) / G.Dxc<3>(k);
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
+            // double divb_local = ((F1(V1, k, j, i+1) - F1(V1, k, j, i)) /
+            // G.Dxc<1>(i) +
+            //                      (F2(V2, k, j+1, i) - F2(V2, k, j, i)) /
+            //                      G.Dxc<2>(j));
+            // if (ndim > 2) divb_local += (F3(V3, k+1, j, i) - F3(V3, k, j, i))
+            // / G.Dxc<3>(k);
 
             divB(k, j, i) = 0.;
-        }
-    );
+        });
 }
 
-void UpdateCtopMax(Mesh *pmesh, ParameterInput *pin, const SimTime &tm)
+void UpdateCtopMax(Mesh* pmesh, ParameterInput* pin, const SimTime& tm)
 {
     // TODO use new Reductions stuff for this
     // Reduce and record the maximum sound speed on the grid, to propagate

--- a/kharma/b_cd/b_cd.hpp
+++ b/kharma/b_cd/b_cd.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_cd.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -47,59 +47,64 @@ using namespace parthenon;
  * The code is here so that we can ensure it keeps compiling,
  * which should make it easier to reintroduce if we want to later
  *
- * This physics package implements B field transport with Constraint-Damping (Dedner et al 2002)
+ * This physics package implements B field transport with Constraint-Damping (Dedner et al
+ * 2002)
  *
- * This requires only the values at cell centers, and preserves a cell-centered divergence representation
- * 
+ * This requires only the values at cell centers, and preserves a cell-centered divergence
+ * representation
+ *
  * This implementation includes conversion from "primitive" to "conserved" B and back,
  * i.e. between field strength and flux via multiplying by gdet.
  */
-namespace B_CD {
+namespace B_CD
+{
 /**
  * Declare fields, initialize (few) parameters
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Get the primitive variables, which in Parthenon's nomenclature are "derived".
  * Also applies floors to the calculated primitives, and fixes up any inversion errors.
- * 
- * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
+ *
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost
+ * zones.
  *
  * input: Conserved B = sqrt(-gdet) * B^i
  * output: Primitive B = B^i
  */
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse=false);
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse = false);
 
 /**
  * Add the source term to dUdt, before it is applied to U
  */
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 
 /**
  * Take a maximum over the divB array, which is updated every step
- * 
+ *
  * Used as a Parthenon History function, so must take exactly the
  * listed arguments
  */
-Real MaxDivB(MeshData<Real> *md);
+Real MaxDivB(MeshData<Real>* md);
 
 /**
  * Find the maximum wavespeed across the whole grid, to use in propagating
  * the phi field.
  */
-void UpdateCtopMax(Mesh *pmesh, ParameterInput *pin, const SimTime &tm);
+void UpdateCtopMax(Mesh* pmesh, ParameterInput* pin, const SimTime& tm);
 
 /**
  * Diagnostics printed/computed after each step
  * Currently nothing, divB is calculated in fluxes.cpp
  */
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *rc);
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* rc);
 
 /**
  * Fill fields which are calculated only for output to file
  * Currently nothing, soon the corner-centered divB values
  */
-void FillOutput(MeshBlock *pmb, ParameterInput *pin);
+void FillOutput(MeshBlock* pmb, ParameterInput* pin);
 
 }

--- a/kharma/b_cleanup/b_cleanup.cpp
+++ b/kharma/b_cleanup/b_cleanup.cpp
@@ -34,16 +34,15 @@
 #include "b_cleanup.hpp"
 
 // For a bunch of utility functions
-#include "b_flux_ct.hpp"
 #include "b_ct.hpp"
+#include "b_flux_ct.hpp"
 
 #include "boundaries.hpp"
 #include "decs.hpp"
 #include "domain.hpp"
-#include "kharma.hpp"
-#include "kharma_driver.hpp"
 #include "grmhd.hpp"
 #include "kharma.hpp"
+#include "kharma_driver.hpp"
 #include "types.hpp"
 
 #if DISABLE_CLEANUP
@@ -51,18 +50,18 @@
 // The package should never be loaded if there is not a global solve to be done.
 // Therefore we yell at load time rather than waiting for the first solve
 // But we still need some stubs to compile
-std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
-    throw std::runtime_error("KHARMA was compiled without global solvers!  Cannot clean B Field!");
+    throw std::runtime_error(
+        "KHARMA was compiled without global solvers!  Cannot clean B Field!");
 }
 TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
 {
-    throw std::runtime_error("KHARMA was compiled without global solvers!  Cannot clean B Field!");
+    throw std::runtime_error(
+        "KHARMA was compiled without global solvers!  Cannot clean B Field!");
 }
-bool B_Cleanup::CleanupThisStep(Mesh* pmesh, int nstep)
-{
-    return false;
-}
+bool B_Cleanup::CleanupThisStep(Mesh* pmesh, int nstep) { return false; }
 
 #else
 
@@ -73,10 +72,11 @@ bool B_Cleanup::CleanupThisStep(Mesh* pmesh, int nstep)
 using namespace parthenon;
 using namespace parthenon::solvers;
 
-std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("B_Cleanup");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // If face centered fields...
     const bool use_b_ct = packages->AllPackages().count("B_CT");
@@ -92,13 +92,16 @@ std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::s
     params.Add("max_iterations", max_iterations);
     int check_interval = pin->GetOrAddInteger("b_cleanup", "check_interval", 20);
     params.Add("check_interval", check_interval);
-    bool fail_without_convergence = pin->GetOrAddBoolean("b_cleanup", "fail_without_convergence", true);
+    bool fail_without_convergence =
+        pin->GetOrAddBoolean("b_cleanup", "fail_without_convergence", true);
     params.Add("fail_without_convergence", fail_without_convergence);
-    bool warn_without_convergence = pin->GetOrAddBoolean("b_cleanup", "warn_without_convergence", false);
+    bool warn_without_convergence =
+        pin->GetOrAddBoolean("b_cleanup", "warn_without_convergence", false);
     params.Add("warn_without_convergence", warn_without_convergence);
     bool always_solve = pin->GetOrAddBoolean("b_cleanup", "always_solve", false);
     params.Add("always_solve", always_solve);
-    bool use_normalized_divb = pin->GetOrAddBoolean("b_cleanup", "use_normalized_divb", false);
+    bool use_normalized_divb =
+        pin->GetOrAddBoolean("b_cleanup", "use_normalized_divb", false);
     params.Add("use_normalized_divb", use_normalized_divb);
 
     // Initialize the solver
@@ -119,7 +122,7 @@ std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::s
     // The flag "StartupOnly" marks solver variables not to be sync'd later,
     // even though they're also marked FillGhost
     BiCGStabSolver<int> solver(pkg.get(), rel_tolerance, abs_tolerance,
-                                SparseMatrixAccessor(), {}, {Metadata::GetUserFlag("StartupOnly")});
+        SparseMatrixAccessor(), {}, {Metadata::GetUserFlag("StartupOnly")});
     // Set callback
     if (use_b_ct) {
         solver.user_MatVec = B_Cleanup::CenterLaplacian;
@@ -131,17 +134,17 @@ std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::s
 
     // FIELDS
     std::vector<int> s_vector({NVEC});
-    std::vector<MetadataFlag> cleanup_flags({Metadata::Real, Metadata::Derived, Metadata::OneCopy,
-                                             Metadata::GetUserFlag("StartupOnly")});
+    std::vector<MetadataFlag> cleanup_flags({Metadata::Real, Metadata::Derived,
+        Metadata::OneCopy, Metadata::GetUserFlag("StartupOnly")});
     if (use_b_ct) {
         auto cleanup_flags_cell = cleanup_flags;
         cleanup_flags_cell.push_back(Metadata::FillGhost);
         cleanup_flags_cell.push_back(Metadata::Cell);
         auto cleanup_flags_face = cleanup_flags;
         cleanup_flags_face.push_back(Metadata::Face);
-        //cleanup_flags_face.push_back(Metadata::FillGhost);
-        //cleanup_flags_face.push_back(Metadata::GetUserFlag("SplitVector"));
-        // Scalar potential, solution to del^2 p = div B
+        // cleanup_flags_face.push_back(Metadata::FillGhost);
+        // cleanup_flags_face.push_back(Metadata::GetUserFlag("SplitVector"));
+        //  Scalar potential, solution to del^2 p = div B
         pkg->AddField("p", Metadata(cleanup_flags_cell));
         // Gradient of potential; temporary for gradient calc
         pkg->AddField("dB", Metadata(cleanup_flags_face));
@@ -161,19 +164,22 @@ std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::s
         pkg->AddField("RHS_divB", Metadata(cleanup_flags_node));
     }
 
-
     // Optionally take care of B field transport ourselves.  Inadvisable.
     // We've already set a default, so only do this if we're *explicitly* asked
     bool manage_field = pin->GetString("b_field", "solver") == "b_cleanup";
     params.Add("manage_field", manage_field);
-    // Set an interval to clean during the run *can be run in addition to a normal solver*!
-    // You might want to do this if, e.g., you care about divergence on faces with outflow/constant conditions
-    int cleanup_interval = pin->GetOrAddInteger("b_cleanup", "cleanup_interval", manage_field ? 10 : -1);
+    // Set an interval to clean during the run *can be run in addition to a normal
+    // solver*! You might want to do this if, e.g., you care about divergence on faces
+    // with outflow/constant conditions
+    int cleanup_interval =
+        pin->GetOrAddInteger("b_cleanup", "cleanup_interval", manage_field ? 10 : -1);
     params.Add("cleanup_interval", cleanup_interval);
 
     if (manage_field) {
-        // Copy in the field initialization from B_CT and/or B_FluxCT here to declare the right stuff
-        throw std::runtime_error("B field cleanup/projection is set as B field transport! This is not implemented!");
+        // Copy in the field initialization from B_CT and/or B_FluxCT here to declare the
+        // right stuff
+        throw std::runtime_error("B field cleanup/projection is set as B field "
+                                 "transport! This is not implemented!");
     }
 
     return pkg;
@@ -182,10 +188,11 @@ std::shared_ptr<KHARMAPackage> B_Cleanup::Initialize(ParameterInput *pin, std::s
 bool B_Cleanup::CleanupThisStep(Mesh* pmesh, int nstep)
 {
     auto pkg = pmesh->packages.Get("B_Cleanup");
-    return (pkg->Param<int>("cleanup_interval") > 0) && (nstep % pkg->Param<int>("cleanup_interval") == 0);
+    return (pkg->Param<int>("cleanup_interval") > 0) &&
+           (nstep % pkg->Param<int>("cleanup_interval") == 0);
 }
 
-// TODO(BSP) Make this add to a TaskCollection rather than operating synchronously
+// TODO(CEP) Make this add to a TaskCollection rather than operating synchronously
 TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
 {
     auto pmesh = md->GetMeshPointer();
@@ -204,10 +211,12 @@ TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
     const bool use_b_ct = pmesh->packages.AllPackages().count("B_CT");
 
     if (MPIRank0() && verbose > 0) {
-        std::cout << "Cleaning divB to absolute tolerance " << abs_tolerance <<
-                     " OR relative tolerance " << rel_tolerance << std::endl;
-        if (warn_flag) std::cout << "Convergence failure will produce a warning." << std::endl;
-        if (fail_flag) std::cout << "Convergence failure will produce an error." << std::endl;
+        std::cout << "Cleaning divB to absolute tolerance " << abs_tolerance
+                  << " OR relative tolerance " << rel_tolerance << std::endl;
+        if (warn_flag)
+            std::cout << "Convergence failure will produce a warning." << std::endl;
+        if (fail_flag)
+            std::cout << "Convergence failure will produce an error." << std::endl;
     }
 
     // Calculate/print inital max divB exactly as we would during run
@@ -217,27 +226,32 @@ TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
     } else {
         divb_start = B_FluxCT::GlobalMaxDivB(md.get(), true);
     }
-    if ((divb_start < abs_tolerance  || divb_start < rel_tolerance) && !always_solve) {
+    if ((divb_start < abs_tolerance || divb_start < rel_tolerance) && !always_solve) {
         // If divB is "pretty good" and we allow not solving...
         if (MPIRank0())
-            std::cout << "Magnetic field divergence of " << divb_start << " is below tolerance. Skipping B field cleanup." << std::endl;
+            std::cout << "Magnetic field divergence of " << divb_start
+                      << " is below tolerance. Skipping B field cleanup." << std::endl;
         return TaskStatus::complete;
     } else {
-        if(MPIRank0())
-            std::cout << "Starting magnetic field divergence: " << divb_start << std::endl;
+        if (MPIRank0())
+            std::cout << "Starting magnetic field divergence: " << divb_start
+                      << std::endl;
     }
 
     // Add a solver container as a shallow copy on the default MeshData
     // msolve is just a sub-set of vars we need from md, making MPI syncs etc faster
-    std::vector<std::string> names = KHARMA::GetVariableNames(&pmesh->packages, {Metadata::GetUserFlag("B_Cleanup"), Metadata::GetUserFlag("StartupOnly")});
-    auto &msolve = pmesh->mesh_data.AddShallow("solve", md, names);
+    std::vector<std::string> names = KHARMA::GetVariableNames(&pmesh->packages,
+        {Metadata::GetUserFlag("B_Cleanup"), Metadata::GetUserFlag("StartupOnly")});
+    auto& msolve = pmesh->mesh_data.AddShallow("solve", md, names);
 
     // Initialize the divB variable, which we'll be solving against.
     if (use_b_ct) {
-        B_CT::CalcDivB(md.get(), "RHS_divB"); // this fn draws from cons.fB, which is not in msolve
+        B_CT::CalcDivB(md.get(),
+            "RHS_divB"); // this fn draws from cons.fB, which is not in msolve
     } else {
         // This gets signed divB on all physical corners (total (N+1)^3)
-        B_FluxCT::CalcDivB(md.get(), "RHS_divB"); // this fn draws from cons.B, which is not in msolve
+        B_FluxCT::CalcDivB(md.get(),
+            "RHS_divB"); // this fn draws from cons.B, which is not in msolve
     }
     if (use_normalized) {
         // Normalize divB by local metric determinant for fairer weighting of errors
@@ -247,16 +261,18 @@ TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
         const IndexRange ib = msolve->GetBoundsI(IndexDomain::entire);
         const IndexRange jb = msolve->GetBoundsJ(IndexDomain::entire);
         const IndexRange kb = msolve->GetBoundsK(IndexDomain::entire);
-        pmb0->par_for("normalize_divB", 0, divb_rhs.GetDim(5)-1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        pmb0->par_for("normalize_divB", 0, divb_rhs.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e,
+            ib.s, ib.e,
+                      KOKKOS_LAMBDA(const int& b, const int& k, const int& j,
+                                    const int& i)
+            {
                 const auto& G = divb_rhs.GetCoords(b);
                 if (use_b_ct) {
                     divb_rhs(b, CC, 0, k, j, i) /= G.gdet(Loci::center, j, i);
                 } else {
                     divb_rhs(b, NN, 0, k, j, i) /= G.gdet(Loci::corner, j, i);
                 }
-            }
-        );
+            });
     }
     // make sure divB_RHS is sync'd
     KHARMADriver::SyncAllBounds(msolve);
@@ -304,7 +320,7 @@ TaskStatus B_Cleanup::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
     return TaskStatus::complete;
 }
 
-TaskStatus B_Cleanup::ApplyPCenter(MeshData<Real> *msolve, MeshData<Real> *md)
+TaskStatus B_Cleanup::ApplyPCenter(MeshData<Real>* msolve, MeshData<Real>* md)
 {
     // Apply on physical zones only, we'll be syncing/updating ghosts
     const IndexRange3 b = KDomain::GetRange(msolve, IndexDomain::interior, 0, 1);
@@ -317,19 +333,19 @@ TaskStatus B_Cleanup::ApplyPCenter(MeshData<Real> *msolve, MeshData<Real> *md)
 
     // dB = grad(p), defined at cell centers, subtract to make field divergence-free
     pmb0->par_for("gradient_P", 0, P.GetDim(5) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
             double b1, b2, b3;
             B_FluxCT::center_grad(G, P(b), k, j, i, ndim > 2, b1, b2, b3);
             B(b, V1, k, j, i) -= b1;
             B(b, V2, k, j, i) -= b2;
             B(b, V3, k, j, i) -= b3;
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
-TaskStatus B_Cleanup::ApplyPFace(MeshData<Real> *msolve, MeshData<Real> *md)
+TaskStatus B_Cleanup::ApplyPFace(MeshData<Real>* msolve, MeshData<Real>* md)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -342,18 +358,19 @@ TaskStatus B_Cleanup::ApplyPFace(MeshData<Real> *msolve, MeshData<Real> *md)
     // Apply on all physical faces, we'll be syncing/updating ghosts
     const IndexRange3 b = KDomain::GetRange(msolve, IndexDomain::interior, 0, 1);
     pmb0->par_for("gradient_P", 0, P.GetDim(5) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
             B(b, F1, 0, k, j, i) -= B_CT::face_grad<X1DIR>(G, P(b), k, j, i);
             B(b, F2, 0, k, j, i) -= B_CT::face_grad<X2DIR>(G, P(b), k, j, i);
             B(b, F3, 0, k, j, i) -= B_CT::face_grad<X3DIR>(G, P(b), k, j, i);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus B_Cleanup::CornerLaplacian(MeshData<Real>* md, const std::string& p_var, MeshData<Real>* md_again, const std::string& lap_var)
+TaskStatus B_Cleanup::CornerLaplacian(MeshData<Real>* md, const std::string& p_var,
+    MeshData<Real>* md_again, const std::string& lap_var)
 {
     auto pkg = md->GetMeshPointer()->packages.Get("B_Cleanup");
     const auto use_normalized = pkg->Param<bool>("use_normalized_divb");
@@ -372,70 +389,75 @@ TaskStatus B_Cleanup::CornerLaplacian(MeshData<Real>* md, const std::string& p_v
 
     // P is defined on cell corners.  We need enough to take
     // grad -> center, then div -> corner, so one extra in each direction
-    const IndexRange ib_l = IndexRange{ib.s-1, ib.e+1};
-    const IndexRange jb_l = (ndim > 1) ? IndexRange{jb.s-1, jb.e+1} : jb;
-    const IndexRange kb_l = (ndim > 2) ? IndexRange{kb.s-1, kb.e+1} : kb;
+    const IndexRange ib_l = IndexRange{ib.s - 1, ib.e + 1};
+    const IndexRange jb_l = (ndim > 1) ? IndexRange{jb.s - 1, jb.e + 1} : jb;
+    const IndexRange kb_l = (ndim > 2) ? IndexRange{kb.s - 1, kb.e + 1} : kb;
     // The div computes corner i,j,k, so needs to be [0,N+1] to cover all physical corners
-    const IndexRange ib_r = IndexRange{ib.s, ib.e+1};
-    const IndexRange jb_r = (ndim > 1) ? IndexRange{jb.s, jb.e+1} : jb;
-    const IndexRange kb_r = (ndim > 2) ? IndexRange{kb.s, kb.e+1} : kb;
+    const IndexRange ib_r = IndexRange{ib.s, ib.e + 1};
+    const IndexRange jb_r = (ndim > 1) ? IndexRange{jb.s, jb.e + 1} : jb;
+    const IndexRange kb_r = (ndim > 2) ? IndexRange{kb.s, kb.e + 1} : kb;
 
     // dB = grad(p), defined at cell centers
-    pmb0->par_for("gradient_P", 0, P.GetDim(5) - 1, kb_l.s, kb_l.e, jb_l.s, jb_l.e, ib_l.s, ib_l.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("gradient_P", 0, P.GetDim(5) - 1, kb_l.s, kb_l.e, jb_l.s, jb_l.e,
+        ib_l.s, ib_l.e,
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
             double b1, b2, b3;
             B_FluxCT::center_grad(G, P(b), k, j, i, ndim > 2, b1, b2, b3);
             dB(b, V1, k, j, i) = b1;
             dB(b, V2, k, j, i) = b2;
             dB(b, V3, k, j, i) = b3;
-        }
-    );
+        });
 
     // Replace ghost zone calculations with strict boundary conditions
-    // Only necessary in j for poles so far, but maybe this should be the condition for outflow too?
+    // Only necessary in j for poles so far, but maybe this should be the condition for
+    // outflow too?
     if (pmb0->coords.coords.is_spherical()) {
-        for (int i=0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
+        for (int i = 0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
             auto rc = md->GetBlockData(i);
             auto pmb = rc->GetBlockPointer();
             auto dB_block = rc->PackVariables(std::vector<std::string>{"dB"});
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2)) {
                 pmb->par_for("dB_boundary", kb_l.s, kb_l.e, ib_l.s, ib_l.e,
-                    KOKKOS_LAMBDA (const int &k, const int &i) {
-                        dB_block(V1, k, jb.s-1, i) = dB_block(V1, k, jb.s, i);
-                        dB_block(V2, k, jb.s-1, i) = -dB_block(V2, k, jb.s, i);
-                        dB_block(V3, k, jb.s-1, i) = dB_block(V3, k, jb.s, i);
-                    }
-                );
+                             KOKKOS_LAMBDA(const int& k, const int& i)
+                    {
+                        dB_block(V1, k, jb.s - 1, i) = dB_block(V1, k, jb.s, i);
+                        dB_block(V2, k, jb.s - 1, i) = -dB_block(V2, k, jb.s, i);
+                        dB_block(V3, k, jb.s - 1, i) = dB_block(V3, k, jb.s, i);
+                    });
             }
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2)) {
                 pmb->par_for("dB_boundary", kb_l.s, kb_l.e, ib_l.s, ib_l.e,
-                    KOKKOS_LAMBDA (const int &k, const int &i) {
-                        dB_block(V1, k, jb.e+1, i) = dB_block(V1, k, jb.e, i);
-                        dB_block(V2, k, jb.e+1, i) = -dB_block(V2, k, jb.e, i);
-                        dB_block(V3, k, jb.e+1, i) = dB_block(V3, k, jb.e, i);
-                    }
-                );
+                             KOKKOS_LAMBDA(const int& k, const int& i)
+                    {
+                        dB_block(V1, k, jb.e + 1, i) = dB_block(V1, k, jb.e, i);
+                        dB_block(V2, k, jb.e + 1, i) = -dB_block(V2, k, jb.e, i);
+                        dB_block(V3, k, jb.e + 1, i) = dB_block(V3, k, jb.e, i);
+                    });
             }
         }
     }
 
     // lap = div(dB), defined at cell corners
-    pmb0->par_for("laplacian_dB", 0, lap.GetDim(5) - 1, kb_r.s, kb_r.e, jb_r.s, jb_r.e, ib_r.s, ib_r.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("laplacian_dB", 0, lap.GetDim(5) - 1, kb_r.s, kb_r.e, jb_r.s, jb_r.e,
+        ib_r.s, ib_r.e,
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = lap.GetCoords(b);
-            // This is the inverse diagonal element of a fictional a_ij Laplacian operator
+            // This is the inverse diagonal element of a fictional a_ij
+            // Laplacian operator
             lap(b, 0, k, j, i) = B_FluxCT::corner_div(G, dB(b), k, j, i, ndim > 2);
             if (use_normalized) {
                 lap(b, 0, k, j, i) /= G.gdet(Loci::corner, j, i);
             }
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus B_Cleanup::CenterLaplacian(MeshData<Real>* md, const std::string& p_var, MeshData<Real>* md_again, const std::string& lap_var)
+TaskStatus B_Cleanup::CenterLaplacian(MeshData<Real>* md, const std::string& p_var,
+    MeshData<Real>* md_again, const std::string& lap_var)
 {
     auto pkg = md->GetMeshPointer()->packages.Get("B_Cleanup");
     const auto use_normalized = pkg->Param<bool>("use_normalized_divb");
@@ -451,97 +473,105 @@ TaskStatus B_Cleanup::CenterLaplacian(MeshData<Real>* md, const std::string& p_v
 
     // dB = grad(p), interpolating to faces
     // Do I know why these have to be ::entire?  No.  Does it work?  Yes.
-    // TODO separate gradient functions since we're calculating directions separately anyway
+    // TODO separate gradient functions since we're calculating directions separately
+    // anyway
     const IndexRange3 b1 = KDomain::GetRange(md, IndexDomain::entire, F1, 1, -1, false);
-    pmb0->par_for("gradient_P", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je, b1.is, b1.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("gradient_P", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je, b1.is,
+        b1.ie,
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
             dB(b, F1, 0, k, j, i) = B_CT::face_grad<X1DIR>(G, P(b), k, j, i);
-        }
-    );
+        });
     const IndexRange3 b2 = KDomain::GetRange(md, IndexDomain::entire, F2, 1, -1, false);
-    pmb0->par_for("gradient_P", block.s, block.e, b2.ks, b2.ke, b2.js, b2.je, b2.is, b2.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("gradient_P", block.s, block.e, b2.ks, b2.ke, b2.js, b2.je, b2.is,
+        b2.ie,
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
             dB(b, F2, 0, k, j, i) = B_CT::face_grad<X2DIR>(G, P(b), k, j, i);
-        }
-    );
+        });
     if (ndim > 2) {
-        const IndexRange3 b3 = KDomain::GetRange(md, IndexDomain::entire, F3, 1, -1, false);
-        pmb0->par_for("gradient_P", block.s, block.e, b3.ks, b3.ke, b3.js, b3.je, b3.is, b3.ie,
-            KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        const IndexRange3 b3 =
+            KDomain::GetRange(md, IndexDomain::entire, F3, 1, -1, false);
+        pmb0->par_for("gradient_P", block.s, block.e, b3.ks, b3.ke, b3.js, b3.je, b3.is,
+            b3.ie,
+            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+            {
                 const auto& G = P.GetCoords(b);
                 dB(b, F3, 0, k, j, i) = B_CT::face_grad<X3DIR>(G, P(b), k, j, i);
-            }
-        );
+            });
     }
 
     // Make sure B on poles is zero
     if (pmb0->coords.coords.is_spherical()) {
-        for (int i=0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
+        for (int i = 0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
             auto rc = md->GetBlockData(i);
             auto pmb = rc->GetBlockPointer();
             auto dB_block = rc->PackVariables(std::vector<std::string>{"dB"});
             const IndexRange3 bi2 = KDomain::GetRange(md, IndexDomain::interior, F2);
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2)) {
                 pmb->par_for("dB_boundary", b2.ks, b2.ke, bi2.js, bi2.js, b2.is, b2.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         dB_block(F2, 0, k, j, i) = 0.;
-                    }
-                );
+                    });
             }
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2)) {
                 pmb->par_for("dB_boundary", b2.ks, b2.ke, bi2.je, bi2.je, b2.is, b2.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         dB_block(F2, 0, k, j, i) = 0.;
-                    }
-                );
+                    });
             }
         }
     }
 
     // lap = div(dB), interpolating back to cell centers
     const IndexRange3 bc = KDomain::GetRange(md, IndexDomain::entire, CC, false);
-    pmb0->par_for("laplacian_dB", block.s, block.e, bc.ks, bc.ke, bc.js, bc.je, bc.is, bc.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("laplacian_dB", block.s, block.e, bc.ks, bc.ke, bc.js, bc.je, bc.is,
+        bc.ie,
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = lap.GetCoords(b);
-            // This is the inverse diagonal element of a fictional a_ij Laplacian operator
+            // This is the inverse diagonal element of a fictional a_ij
+            // Laplacian operator
             lap(b, 0, k, j, i) = B_CT::face_div(G, dB(b), ndim, k, j, i);
             if (use_normalized) {
                 lap(b, 0, k, j, i) /= G.gdet(Loci::corner, j, i);
             }
-        }
-    );
+        });
 
     // Make sure divB on outflows is 0
-    // Our outflow conditions guarantee divergence-free last zones, so we shouldn't clean for them
+    // Our outflow conditions guarantee divergence-free last zones, so we shouldn't clean
+    // for them
     if (pmb0->packages.Get("Boundaries")->Param<std::string>("inner_x1") == "outflow") {
-        for (int i=0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
+        for (int i = 0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
             auto rc = md->GetBlockData(i);
             auto pmb = rc->GetBlockPointer();
             auto lap_block = rc->PackVariables(std::vector<std::string>{lap_var});
             const IndexRange3 bic = KDomain::GetRange(md, IndexDomain::interior);
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x1)) {
                 pmb->par_for("lap_boundary", bc.ks, bc.ke, bc.js, bc.je, bc.is, bic.is,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         lap_block(0, k, j, i) = 0.;
-                    }
-                );
+                    });
             }
         }
     }
     if (pmb0->packages.Get("Boundaries")->Param<std::string>("outer_x1") == "outflow") {
-        for (int i=0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
+        for (int i = 0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
             auto rc = md->GetBlockData(i);
             auto pmb = rc->GetBlockPointer();
             auto lap_block = rc->PackVariables(std::vector<std::string>{lap_var});
             const IndexRange3 bic = KDomain::GetRange(md, IndexDomain::interior);
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x1)) {
                 pmb->par_for("lap_boundary", bc.ks, bc.ke, bc.js, bc.je, bic.ie, bc.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         lap_block(0, k, j, i) = 0.;
-                    }
-                );
+                    });
             }
         }
     }

--- a/kharma/b_cleanup/b_cleanup.hpp
+++ b/kharma/b_cleanup/b_cleanup.hpp
@@ -1,25 +1,25 @@
 /*
  *  File: b_cleanup.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,15 +45,17 @@ using namespace parthenon;
 /**
  * This physics package implements an elliptic solver which minimizes the divergence of
  * the magnetic field B, most useful for mesh resizing.
- * Written to leave open the possibility of using this at every 
- * 
+ * Written to leave open the possibility of using this at every
+ *
  * Mostly now, it is used when resizing input arrays
  */
-namespace B_Cleanup {
+namespace B_Cleanup
+{
 /**
  * Declare fields, initialize (few) parameters
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Single-call divergence cleanup.  Lots of MPI syncs, probably slow to use in task lists.
@@ -70,19 +72,21 @@ bool CleanupThisStep(Mesh* pmesh, int nstep);
  * Calculate the laplacian using divergence at corners.
  * Extra MeshData arg is just to satisfy Parthenon solver calling convention
  */
-TaskStatus CornerLaplacian(MeshData<Real>* md, const std::string& p_var, MeshData<Real>* md_again, const std::string& lap_var);
+TaskStatus CornerLaplacian(MeshData<Real>* md, const std::string& p_var,
+    MeshData<Real>* md_again, const std::string& lap_var);
 /**
  * Calculate the laplacian using divergence at centers.
  */
-TaskStatus CenterLaplacian(MeshData<Real>* md, const std::string& p_var, MeshData<Real>* md_again, const std::string& lap_var);
+TaskStatus CenterLaplacian(MeshData<Real>* md, const std::string& p_var,
+    MeshData<Real>* md_again, const std::string& lap_var);
 
 /**
  * Apply B -= grad(P) on cell centers to subtract divergence from the magnetic field
  */
-TaskStatus ApplyPCenter(MeshData<Real> *msolve, MeshData<Real> *md);
+TaskStatus ApplyPCenter(MeshData<Real>* msolve, MeshData<Real>* md);
 /**
  * Apply B -= grad(P) on faces to subtract divergence from the magnetic field
  */
-TaskStatus ApplyPFace(MeshData<Real> *msolve, MeshData<Real> *md);
+TaskStatus ApplyPFace(MeshData<Real>* msolve, MeshData<Real>* md);
 
 } // namespace B_Cleanup

--- a/kharma/b_cleanup/bicgstab_solver.hpp
+++ b/kharma/b_cleanup/bicgstab_solver.hpp
@@ -17,657 +17,690 @@
 #include <string>
 #include <vector>
 
-#include "mesh/mesh.hpp"
 #include "interface/mesh_data.hpp"
 #include "interface/meshblock_data.hpp"
 #include "interface/state_descriptor.hpp"
 #include "kokkos_abstraction.hpp"
+#include "mesh/mesh.hpp"
 #include "tasks/task_id.hpp"
 #include "tasks/task_list.hpp"
 
 #include "solver_utils.hpp"
 
-namespace parthenon {
+namespace parthenon
+{
 
-namespace solvers {
+namespace solvers
+{
 
-struct BiCGStabCounter {
-  static int global_num_bicgstab_solvers;
+struct BiCGStabCounter
+{
+    static int global_num_bicgstab_solvers;
 };
 
-template <typename SPType>
-class BiCGStabSolver : BiCGStabCounter {
- public:
-  BiCGStabSolver() = default;
-  BiCGStabSolver(StateDescriptor *pkg, const Real rel_error_tol_in,
-                 const Real abs_error_tol_in, const SparseMatrixAccessor &sp,
-                 const std::vector<std::string> &aux_vars = {},
-                 std::vector<MetadataFlag> user_flags={})
-      : rel_error_tol(rel_error_tol_in), abs_error_tol(abs_error_tol_in),
-        sp_accessor(sp), max_iters(pkg->Param<int>("bicgstab_max_iterations")),
-        check_interval(pkg->Param<int>("bicgstab_check_interval")),
-        fail_flag(pkg->Param<bool>("bicgstab_abort_on_fail")),
-        warn_flag(pkg->Param<bool>("bicgstab_warn_on_fail")), aux_vars(aux_vars) {
-    Init(pkg, user_flags);
-  }
-  std::vector<std::string> SolverState() const {
-    std::vector<std::string> vars{spm_name, rhs_name, res, res0, vk, pk, tk, temp};
-    vars.insert(vars.end(), aux_vars.begin(), aux_vars.end());
-    return vars;
-  }
-  std::string label() const {
-    std::string lab;
-    for (const auto &s : SolverState())
-      lab += s;
-    return lab;
-  }
-
-  TaskID CreateTaskList(const TaskID &begin, const int i, TaskRegion &tr,
-                        std::shared_ptr<MeshData<Real>> md,
-                        std::shared_ptr<MeshData<Real>> mout) {
-    auto &solver = tr[i].AddIteration(solver_name);
-    solver.SetMaxIterations(max_iters);
-    solver.SetCheckInterval(check_interval);
-    solver.SetFailWithMaxIterations(fail_flag);
-    solver.SetWarnWithMaxIterations(warn_flag);
-    return CreateTaskList(begin, i, tr, solver, md, mout);
-  }
-
-  using FMatVec = std::function<TaskStatus(MeshData<Real> *, const std::string &,
-                                           MeshData<Real> *, const std::string &)>;
-  using FScale = std::function<TaskStatus(MeshData<Real> *, const std::string &)>;
-  FMatVec user_MatVec;
-  FMatVec user_pre_fluxcor;
-  FMatVec user_precomm_MatVec;
-  FScale user_precomm_scale;
-  FScale user_postcomm_scale;
-
-  std::vector<std::string> aux_vars;
-
- private:
-  void Init(StateDescriptor *pkg, std::vector<MetadataFlag> user_flags) {
-    // create vectors used internally by the solver
-    spm_name = pkg->Param<std::string>("spm_name");
-    sol_name = pkg->Param<std::string>("sol_name");
-    rhs_name = pkg->Param<std::string>("rhs_name");
-
-    const std::string bicg_id(std::to_string(global_num_bicgstab_solvers));
-    solver_name = "internal_bicgstab_" + bicg_id;
-
-    res0 = "res_0" + bicg_id;
-    std::vector<MetadataFlag> base_flags({Metadata::Node, Metadata::OneCopy});
-    base_flags.insert(base_flags.end(), user_flags.begin(), user_flags.end());
-    auto meta = Metadata(base_flags);
-    pkg->AddField(res0, meta);
-
-    vk = "vk" + bicg_id;
-    tk = "tk" + bicg_id;
-    auto flux_flags = base_flags;
-    flux_flags.push_back(Metadata::WithFluxes);
-    meta = Metadata(flux_flags);
-    pkg->AddField(vk, meta);
-    pkg->AddField(tk, meta);
-
-    res = "res" + bicg_id;
-    pk = "pk" + bicg_id;
-    temp = "temp" + bicg_id;
-    auto ghost_flags = base_flags;
-    ghost_flags.push_back(Metadata::FillGhost);
-    meta = Metadata(ghost_flags);
-    pkg->AddField(pk, meta);
-    pkg->AddField(res, meta);
-    pkg->AddField(temp, meta);
-
-    global_num_bicgstab_solvers++;
-  }
-
-  TaskID CreateTaskList(const TaskID &begin, const int i, TaskRegion &tr,
-                        IterativeTasks &solver, std::shared_ptr<MeshData<Real>> md,
-                        std::shared_ptr<MeshData<Real>> mout) {
-    using Solver_t = BiCGStabSolver<SPType>;
-    using MD_t = MeshData<Real>;
-    TaskID none(0);
-    TaskList &tl = tr[i];
-    RegionCounter reg(solver_name);
-
-    // initialize some shared state
-    bicgstab_cntr = 0;
-    global_res0.val = 0.0;
-    global_res.val = 0.0;
-    rhoi.val = 0.0;
-    r0_dot_vk.val = 0.0;
-    t_dot_s.val = 0.0;
-    t_dot_t.val = 0.0;
-
-    auto MatVec = [this](auto &task_list, const TaskID &init_depend,
-                         std::shared_ptr<MeshData<Real>> &spmd,
-                         const std::string &name_in, const std::string &name_out) {
-      auto precom = init_depend;
-      auto vec_name = name_in;
-      if (this->user_precomm_MatVec) {
-        precom = task_list.AddTask(init_depend, this->user_precomm_MatVec, spmd.get(),
-                                   name_in, spmd.get(), this->temp);
-        vec_name = this->temp;
-      }
-      auto precom2 = precom;
-      if (this->user_precomm_scale) {
-        precom2 =
-            task_list.AddTask(precom, this->user_precomm_scale, spmd.get(), vec_name);
-      }
-
-      // TODO(BSP) this is AddBoundaryExchangeTasks, would use that except it's not
-      // templated for special iterative lists
-      auto dependency = precom2;
-      auto &tl = task_list;
-      auto &md = spmd;
-      const auto any = BoundaryType::any;
-      auto send = tl.AddTask(dependency, SendBoundBufs<any>, md);
-      auto recv = tl.AddTask(dependency, ReceiveBoundBufs<any>, md);
-      auto set = tl.AddTask(recv, SetBounds<any>, md);
-
-      auto pro = set;
-      if (md->GetMeshPointer()->multilevel) {
-        auto cbound = tl.AddTask(set, ApplyBoundaryConditionsOnCoarseOrFineMD, md, true);
-        pro = tl.AddTask(cbound, ProlongateBounds<any>, md);
-      }
-      auto fbound = tl.AddTask(pro, ApplyBoundaryConditionsOnCoarseOrFineMD, md, false);
-      auto boundaries = fbound;
-
-      auto postcomm = boundaries;
-      if (this->user_postcomm_scale) {
-        postcomm =
-            task_list.AddTask(boundaries, this->user_postcomm_scale, spmd.get(), vec_name);
-      }
-
-      auto update_rhs = postcomm;
-      if (this->user_MatVec) {
-        auto preflx = boundaries;
-        if (this->user_pre_fluxcor) {
-          auto calc_flx = task_list.AddTask(boundaries, this->user_pre_fluxcor, spmd.get(),
-                                            vec_name, spmd.get(), name_out);
-          auto send_flx =
-              task_list.AddTask(calc_flx, parthenon::LoadAndSendFluxCorrections, spmd);
-          auto recv_flx =
-              task_list.AddTask(calc_flx, parthenon::ReceiveFluxCorrections, spmd);
-          preflx = task_list.AddTask(recv_flx, parthenon::SetFluxCorrections, spmd);
-        }
-        update_rhs = task_list.AddTask(preflx, this->user_MatVec, spmd.get(), vec_name,
-                                       spmd.get(), name_out);
-      } else {
-        update_rhs = task_list.AddTask(boundaries, &Solver_t::MatVec<MD_t>, this, spmd.get(),
-                                       name_in, name_out);
-      }
-      return update_rhs;
-    };
-
-    auto get_init = MatVec(tl, begin, md, rhs_name, vk);
-
-    auto init_bicgstab = tl.AddTask(get_init, &Solver_t::InitializeBiCGStab<MD_t>, this,
-                                    md.get(), mout.get(), &global_res0.val);
-    tr.AddRegionalDependencies(reg.ID(), i, init_bicgstab);
-    // global reduction for initial residual
-    auto start_global_res0 =
-        (i == 0 ? tl.AddTask(init_bicgstab, &AllReduce<Real>::StartReduce, &global_res0,
-                             MPI_SUM)
-                : init_bicgstab);
-    auto finish_global_res0 =
-        tl.AddTask(start_global_res0, &AllReduce<Real>::CheckReduce, &global_res0);
-    tr.AddRegionalDependencies(reg.ID(), i, finish_global_res0);
-
-    // 1. \hat{r}_0 \cdot r_{i-1}
-    auto get_rhoi = solver.AddTask(init_bicgstab, &Solver_t::DotProduct<MD_t>, this,
-                                   md.get(), res0, res, &rhoi.val);
-    tr.AddRegionalDependencies(reg.ID(), i, get_rhoi);
-    auto start_global_rhoi =
-        (i == 0 ? solver.AddTask(get_rhoi, &AllReduce<Real>::StartReduce, &rhoi, MPI_SUM)
-                : get_rhoi);
-    auto finish_global_rhoi =
-        solver.AddTask(start_global_rhoi, &AllReduce<Real>::CheckReduce, &rhoi);
-
-    // 2. \beta = (rho_i/rho_{i-1}) (\alpha / \omega_{i-1})
-    // 3. p_i = r_{i-1} + \beta (p_{i-1} - \omega_{i-1} v_{i-1})
-    auto update_pk =
-        solver.AddTask(finish_global_rhoi, &Solver_t::Compute_pk<MD_t>, this, md.get());
-
-    // 4. v = A p
-    auto get_v = MatVec(solver, update_pk, md, pk, vk);
-
-    // 5. alpha = rho_i / (\hat{r}_0 \cdot v_i) [Actually just calculate \hat{r}_0 \cdot
-    // v_i]
-    auto get_r0dotv = solver.AddTask(get_v, &Solver_t::DotProduct<MD_t>, this, md.get(),
-                                     res0, vk, &r0_dot_vk.val);
-    tr.AddRegionalDependencies(reg.ID(), i, get_r0dotv);
-    auto start_global_r0dotv =
-        (i == 0 ? solver.AddTask(get_r0dotv, &AllReduce<Real>::StartReduce, &r0_dot_vk,
-                                 MPI_SUM)
-                : get_r0dotv);
-    auto finish_global_r0dotv =
-        solver.AddTask(start_global_r0dotv, &AllReduce<Real>::CheckReduce, &r0_dot_vk);
-    // alpha is actually updated in this next task
-
-    // 6. h = x_{i-1} + alpha p [Really updates x_i]
-    // 7. check for convergence [Not actually done]
-    // 8. s = r_{i-1} - alpha v
-    auto get_s = solver.AddTask(finish_global_r0dotv, &Solver_t::Update_h_and_s<MD_t>,
-                                this, md.get(), mout.get());
-
-    // 9. t = A s
-    auto get_t = MatVec(solver, get_s, md, res, tk);
-
-    // 10. omega = (t \cdot s) / (t \cdot t)
-    auto get_tdots = solver.AddTask(get_t, &Solver_t::OmegaDotProd<MD_t>, this, md.get(),
-                                    &t_dot_s.val, &t_dot_t.val);
-    tr.AddRegionalDependencies(reg.ID(), i, get_tdots);
-    auto start_global_tdots =
-        (i == 0
-             ? solver.AddTask(get_tdots, &AllReduce<Real>::StartReduce, &t_dot_s, MPI_SUM)
-             : get_tdots);
-    auto finish_global_tdots =
-        solver.AddTask(start_global_tdots, &AllReduce<Real>::CheckReduce, &t_dot_s);
-    auto start_global_tdott =
-        (i == 0
-             ? solver.AddTask(get_tdots, &AllReduce<Real>::StartReduce, &t_dot_t, MPI_SUM)
-             : get_tdots);
-    auto finish_global_tdott =
-        solver.AddTask(start_global_tdott, &AllReduce<Real>::CheckReduce, &t_dot_t);
-    // omega is actually updated in this next task
-
-    // 11. update x and residual
-    auto update_x = solver.AddTask(finish_global_tdots | finish_global_tdott,
-                                   &Solver_t::Update_x_res<MD_t>, this, md.get(),
-                                   mout.get(), &global_res.val);
-    tr.AddRegionalDependencies(reg.ID(), i, update_x);
-    auto start_global_res =
-        (i == 0 ? solver.AddTask(update_x, &AllReduce<Real>::StartReduce, &global_res,
-                                 MPI_SUM)
-                : update_x);
-    auto finish_global_res =
-        solver.AddTask(start_global_res, &AllReduce<Real>::CheckReduce, &global_res);
-
-    // 12. check for convergence
-    auto check = solver.SetCompletionTask(finish_global_res, &Solver_t::CheckConvergence,
-                                          this, i, true);
-    tr.AddGlobalDependencies(reg.ID(), i, check);
-
-    return check;
-  }
-
- public:
-  template <typename T>
-  TaskStatus InitializeBiCGStab(T *u, T *du, Real *gres0) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    std::vector<std::string> vars({res, res0, vk, pk, rhs_name});
-    const auto &v = u->PackVariables(vars, imap);
-    const int ires = imap[res].first;
-    const int ires0 = imap[res0].first;
-    const int ivk = imap[vk].first;
-    const int ipk = imap[pk].first;
-    const int irhs = imap[rhs_name].first;
-
-    const auto &dv = du->PackVariables(std::vector<std::string>({sol_name}));
-
-    rhoi_old = 1.0;
-    alpha_old = 1.0;
-    omega_old = 1.0;
-    Real err(0);
-    const Real fac0 = 0.0;
-    const Real fac = 0.0;
-    par_reduce(
-        loop_pattern_mdrange_tag, "initialize bicgstab", DevExecSpace(), 0,
-        v.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lerr) {
-          // initialize guess for solution
-          dv(b, 0, k, j, i) = fac * v(b, irhs, k, j, i);
-
-          v(b, ires, k, j, i) = v(b, irhs, k, j, i) - fac * v(b, ivk, k, j, i);
-          v(b, ires0, k, j, i) = v(b, irhs, k, j, i) - fac0 * v(b, ivk, k, j, i);
-
-          v(b, ivk, k, j, i) = 0.0;
-          v(b, ipk, k, j, i) = 0.0;
-
-          lerr += v(b, irhs, k, j, i) * v(b, irhs, k, j, i);
-        },
-        Kokkos::Sum<Real>(err));
-    *gres0 += err;
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus update_r(T *u) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    std::vector<std::string> vars({res, rhs_name});
-    const auto &v = u->PackVariables(vars, imap);
-    const int ires = imap[res].first;
-    const int irhs = imap[rhs_name].first;
-
-    par_for(
-        loop_pattern_mdrange_tag, "initialize bicgstab", DevExecSpace(), 0,
-        v.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          v(b, ires, k, j, i) = v(b, irhs, k, j, i) - v(b, ires, k, j, i);
-        });
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus DotProduct(T *u, const std::string &vec1, const std::string &vec2,
-                        Real *reduce_sum) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    auto &v = u->PackVariables(std::vector<std::string>({vec1, vec2}));
-
-    Real gsum(0);
-    par_reduce(
-        loop_pattern_mdrange_tag, "DotProduct", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s,
-        kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lsum) {
-          lsum += v(b, 0, k, j, i) * v(b, 1, k, j, i);
-        },
-        Kokkos::Sum<Real>(gsum));
-    *reduce_sum += gsum;
-    // printf("DotProduct: %s dot %s  = %e (%e)\n", vec1.c_str(), vec2.c_str(),
-    // *reduce_sum, gsum);
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus Compute_pk(T *u) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    auto &v = u->PackVariables(std::vector<std::string>({pk, res, vk, res0}), imap);
-    const int ipk = imap[pk].first;
-    const int ires = imap[res].first;
-    const int ires0 = imap[res0].first;
-    const int ivk = imap[vk].first;
-
-    const Real beta = (rhoi.val / rhoi_old) * (alpha_old / omega_old);
-    bool reset = false;
-    // if (std::abs(rhoi.val) < 1.e-8) {
-    //   // Reset
-    //   printf("Resetting (r_{i-1}, r_0) = %e res = %e \n", rhoi.val, res_old);
-    //   rhoi.val = res_old; // this should be the norm of the old residual, which we are
-    //   resetting to reset = true;
-    // }
-    // printf("Compute_pk: rho_i = %e rho_{i-1} = %e alpha_old = %e omega_old = %e beta =
-    // %e\n", rhoi.val, rhoi_old, alpha_old, omega_old, beta); rhoi_old = rhoi.val;
-    const Real w_o = omega_old;
-    par_for(
-        DEFAULT_LOOP_PATTERN, "compute pk", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s,
-        kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          v(b, ipk, k, j, i) = v(b, ires, k, j, i) +
-                               beta * (v(b, ipk, k, j, i) - w_o * v(b, ivk, k, j, i));
-          if (reset) {
-            v(b, ipk, k, j, i) = v(b, ires, k, j, i);
-            v(b, ires0, k, j, i) = v(b, ires, k, j, i);
-          }
-        });
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus MatVec(T *u, const std::string &in_vec, const std::string &out_vec) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    auto &v =
-        u->PackVariables(std::vector<std::string>({in_vec, out_vec, spm_name}), imap);
-    const int iin = imap[in_vec].first;
-    const int iout = imap[out_vec].first;
-    const int isp_lo = imap[spm_name].first;
-    const int isp_hi = imap[spm_name].second;
-    SparseMatrixAccessor &r_sp_accessor = sp_accessor;
-
-    par_for(
-        DEFAULT_LOOP_PATTERN, "MatVec", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s, kb.e,
-        jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          v(b, iout, k, j, i) =
-              r_sp_accessor.MatVec(v, isp_lo, isp_hi, v, iin, b, k, j, i);
-        });
-    // printf("MatVec: in_vec = %s out_vec = %s spm = %s\n", in_vec.c_str(),
-    // out_vec.c_str(), spm_name.c_str());
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus Update_h_and_s(T *u, T *du) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    auto &v = u->PackVariables(std::vector<std::string>({res, pk, vk}), imap);
-    auto &dv = du->PackVariables(std::vector<std::string>({sol_name}));
-    const int ires = imap[res].first;
-    const int ipk = imap[pk].first;
-    const int ivk = imap[vk].first;
-
-    Real alpha = rhoi.val / r0_dot_vk.val;
-    // printf("alpha = %e rho = %e (v, r_0) = %e\n", alpha, rhoi.val, r0_dot_vk.val);
-    if (std::abs(r0_dot_vk.val) < 1.e-200) alpha = 0.0;
-    par_for(
-        DEFAULT_LOOP_PATTERN, "Update_h", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s, kb.e,
-        jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          dv(b, 0, k, j, i) += alpha * v(b, ipk, k, j, i);
-          v(b, ires, k, j, i) -= alpha * v(b, ivk, k, j, i);
-        });
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus Update_h(T *u, T *du) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    auto &v = u->PackVariables(std::vector<std::string>({pk}));
-    auto &dv = du->PackVariables(std::vector<std::string>({sol_name}));
-    Real alpha = rhoi.val / r0_dot_vk.val;
-    // printf("Update_h: r0_dot_vk = %e rhoi = %e alpha = %e\n", r0_dot_vk.val, rhoi.val,
-    // alpha);
-    par_for(
-        DEFAULT_LOOP_PATTERN, "Update_h", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s, kb.e,
-        jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          dv(b, 0, k, j, i) += alpha * v(b, 0, k, j, i);
-        });
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus Update_s(T *u) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    auto &v = u->PackVariables(std::vector<std::string>({res, vk}), imap);
-    const int ires = imap[res].first;
-    const int ivk = imap[vk].first;
-    Real alpha = rhoi.val / r0_dot_vk.val;
-    // printf("Update_s: r0_dot_vk = %e rhoi = %e alpha = %e\n", r0_dot_vk.val, rhoi.val,
-    // alpha);
-    par_for(
-        DEFAULT_LOOP_PATTERN, "Update_s", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s, kb.e,
-        jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          v(b, ires, k, j, i) -= alpha * v(b, ivk, k, j, i);
-        });
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus OmegaDotProd(T *u, Real *t_dot_s, Real *t_dot_t) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    auto &v = u->PackVariables(std::vector<std::string>({tk, res}));
-
-    // TODO(JCD): these should probably be merged
-    Real ts_sum(0);
-    par_reduce(
-        loop_pattern_mdrange_tag, "tk dot sk", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s,
-        kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lsum) {
-          lsum += v(b, 0, k, j, i) * v(b, 1, k, j, i);
-        },
-        Kokkos::Sum<Real>(ts_sum));
-    *t_dot_s += ts_sum;
-
-    Real tt_sum(0);
-    par_reduce(
-        loop_pattern_mdrange_tag, "tk dot sk", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s,
-        kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lsum) {
-          lsum += v(b, 0, k, j, i) * v(b, 0, k, j, i);
-        },
-        Kokkos::Sum<Real>(tt_sum));
-    *t_dot_t += tt_sum;
-    // printf("OmegaDotProd: t_dot_s = %e (%e) t_dot_t = %e (%e)\n", *t_dot_s, ts_sum,
-    // *t_dot_t, tt_sum);
-    return TaskStatus::complete;
-  }
-
-  template <typename T>
-  TaskStatus Update_x_res(T *u, T *du, Real *gres) {
-    const auto &ibi = u->GetBoundsI(IndexDomain::interior);
-    const auto &jbi = u->GetBoundsJ(IndexDomain::interior);
-    const auto &kbi = u->GetBoundsK(IndexDomain::interior);
-    const int ndim = u->GetMeshPointer()->ndim;
-    const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
-    const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
-    const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
-
-    PackIndexMap imap;
-    auto &v = u->PackVariables(std::vector<std::string>({res, tk}), imap);
-    const int ires = imap[res].first;
-    const int itk = imap[tk].first;
-    auto &dv = du->PackVariables(std::vector<std::string>({sol_name}));
-    Real omega = t_dot_s.val / t_dot_t.val;
-    if (std::abs(t_dot_t.val) < 1.e-200) omega = 0.0;
-    Real err(0);
-    par_reduce(
-        loop_pattern_mdrange_tag, "Update_x", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s,
-        kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lerr) {
-          dv(b, 0, k, j, i) += omega * v(b, ires, k, j, i);
-          v(b, ires, k, j, i) -= omega * v(b, itk, k, j, i);
-          lerr += v(b, ires, k, j, i) * v(b, ires, k, j, i);
-        },
-        Kokkos::Sum<Real>(err));
-    *gres += err;
-    return TaskStatus::complete;
-  }
-
-  TaskStatus CheckConvergence(const int &i, bool report) {
-    if (i != 0) return TaskStatus::complete;
-    bicgstab_cntr++;
-    global_res.val = std::sqrt(global_res.val);
-    if (bicgstab_cntr == 1) global_res0.val = std::sqrt(global_res0.val);
-
-    // printf("rhoi: %e r0_dot_vk: %e t_dot_t: %e\n", rhoi.val, r0_dot_vk.val,
-    // t_dot_s.val);
-    //  Update global scalars
-    rhoi_old = rhoi.val;
-    alpha_old = rhoi.val / r0_dot_vk.val;
-    omega_old = t_dot_s.val / t_dot_t.val;
-    res_old = global_res.val;
-
-    bool converged = std::abs(global_res.val / global_res0.val) < rel_error_tol
-                    || std::abs(global_res.val) < abs_error_tol;
-
-    bool stop = bicgstab_cntr == max_iters;
-    if (std::abs(alpha_old) < 1.e-8 && std::abs(omega_old) < 1.e-8) stop = true;
-    if (bicgstab_cntr % check_interval == 0) {
-      if (Globals::my_rank == 0) {
-        std::cout << " its= " << bicgstab_cntr << " rho= " << rhoi_old
-                  << " alpha= " << alpha_old << " omega= " << omega_old
-                  << " relative-res: " << global_res.val / global_res0.val
-                  << " absolute-res: " << global_res.val
-                  << " absolute-res0: " << global_res0.val << " relerr-tol: " << rel_error_tol
-                  << " abserr-tol: " << abs_error_tol
-                  << std::endl;
-      }
+template<typename SPType>
+class BiCGStabSolver : BiCGStabCounter
+{
+  public:
+    BiCGStabSolver() = default;
+    BiCGStabSolver(StateDescriptor* pkg, const Real rel_error_tol_in,
+        const Real abs_error_tol_in, const SparseMatrixAccessor& sp,
+        const std::vector<std::string>& aux_vars = {},
+        std::vector<MetadataFlag> user_flags = {})
+        : rel_error_tol(rel_error_tol_in)
+        , abs_error_tol(abs_error_tol_in)
+        , sp_accessor(sp)
+        , max_iters(pkg->Param<int>("bicgstab_max_iterations"))
+        , check_interval(pkg->Param<int>("bicgstab_check_interval"))
+        , fail_flag(pkg->Param<bool>("bicgstab_abort_on_fail"))
+        , warn_flag(pkg->Param<bool>("bicgstab_warn_on_fail"))
+        , aux_vars(aux_vars)
+    {
+        Init(pkg, user_flags);
+    }
+    std::vector<std::string> SolverState() const
+    {
+        std::vector<std::string> vars{spm_name, rhs_name, res, res0, vk, pk, tk, temp};
+        vars.insert(vars.end(), aux_vars.begin(), aux_vars.end());
+        return vars;
+    }
+    std::string label() const
+    {
+        std::string lab;
+        for (const auto& s : SolverState()) lab += s;
+        return lab;
     }
 
-    global_res.val = 0.0;
-    rhoi.val = 0.0;
-    r0_dot_vk.val = 0.0;
-    t_dot_s.val = 0.0;
-    t_dot_t.val = 0.0;
+    TaskID CreateTaskList(const TaskID& begin, const int i, TaskRegion& tr,
+        std::shared_ptr<MeshData<Real>> md, std::shared_ptr<MeshData<Real>> mout)
+    {
+        auto& solver = tr[i].AddIteration(solver_name);
+        solver.SetMaxIterations(max_iters);
+        solver.SetCheckInterval(check_interval);
+        solver.SetFailWithMaxIterations(fail_flag);
+        solver.SetWarnWithMaxIterations(warn_flag);
+        return CreateTaskList(begin, i, tr, solver, md, mout);
+    }
 
-    return converged || stop ? TaskStatus::complete : TaskStatus::iterate;
-  }
+    using FMatVec = std::function<TaskStatus(
+        MeshData<Real>*, const std::string&, MeshData<Real>*, const std::string&)>;
+    using FScale = std::function<TaskStatus(MeshData<Real>*, const std::string&)>;
+    FMatVec user_MatVec;
+    FMatVec user_pre_fluxcor;
+    FMatVec user_precomm_MatVec;
+    FScale user_precomm_scale;
+    FScale user_postcomm_scale;
 
- private:
-  Real rel_error_tol, abs_error_tol;
-  SparseMatrixAccessor sp_accessor;
-  int max_iters, check_interval, bicgstab_cntr;
-  bool fail_flag, warn_flag;
-  std::string spm_name, sol_name, rhs_name, res, res0, vk, pk, tk, temp, solver_name;
+    std::vector<std::string> aux_vars;
 
-  Real rhoi_old, alpha_old, omega_old, res_old;
+  private:
+    void Init(StateDescriptor* pkg, std::vector<MetadataFlag> user_flags)
+    {
+        // create vectors used internally by the solver
+        spm_name = pkg->Param<std::string>("spm_name");
+        sol_name = pkg->Param<std::string>("sol_name");
+        rhs_name = pkg->Param<std::string>("rhs_name");
 
-  AllReduce<Real> global_res0;
-  AllReduce<Real> global_res;
-  AllReduce<Real> rhoi;
-  AllReduce<Real> r0_dot_vk;
-  AllReduce<Real> t_dot_s;
-  AllReduce<Real> t_dot_t;
+        const std::string bicg_id(std::to_string(global_num_bicgstab_solvers));
+        solver_name = "internal_bicgstab_" + bicg_id;
+
+        res0 = "res_0" + bicg_id;
+        std::vector<MetadataFlag> base_flags({Metadata::Node, Metadata::OneCopy});
+        base_flags.insert(base_flags.end(), user_flags.begin(), user_flags.end());
+        auto meta = Metadata(base_flags);
+        pkg->AddField(res0, meta);
+
+        vk = "vk" + bicg_id;
+        tk = "tk" + bicg_id;
+        auto flux_flags = base_flags;
+        flux_flags.push_back(Metadata::WithFluxes);
+        meta = Metadata(flux_flags);
+        pkg->AddField(vk, meta);
+        pkg->AddField(tk, meta);
+
+        res = "res" + bicg_id;
+        pk = "pk" + bicg_id;
+        temp = "temp" + bicg_id;
+        auto ghost_flags = base_flags;
+        ghost_flags.push_back(Metadata::FillGhost);
+        meta = Metadata(ghost_flags);
+        pkg->AddField(pk, meta);
+        pkg->AddField(res, meta);
+        pkg->AddField(temp, meta);
+
+        global_num_bicgstab_solvers++;
+    }
+
+    TaskID CreateTaskList(const TaskID& begin, const int i, TaskRegion& tr,
+        IterativeTasks& solver, std::shared_ptr<MeshData<Real>> md,
+        std::shared_ptr<MeshData<Real>> mout)
+    {
+        using Solver_t = BiCGStabSolver<SPType>;
+        using MD_t = MeshData<Real>;
+        TaskID none(0);
+        TaskList& tl = tr[i];
+        RegionCounter reg(solver_name);
+
+        // initialize some shared state
+        bicgstab_cntr = 0;
+        global_res0.val = 0.0;
+        global_res.val = 0.0;
+        rhoi.val = 0.0;
+        r0_dot_vk.val = 0.0;
+        t_dot_s.val = 0.0;
+        t_dot_t.val = 0.0;
+
+        auto MatVec = [this](auto& task_list, const TaskID& init_depend,
+                          std::shared_ptr<MeshData<Real>>& spmd,
+                          const std::string& name_in, const std::string& name_out)
+        {
+            auto precom = init_depend;
+            auto vec_name = name_in;
+            if (this->user_precomm_MatVec) {
+                precom = task_list.AddTask(init_depend, this->user_precomm_MatVec,
+                    spmd.get(), name_in, spmd.get(), this->temp);
+                vec_name = this->temp;
+            }
+            auto precom2 = precom;
+            if (this->user_precomm_scale) {
+                precom2 = task_list.AddTask(
+                    precom, this->user_precomm_scale, spmd.get(), vec_name);
+            }
+
+            // TODO(CEP) this is AddBoundaryExchangeTasks, would use that except it's not
+            // templated for special iterative lists
+            auto dependency = precom2;
+            auto& tl = task_list;
+            auto& md = spmd;
+            const auto any = BoundaryType::any;
+            auto send = tl.AddTask(dependency, SendBoundBufs<any>, md);
+            auto recv = tl.AddTask(dependency, ReceiveBoundBufs<any>, md);
+            auto set = tl.AddTask(recv, SetBounds<any>, md);
+
+            auto pro = set;
+            if (md->GetMeshPointer()->multilevel) {
+                auto cbound =
+                    tl.AddTask(set, ApplyBoundaryConditionsOnCoarseOrFineMD, md, true);
+                pro = tl.AddTask(cbound, ProlongateBounds<any>, md);
+            }
+            auto fbound =
+                tl.AddTask(pro, ApplyBoundaryConditionsOnCoarseOrFineMD, md, false);
+            auto boundaries = fbound;
+
+            auto postcomm = boundaries;
+            if (this->user_postcomm_scale) {
+                postcomm = task_list.AddTask(
+                    boundaries, this->user_postcomm_scale, spmd.get(), vec_name);
+            }
+
+            auto update_rhs = postcomm;
+            if (this->user_MatVec) {
+                auto preflx = boundaries;
+                if (this->user_pre_fluxcor) {
+                    auto calc_flx = task_list.AddTask(boundaries, this->user_pre_fluxcor,
+                        spmd.get(), vec_name, spmd.get(), name_out);
+                    auto send_flx = task_list.AddTask(
+                        calc_flx, parthenon::LoadAndSendFluxCorrections, spmd);
+                    auto recv_flx = task_list.AddTask(
+                        calc_flx, parthenon::ReceiveFluxCorrections, spmd);
+                    preflx =
+                        task_list.AddTask(recv_flx, parthenon::SetFluxCorrections, spmd);
+                }
+                update_rhs = task_list.AddTask(preflx, this->user_MatVec, spmd.get(),
+                    vec_name, spmd.get(), name_out);
+            } else {
+                update_rhs = task_list.AddTask(boundaries, &Solver_t::MatVec<MD_t>, this,
+                    spmd.get(), name_in, name_out);
+            }
+            return update_rhs;
+        };
+
+        auto get_init = MatVec(tl, begin, md, rhs_name, vk);
+
+        auto init_bicgstab = tl.AddTask(get_init, &Solver_t::InitializeBiCGStab<MD_t>,
+            this, md.get(), mout.get(), &global_res0.val);
+        tr.AddRegionalDependencies(reg.ID(), i, init_bicgstab);
+        // global reduction for initial residual
+        auto start_global_res0 =
+            (i == 0 ? tl.AddTask(init_bicgstab, &AllReduce<Real>::StartReduce,
+                          &global_res0, MPI_SUM)
+                    : init_bicgstab);
+        auto finish_global_res0 =
+            tl.AddTask(start_global_res0, &AllReduce<Real>::CheckReduce, &global_res0);
+        tr.AddRegionalDependencies(reg.ID(), i, finish_global_res0);
+
+        // 1. \hat{r}_0 \cdot r_{i-1}
+        auto get_rhoi = solver.AddTask(init_bicgstab, &Solver_t::DotProduct<MD_t>, this,
+            md.get(), res0, res, &rhoi.val);
+        tr.AddRegionalDependencies(reg.ID(), i, get_rhoi);
+        auto start_global_rhoi =
+            (i == 0 ? solver.AddTask(
+                          get_rhoi, &AllReduce<Real>::StartReduce, &rhoi, MPI_SUM)
+                    : get_rhoi);
+        auto finish_global_rhoi =
+            solver.AddTask(start_global_rhoi, &AllReduce<Real>::CheckReduce, &rhoi);
+
+        // 2. \beta = (rho_i/rho_{i-1}) (\alpha / \omega_{i-1})
+        // 3. p_i = r_{i-1} + \beta (p_{i-1} - \omega_{i-1} v_{i-1})
+        auto update_pk = solver.AddTask(
+            finish_global_rhoi, &Solver_t::Compute_pk<MD_t>, this, md.get());
+
+        // 4. v = A p
+        auto get_v = MatVec(solver, update_pk, md, pk, vk);
+
+        // 5. alpha = rho_i / (\hat{r}_0 \cdot v_i) [Actually just calculate \hat{r}_0
+        // \cdot v_i]
+        auto get_r0dotv = solver.AddTask(
+            get_v, &Solver_t::DotProduct<MD_t>, this, md.get(), res0, vk, &r0_dot_vk.val);
+        tr.AddRegionalDependencies(reg.ID(), i, get_r0dotv);
+        auto start_global_r0dotv =
+            (i == 0 ? solver.AddTask(
+                          get_r0dotv, &AllReduce<Real>::StartReduce, &r0_dot_vk, MPI_SUM)
+                    : get_r0dotv);
+        auto finish_global_r0dotv = solver.AddTask(
+            start_global_r0dotv, &AllReduce<Real>::CheckReduce, &r0_dot_vk);
+        // alpha is actually updated in this next task
+
+        // 6. h = x_{i-1} + alpha p [Really updates x_i]
+        // 7. check for convergence [Not actually done]
+        // 8. s = r_{i-1} - alpha v
+        auto get_s = solver.AddTask(finish_global_r0dotv, &Solver_t::Update_h_and_s<MD_t>,
+            this, md.get(), mout.get());
+
+        // 9. t = A s
+        auto get_t = MatVec(solver, get_s, md, res, tk);
+
+        // 10. omega = (t \cdot s) / (t \cdot t)
+        auto get_tdots = solver.AddTask(get_t, &Solver_t::OmegaDotProd<MD_t>, this,
+            md.get(), &t_dot_s.val, &t_dot_t.val);
+        tr.AddRegionalDependencies(reg.ID(), i, get_tdots);
+        auto start_global_tdots =
+            (i == 0 ? solver.AddTask(
+                          get_tdots, &AllReduce<Real>::StartReduce, &t_dot_s, MPI_SUM)
+                    : get_tdots);
+        auto finish_global_tdots =
+            solver.AddTask(start_global_tdots, &AllReduce<Real>::CheckReduce, &t_dot_s);
+        auto start_global_tdott =
+            (i == 0 ? solver.AddTask(
+                          get_tdots, &AllReduce<Real>::StartReduce, &t_dot_t, MPI_SUM)
+                    : get_tdots);
+        auto finish_global_tdott =
+            solver.AddTask(start_global_tdott, &AllReduce<Real>::CheckReduce, &t_dot_t);
+        // omega is actually updated in this next task
+
+        // 11. update x and residual
+        auto update_x = solver.AddTask(finish_global_tdots | finish_global_tdott,
+            &Solver_t::Update_x_res<MD_t>, this, md.get(), mout.get(), &global_res.val);
+        tr.AddRegionalDependencies(reg.ID(), i, update_x);
+        auto start_global_res =
+            (i == 0 ? solver.AddTask(
+                          update_x, &AllReduce<Real>::StartReduce, &global_res, MPI_SUM)
+                    : update_x);
+        auto finish_global_res =
+            solver.AddTask(start_global_res, &AllReduce<Real>::CheckReduce, &global_res);
+
+        // 12. check for convergence
+        auto check = solver.SetCompletionTask(
+            finish_global_res, &Solver_t::CheckConvergence, this, i, true);
+        tr.AddGlobalDependencies(reg.ID(), i, check);
+
+        return check;
+    }
+
+  public:
+    template<typename T>
+    TaskStatus InitializeBiCGStab(T* u, T* du, Real* gres0)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        std::vector<std::string> vars({res, res0, vk, pk, rhs_name});
+        const auto& v = u->PackVariables(vars, imap);
+        const int ires = imap[res].first;
+        const int ires0 = imap[res0].first;
+        const int ivk = imap[vk].first;
+        const int ipk = imap[pk].first;
+        const int irhs = imap[rhs_name].first;
+
+        const auto& dv = du->PackVariables(std::vector<std::string>({sol_name}));
+
+        rhoi_old = 1.0;
+        alpha_old = 1.0;
+        omega_old = 1.0;
+        Real err(0);
+        const Real fac0 = 0.0;
+        const Real fac = 0.0;
+        par_reduce(
+            loop_pattern_mdrange_tag, "initialize bicgstab", DevExecSpace(), 0,
+            v.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real& lerr)
+            {
+                // initialize guess for solution
+                dv(b, 0, k, j, i) = fac * v(b, irhs, k, j, i);
+
+                v(b, ires, k, j, i) = v(b, irhs, k, j, i) - fac * v(b, ivk, k, j, i);
+                v(b, ires0, k, j, i) = v(b, irhs, k, j, i) - fac0 * v(b, ivk, k, j, i);
+
+                v(b, ivk, k, j, i) = 0.0;
+                v(b, ipk, k, j, i) = 0.0;
+
+                lerr += v(b, irhs, k, j, i) * v(b, irhs, k, j, i);
+            },
+            Kokkos::Sum<Real>(err));
+        *gres0 += err;
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus update_r(T* u)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        std::vector<std::string> vars({res, rhs_name});
+        const auto& v = u->PackVariables(vars, imap);
+        const int ires = imap[res].first;
+        const int irhs = imap[rhs_name].first;
+
+        par_for(loop_pattern_mdrange_tag, "initialize bicgstab", DevExecSpace(), 0,
+            v.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int b, const int k, const int j, const int i)
+            {
+                v(b, ires, k, j, i) = v(b, irhs, k, j, i) - v(b, ires, k, j, i);
+            });
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus DotProduct(
+        T* u, const std::string& vec1, const std::string& vec2, Real* reduce_sum)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        auto& v = u->PackVariables(std::vector<std::string>({vec1, vec2}));
+
+        Real gsum(0);
+        par_reduce(
+            loop_pattern_mdrange_tag, "DotProduct", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real& lsum)
+            {
+                lsum += v(b, 0, k, j, i) * v(b, 1, k, j, i);
+            },
+            Kokkos::Sum<Real>(gsum));
+        *reduce_sum += gsum;
+        // printf("DotProduct: %s dot %s  = %e (%e)\n", vec1.c_str(), vec2.c_str(),
+        // *reduce_sum, gsum);
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus Compute_pk(T* u)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        auto& v = u->PackVariables(std::vector<std::string>({pk, res, vk, res0}), imap);
+        const int ipk = imap[pk].first;
+        const int ires = imap[res].first;
+        const int ires0 = imap[res0].first;
+        const int ivk = imap[vk].first;
+
+        const Real beta = (rhoi.val / rhoi_old) * (alpha_old / omega_old);
+        bool reset = false;
+        // if (std::abs(rhoi.val) < 1.e-8) {
+        //   // Reset
+        //   printf("Resetting (r_{i-1}, r_0) = %e res = %e \n", rhoi.val, res_old);
+        //   rhoi.val = res_old; // this should be the norm of the old residual, which we
+        //   are resetting to reset = true;
+        // }
+        // printf("Compute_pk: rho_i = %e rho_{i-1} = %e alpha_old = %e omega_old = %e
+        // beta = %e\n", rhoi.val, rhoi_old, alpha_old, omega_old, beta); rhoi_old =
+        // rhoi.val;
+        const Real w_o = omega_old;
+        par_for(DEFAULT_LOOP_PATTERN, "compute pk", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int b, const int k, const int j, const int i)
+            {
+                v(b, ipk, k, j, i) =
+                    v(b, ires, k, j, i) +
+                    beta * (v(b, ipk, k, j, i) - w_o * v(b, ivk, k, j, i));
+                if (reset) {
+                    v(b, ipk, k, j, i) = v(b, ires, k, j, i);
+                    v(b, ires0, k, j, i) = v(b, ires, k, j, i);
+                }
+            });
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus MatVec(T* u, const std::string& in_vec, const std::string& out_vec)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        auto& v =
+            u->PackVariables(std::vector<std::string>({in_vec, out_vec, spm_name}), imap);
+        const int iin = imap[in_vec].first;
+        const int iout = imap[out_vec].first;
+        const int isp_lo = imap[spm_name].first;
+        const int isp_hi = imap[spm_name].second;
+        SparseMatrixAccessor& r_sp_accessor = sp_accessor;
+
+        par_for(DEFAULT_LOOP_PATTERN, "MatVec", DevExecSpace(), 0, v.GetDim(5) - 1, kb.s,
+            kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int b, const int k, const int j, const int i)
+            {
+                v(b, iout, k, j, i) =
+                    r_sp_accessor.MatVec(v, isp_lo, isp_hi, v, iin, b, k, j, i);
+            });
+        // printf("MatVec: in_vec = %s out_vec = %s spm = %s\n", in_vec.c_str(),
+        // out_vec.c_str(), spm_name.c_str());
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus Update_h_and_s(T* u, T* du)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        auto& v = u->PackVariables(std::vector<std::string>({res, pk, vk}), imap);
+        auto& dv = du->PackVariables(std::vector<std::string>({sol_name}));
+        const int ires = imap[res].first;
+        const int ipk = imap[pk].first;
+        const int ivk = imap[vk].first;
+
+        Real alpha = rhoi.val / r0_dot_vk.val;
+        // printf("alpha = %e rho = %e (v, r_0) = %e\n", alpha, rhoi.val, r0_dot_vk.val);
+        if (std::abs(r0_dot_vk.val) < 1.e-200) alpha = 0.0;
+        par_for(DEFAULT_LOOP_PATTERN, "Update_h", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int b, const int k, const int j, const int i)
+            {
+                dv(b, 0, k, j, i) += alpha * v(b, ipk, k, j, i);
+                v(b, ires, k, j, i) -= alpha * v(b, ivk, k, j, i);
+            });
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus Update_h(T* u, T* du)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        auto& v = u->PackVariables(std::vector<std::string>({pk}));
+        auto& dv = du->PackVariables(std::vector<std::string>({sol_name}));
+        Real alpha = rhoi.val / r0_dot_vk.val;
+        // printf("Update_h: r0_dot_vk = %e rhoi = %e alpha = %e\n", r0_dot_vk.val,
+        // rhoi.val, alpha);
+        par_for(DEFAULT_LOOP_PATTERN, "Update_h", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int b, const int k, const int j, const int i)
+            {
+                dv(b, 0, k, j, i) += alpha * v(b, 0, k, j, i);
+            });
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus Update_s(T* u)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        auto& v = u->PackVariables(std::vector<std::string>({res, vk}), imap);
+        const int ires = imap[res].first;
+        const int ivk = imap[vk].first;
+        Real alpha = rhoi.val / r0_dot_vk.val;
+        // printf("Update_s: r0_dot_vk = %e rhoi = %e alpha = %e\n", r0_dot_vk.val,
+        // rhoi.val, alpha);
+        par_for(DEFAULT_LOOP_PATTERN, "Update_s", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int b, const int k, const int j, const int i)
+            {
+                v(b, ires, k, j, i) -= alpha * v(b, ivk, k, j, i);
+            });
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus OmegaDotProd(T* u, Real* t_dot_s, Real* t_dot_t)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        auto& v = u->PackVariables(std::vector<std::string>({tk, res}));
+
+        // TODO(JCD): these should probably be merged
+        Real ts_sum(0);
+        par_reduce(
+            loop_pattern_mdrange_tag, "tk dot sk", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real& lsum)
+            {
+                lsum += v(b, 0, k, j, i) * v(b, 1, k, j, i);
+            },
+            Kokkos::Sum<Real>(ts_sum));
+        *t_dot_s += ts_sum;
+
+        Real tt_sum(0);
+        par_reduce(
+            loop_pattern_mdrange_tag, "tk dot sk", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real& lsum)
+            {
+                lsum += v(b, 0, k, j, i) * v(b, 0, k, j, i);
+            },
+            Kokkos::Sum<Real>(tt_sum));
+        *t_dot_t += tt_sum;
+        // printf("OmegaDotProd: t_dot_s = %e (%e) t_dot_t = %e (%e)\n", *t_dot_s, ts_sum,
+        // *t_dot_t, tt_sum);
+        return TaskStatus::complete;
+    }
+
+    template<typename T>
+    TaskStatus Update_x_res(T* u, T* du, Real* gres)
+    {
+        const auto& ibi = u->GetBoundsI(IndexDomain::interior);
+        const auto& jbi = u->GetBoundsJ(IndexDomain::interior);
+        const auto& kbi = u->GetBoundsK(IndexDomain::interior);
+        const int ndim = u->GetMeshPointer()->ndim;
+        const auto ib = IndexRange{ibi.s, ibi.e + (ndim > 0)};
+        const auto jb = IndexRange{jbi.s, jbi.e + (ndim > 1)};
+        const auto kb = IndexRange{kbi.s, kbi.e + (ndim > 2)};
+
+        PackIndexMap imap;
+        auto& v = u->PackVariables(std::vector<std::string>({res, tk}), imap);
+        const int ires = imap[res].first;
+        const int itk = imap[tk].first;
+        auto& dv = du->PackVariables(std::vector<std::string>({sol_name}));
+        Real omega = t_dot_s.val / t_dot_t.val;
+        if (std::abs(t_dot_t.val) < 1.e-200) omega = 0.0;
+        Real err(0);
+        par_reduce(
+            loop_pattern_mdrange_tag, "Update_x", DevExecSpace(), 0, v.GetDim(5) - 1,
+            kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real& lerr)
+            {
+                dv(b, 0, k, j, i) += omega * v(b, ires, k, j, i);
+                v(b, ires, k, j, i) -= omega * v(b, itk, k, j, i);
+                lerr += v(b, ires, k, j, i) * v(b, ires, k, j, i);
+            },
+            Kokkos::Sum<Real>(err));
+        *gres += err;
+        return TaskStatus::complete;
+    }
+
+    TaskStatus CheckConvergence(const int& i, bool report)
+    {
+        if (i != 0) return TaskStatus::complete;
+        bicgstab_cntr++;
+        global_res.val = std::sqrt(global_res.val);
+        if (bicgstab_cntr == 1) global_res0.val = std::sqrt(global_res0.val);
+
+        // printf("rhoi: %e r0_dot_vk: %e t_dot_t: %e\n", rhoi.val, r0_dot_vk.val,
+        // t_dot_s.val);
+        //  Update global scalars
+        rhoi_old = rhoi.val;
+        alpha_old = rhoi.val / r0_dot_vk.val;
+        omega_old = t_dot_s.val / t_dot_t.val;
+        res_old = global_res.val;
+
+        bool converged = std::abs(global_res.val / global_res0.val) < rel_error_tol ||
+                         std::abs(global_res.val) < abs_error_tol;
+
+        bool stop = bicgstab_cntr == max_iters;
+        if (std::abs(alpha_old) < 1.e-8 && std::abs(omega_old) < 1.e-8) stop = true;
+        if (bicgstab_cntr % check_interval == 0) {
+            if (Globals::my_rank == 0) {
+                std::cout << " its= " << bicgstab_cntr << " rho= " << rhoi_old
+                          << " alpha= " << alpha_old << " omega= " << omega_old
+                          << " relative-res: " << global_res.val / global_res0.val
+                          << " absolute-res: " << global_res.val
+                          << " absolute-res0: " << global_res0.val
+                          << " relerr-tol: " << rel_error_tol
+                          << " abserr-tol: " << abs_error_tol << std::endl;
+            }
+        }
+
+        global_res.val = 0.0;
+        rhoi.val = 0.0;
+        r0_dot_vk.val = 0.0;
+        t_dot_s.val = 0.0;
+        t_dot_t.val = 0.0;
+
+        return converged || stop ? TaskStatus::complete : TaskStatus::iterate;
+    }
+
+  private:
+    Real rel_error_tol, abs_error_tol;
+    SparseMatrixAccessor sp_accessor;
+    int max_iters, check_interval, bicgstab_cntr;
+    bool fail_flag, warn_flag;
+    std::string spm_name, sol_name, rhs_name, res, res0, vk, pk, tk, temp, solver_name;
+
+    Real rhoi_old, alpha_old, omega_old, res_old;
+
+    AllReduce<Real> global_res0;
+    AllReduce<Real> global_res;
+    AllReduce<Real> rhoi;
+    AllReduce<Real> r0_dot_vk;
+    AllReduce<Real> t_dot_s;
+    AllReduce<Real> t_dot_t;
 };
 
 } // namespace solvers

--- a/kharma/b_cleanup/solver_utils.hpp
+++ b/kharma/b_cleanup/solver_utils.hpp
@@ -19,154 +19,185 @@
 #include "basic_types.hpp"
 #include "kokkos_abstraction.hpp"
 
-namespace parthenon {
+namespace parthenon
+{
 
-namespace solvers {
+namespace solvers
+{
 
-struct SparseMatrixAccessor {
-  ParArray1D<int> ioff, joff, koff;
-  ParArray1D<int> ioff_inv, joff_inv, koff_inv;
-  ParArray1D<int> inv_entries;
+struct SparseMatrixAccessor
+{
+    ParArray1D<int> ioff, joff, koff;
+    ParArray1D<int> ioff_inv, joff_inv, koff_inv;
+    ParArray1D<int> inv_entries;
 
-  const int nstencil;
-  int ndiag;
-  SparseMatrixAccessor() : nstencil(0), ndiag(0) {}
-  SparseMatrixAccessor(const SparseMatrixAccessor &sp)
-      : ioff(sp.ioff), joff(sp.joff), koff(sp.koff), nstencil(sp.nstencil),
-        ndiag(sp.ndiag), inv_entries(sp.inv_entries) {}
-  SparseMatrixAccessor(const std::string &label, const int n,
-                       std::vector<std::vector<int>> off)
-      : ioff(label + "_ioff", n), joff(label + "_joff", n), koff(label + "_koff", n),
-        ioff_inv(label + "_ioff_inv", n), joff_inv(label + "_joff_inv", n),
-        koff_inv(label + "_koff_inv", n), inv_entries(label + "_inv_ent", n),
-        nstencil(n) {
-    PARTHENON_REQUIRE_THROWS(off.size() == 3,
-                             "Offset array must have dimensions off[3][*]");
-    PARTHENON_REQUIRE_THROWS(off[0].size() >= n, "Offset array off[0][*] too small");
-    PARTHENON_REQUIRE_THROWS(off[1].size() >= n, "Offset array off[1][*] too small");
-    PARTHENON_REQUIRE_THROWS(off[2].size() >= n, "Offset array off[2][*] too small");
-    auto ioff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), ioff);
-    auto joff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), joff);
-    auto koff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), koff);
+    const int nstencil;
+    int ndiag;
+    SparseMatrixAccessor()
+        : nstencil(0)
+        , ndiag(0)
+    {}
+    SparseMatrixAccessor(const SparseMatrixAccessor& sp)
+        : ioff(sp.ioff)
+        , joff(sp.joff)
+        , koff(sp.koff)
+        , nstencil(sp.nstencil)
+        , ndiag(sp.ndiag)
+        , inv_entries(sp.inv_entries)
+    {}
+    SparseMatrixAccessor(
+        const std::string& label, const int n, std::vector<std::vector<int>> off)
+        : ioff(label + "_ioff", n)
+        , joff(label + "_joff", n)
+        , koff(label + "_koff", n)
+        , ioff_inv(label + "_ioff_inv", n)
+        , joff_inv(label + "_joff_inv", n)
+        , koff_inv(label + "_koff_inv", n)
+        , inv_entries(label + "_inv_ent", n)
+        , nstencil(n)
+    {
+        PARTHENON_REQUIRE_THROWS(
+            off.size() == 3, "Offset array must have dimensions off[3][*]");
+        PARTHENON_REQUIRE_THROWS(off[0].size() >= n, "Offset array off[0][*] too small");
+        PARTHENON_REQUIRE_THROWS(off[1].size() >= n, "Offset array off[1][*] too small");
+        PARTHENON_REQUIRE_THROWS(off[2].size() >= n, "Offset array off[2][*] too small");
+        auto ioff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), ioff);
+        auto joff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), joff);
+        auto koff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), koff);
 
-    auto ioff_inv_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), ioff_inv);
-    auto joff_inv_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), joff_inv);
-    auto koff_inv_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), koff_inv);
+        auto ioff_inv_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), ioff_inv);
+        auto joff_inv_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), joff_inv);
+        auto koff_inv_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), koff_inv);
 
-    auto inv_ent_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), inv_entries);
+        auto inv_ent_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), inv_entries);
 
-    for (int i = 0; i < n; i++) {
-      ioff_h(i) = off[0][i];
-      joff_h(i) = off[1][i];
-      koff_h(i) = off[2][i];
-      // this is inverse.
-      ioff_inv_h(i) = -off[0][i];
-      joff_inv_h(i) = -off[1][i];
-      koff_inv_h(i) = -off[2][i];
+        for (int i = 0; i < n; i++) {
+            ioff_h(i) = off[0][i];
+            joff_h(i) = off[1][i];
+            koff_h(i) = off[2][i];
+            // this is inverse.
+            ioff_inv_h(i) = -off[0][i];
+            joff_inv_h(i) = -off[1][i];
+            koff_inv_h(i) = -off[2][i];
 
-      if (off[0][i] == 0 && off[1][i] == 0 && off[2][i] == 0) {
-        ndiag = i;
-      }
-    }
-    for (int i = 0; i < n; i++) {
-      for (int j = 0; j < n; j++) {
-        if (ioff_h(i) == ioff_inv_h(j) && joff_h(i) == joff_inv_h(j) &&
-            koff_h(i) == koff_inv_h(j)) {
-          inv_entries(i) = j;
-          std::cout << "inv_entries:" << i << " " << j << std::endl;
+            if (off[0][i] == 0 && off[1][i] == 0 && off[2][i] == 0) {
+                ndiag = i;
+            }
         }
-      } // j
-    }   // i
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (ioff_h(i) == ioff_inv_h(j) && joff_h(i) == joff_inv_h(j) &&
+                    koff_h(i) == koff_inv_h(j)) {
+                    inv_entries(i) = j;
+                    std::cout << "inv_entries:" << i << " " << j << std::endl;
+                }
+            } // j
+        } // i
 
-    Kokkos::deep_copy(ioff, ioff_h);
-    Kokkos::deep_copy(joff, joff_h);
-    Kokkos::deep_copy(koff, koff_h);
+        Kokkos::deep_copy(ioff, ioff_h);
+        Kokkos::deep_copy(joff, joff_h);
+        Kokkos::deep_copy(koff, koff_h);
 
-    Kokkos::deep_copy(inv_entries, inv_ent_h);
-  }
-
-  template <typename PackType>
-  KOKKOS_INLINE_FUNCTION Real MatVec(const PackType &spmat, const int imat_lo,
-                                     const int imat_hi, const PackType &v, const int iv,
-                                     const int b, const int k, const int j,
-                                     const int i) const {
-    Real matvec = 0.0;
-    for (int n = imat_lo; n <= imat_hi; n++) {
-      const int m = n - imat_lo;
-      matvec += spmat(b, n, k, j, i) * v(b, iv, k + koff(m), j + joff(m), i + ioff(m));
+        Kokkos::deep_copy(inv_entries, inv_ent_h);
     }
-    return matvec;
-  }
 
-  template <typename PackType>
-  KOKKOS_INLINE_FUNCTION Real Jacobi(const PackType &spmat, const int imat_lo,
-                                     const int imat_hi, const PackType &v, const int iv,
-                                     const int b, const int k, const int j, const int i,
-                                     const Real rhs) const {
-    const Real matvec = MatVec(spmat, imat_lo, imat_hi, v, iv, b, k, j, i);
-    return (rhs - matvec + spmat(b, imat_lo + ndiag, k, j, i) * v(b, iv, k, j, i)) /
-           spmat(b, imat_lo + ndiag, k, j, i);
-  }
+    template<typename PackType>
+    KOKKOS_INLINE_FUNCTION Real MatVec(const PackType& spmat, const int imat_lo,
+        const int imat_hi, const PackType& v, const int iv, const int b, const int k,
+        const int j, const int i) const
+    {
+        Real matvec = 0.0;
+        for (int n = imat_lo; n <= imat_hi; n++) {
+            const int m = n - imat_lo;
+            matvec +=
+                spmat(b, n, k, j, i) * v(b, iv, k + koff(m), j + joff(m), i + ioff(m));
+        }
+        return matvec;
+    }
+
+    template<typename PackType>
+    KOKKOS_INLINE_FUNCTION Real Jacobi(const PackType& spmat, const int imat_lo,
+        const int imat_hi, const PackType& v, const int iv, const int b, const int k,
+        const int j, const int i, const Real rhs) const
+    {
+        const Real matvec = MatVec(spmat, imat_lo, imat_hi, v, iv, b, k, j, i);
+        return (rhs - matvec + spmat(b, imat_lo + ndiag, k, j, i) * v(b, iv, k, j, i)) /
+               spmat(b, imat_lo + ndiag, k, j, i);
+    }
 };
 
-template <typename T>
-struct Stencil {
-  ParArray1D<T> w;
-  ParArray1D<int> ioff, joff, koff;
-  const int nstencil;
-  int ndiag;
-  Stencil() : nstencil(0), ndiag(0) {}
-  Stencil(const Stencil<T> &st)
-      : w(st.w), ioff(st.ioff), joff(st.joff), koff(st.koff), nstencil(st.nstencil),
-        ndiag(st.ndiag) {}
-  Stencil(const std::string &label, const int n, std::vector<T> wgt,
-          std::vector<std::vector<int>> off)
-      : w(label + "_w", n), ioff(label + "_ioff", n), joff(label + "_joff", n),
-        koff(label + "_koff", n), nstencil(n) {
-    PARTHENON_REQUIRE_THROWS(off.size() == 3,
-                             "Offset array must have dimensions off[3][*]");
-    PARTHENON_REQUIRE_THROWS(wgt.size() >= n, "Weight array too small");
-    PARTHENON_REQUIRE_THROWS(off[0].size() >= n, "Offset array off[0][*] too small");
-    PARTHENON_REQUIRE_THROWS(off[1].size() >= n, "Offset array off[1][*] too small");
-    PARTHENON_REQUIRE_THROWS(off[2].size() >= n, "Offset array off[2][*] too small");
-    auto w_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), w);
-    auto ioff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), ioff);
-    auto joff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), joff);
-    auto koff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), koff);
+template<typename T>
+struct Stencil
+{
+    ParArray1D<T> w;
+    ParArray1D<int> ioff, joff, koff;
+    const int nstencil;
+    int ndiag;
+    Stencil()
+        : nstencil(0)
+        , ndiag(0)
+    {}
+    Stencil(const Stencil<T>& st)
+        : w(st.w)
+        , ioff(st.ioff)
+        , joff(st.joff)
+        , koff(st.koff)
+        , nstencil(st.nstencil)
+        , ndiag(st.ndiag)
+    {}
+    Stencil(const std::string& label, const int n, std::vector<T> wgt,
+        std::vector<std::vector<int>> off)
+        : w(label + "_w", n)
+        , ioff(label + "_ioff", n)
+        , joff(label + "_joff", n)
+        , koff(label + "_koff", n)
+        , nstencil(n)
+    {
+        PARTHENON_REQUIRE_THROWS(
+            off.size() == 3, "Offset array must have dimensions off[3][*]");
+        PARTHENON_REQUIRE_THROWS(wgt.size() >= n, "Weight array too small");
+        PARTHENON_REQUIRE_THROWS(off[0].size() >= n, "Offset array off[0][*] too small");
+        PARTHENON_REQUIRE_THROWS(off[1].size() >= n, "Offset array off[1][*] too small");
+        PARTHENON_REQUIRE_THROWS(off[2].size() >= n, "Offset array off[2][*] too small");
+        auto w_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), w);
+        auto ioff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), ioff);
+        auto joff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), joff);
+        auto koff_h = Kokkos::create_mirror_view(Kokkos::HostSpace(), koff);
 
-    for (int i = 0; i < n; i++) {
-      w_h(i) = wgt[i];
-      ioff_h(i) = off[0][i];
-      joff_h(i) = off[1][i];
-      koff_h(i) = off[2][i];
-      if (off[0][i] == 0 && off[1][i] == 0 && off[2][i] == 0) {
-        ndiag = i;
-      }
+        for (int i = 0; i < n; i++) {
+            w_h(i) = wgt[i];
+            ioff_h(i) = off[0][i];
+            joff_h(i) = off[1][i];
+            koff_h(i) = off[2][i];
+            if (off[0][i] == 0 && off[1][i] == 0 && off[2][i] == 0) {
+                ndiag = i;
+            }
+        }
+
+        Kokkos::deep_copy(w, w_h);
+        Kokkos::deep_copy(ioff, ioff_h);
+        Kokkos::deep_copy(joff, joff_h);
+        Kokkos::deep_copy(koff, koff_h);
     }
 
-    Kokkos::deep_copy(w, w_h);
-    Kokkos::deep_copy(ioff, ioff_h);
-    Kokkos::deep_copy(joff, joff_h);
-    Kokkos::deep_copy(koff, koff_h);
-  }
-
-  template <typename PackType>
-  KOKKOS_INLINE_FUNCTION Real MatVec(const PackType &v, const int iv, const int b,
-                                     const int k, const int j, const int i) const {
-    Real matvec = 0.0;
-    for (int n = 0; n < nstencil; n++) {
-      matvec += w(n) * v(b, iv, k + koff(n), j + joff(n), i + ioff(n));
+    template<typename PackType>
+    KOKKOS_INLINE_FUNCTION Real MatVec(const PackType& v, const int iv, const int b,
+        const int k, const int j, const int i) const
+    {
+        Real matvec = 0.0;
+        for (int n = 0; n < nstencil; n++) {
+            matvec += w(n) * v(b, iv, k + koff(n), j + joff(n), i + ioff(n));
+        }
+        return matvec;
     }
-    return matvec;
-  }
 
-  template <typename PackType>
-  KOKKOS_INLINE_FUNCTION Real Jacobi(const PackType &v, const int iv, const int b,
-                                     const int k, const int j, const int i,
-                                     const Real rhs) const {
-    const Real matvec = MatVec(v, iv, b, k, j, i);
-    return (rhs - matvec + w(ndiag) * v(b, iv, k, j, i)) / w(ndiag);
-  }
+    template<typename PackType>
+    KOKKOS_INLINE_FUNCTION Real Jacobi(const PackType& v, const int iv, const int b,
+        const int k, const int j, const int i, const Real rhs) const
+    {
+        const Real matvec = MatVec(v, iv, b, k, j, i);
+        return (rhs - matvec + w(ndiag) * v(b, iv, k, j, i)) / w(ndiag);
+    }
 };
 
 } // namespace solvers

--- a/kharma/b_cleanup/solvers.cpp
+++ b/kharma/b_cleanup/solvers.cpp
@@ -17,8 +17,10 @@
 
 #include "bicgstab_solver.hpp"
 
-namespace parthenon {
-namespace solvers {
+namespace parthenon
+{
+namespace solvers
+{
 
 int BiCGStabCounter::global_num_bicgstab_solvers = 0;
 

--- a/kharma/b_cleanup_gmg/b_cleanup_gmg.cpp
+++ b/kharma/b_cleanup_gmg/b_cleanup_gmg.cpp
@@ -55,8 +55,12 @@
 
 // The package should never be loaded if there is not a global solve to be done.
 // Therefore we yell at load time rather than waiting for the first solve
-std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
-{throw std::runtime_error("KHARMA was compiled without global solvers!  Cannot clean B Field!");}
+std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
+{
+    throw std::runtime_error(
+        "KHARMA was compiled without global solvers!  Cannot clean B Field!");
+}
 // We still need some stubs to compile
 // TODO throw to ensure these aren't called if package isn't loaded?
 TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
@@ -66,30 +70,44 @@ TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
 
 #else
 
-std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("B_CleanupGMG");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Set boundary conditions for Poisson variables
     using BF = parthenon::BoundaryFace;
-    //pkg->UserBoundaryFunctions[BF::inner_x1].push_back(GetBCReflecting<X1DIR, BCSide::Inner>());
-    pkg->UserBoundaryFunctions[BF::outer_x1].push_back(GetBCReflecting<X1DIR, BCSide::Outer>());
-    pkg->UserBoundaryFunctions[BF::inner_x2].push_back(GetBCReflecting<X2DIR, BCSide::Inner>());
-    pkg->UserBoundaryFunctions[BF::outer_x2].push_back(GetBCReflecting<X2DIR, BCSide::Outer>());
-    // pkg->UserBoundaryFunctions[BF::inner_x3].push_back(GetBCReflecting<X3DIR, BCSide::Inner>());
-    // pkg->UserBoundaryFunctions[BF::outer_x3].push_back(GetBCReflecting<X3DIR, BCSide::Outer>());
+    // pkg->UserBoundaryFunctions[BF::inner_x1].push_back(GetBCReflecting<X1DIR,
+    // BCSide::Inner>());
+    pkg->UserBoundaryFunctions[BF::outer_x1].push_back(
+        GetBCReflecting<X1DIR, BCSide::Outer>());
+    pkg->UserBoundaryFunctions[BF::inner_x2].push_back(
+        GetBCReflecting<X2DIR, BCSide::Inner>());
+    pkg->UserBoundaryFunctions[BF::outer_x2].push_back(
+        GetBCReflecting<X2DIR, BCSide::Outer>());
+    // pkg->UserBoundaryFunctions[BF::inner_x3].push_back(GetBCReflecting<X3DIR,
+    // BCSide::Inner>());
+    // pkg->UserBoundaryFunctions[BF::outer_x3].push_back(GetBCReflecting<X3DIR,
+    // BCSide::Outer>());
 
-    pkg->UserBoundaryFunctions[BF::inner_x1].push_back(GetBCDirichlet<X1DIR, BCSide::Inner>());
-    // pkg->UserBoundaryFunctions[BF::outer_x1].push_back(GetBCDirichlet<X1DIR, BCSide::Outer>());
-    // pkg->UserBoundaryFunctions[BF::inner_x2].push_back(GetBCDirichlet<X2DIR, BCSide::Inner>());
-    // pkg->UserBoundaryFunctions[BF::outer_x2].push_back(GetBCDirichlet<X2DIR, BCSide::Outer>());
-    // pkg->UserBoundaryFunctions[BF::inner_x3].push_back(GetBCDirichlet<X3DIR, BCSide::Inner>());
-    // pkg->UserBoundaryFunctions[BF::outer_x3].push_back(GetBCDirichlet<X3DIR, BCSide::Outer>());
+    pkg->UserBoundaryFunctions[BF::inner_x1].push_back(
+        GetBCDirichlet<X1DIR, BCSide::Inner>());
+    // pkg->UserBoundaryFunctions[BF::outer_x1].push_back(GetBCDirichlet<X1DIR,
+    // BCSide::Outer>());
+    // pkg->UserBoundaryFunctions[BF::inner_x2].push_back(GetBCDirichlet<X2DIR,
+    // BCSide::Inner>());
+    // pkg->UserBoundaryFunctions[BF::outer_x2].push_back(GetBCDirichlet<X2DIR,
+    // BCSide::Outer>());
+    // pkg->UserBoundaryFunctions[BF::inner_x3].push_back(GetBCDirichlet<X3DIR,
+    // BCSide::Inner>());
+    // pkg->UserBoundaryFunctions[BF::outer_x3].push_back(GetBCDirichlet<X3DIR,
+    // BCSide::Outer>());
 
     double init_tolerance = pin->GetOrAddReal("b_cleanup", "no_clean_below", 1.e-10);
     pkg->AddParam<>("init_tolerance", init_tolerance);
-    bool use_normalized_divb = pin->GetOrAddBoolean("b_cleanup", "use_normalized_divb", false);
+    bool use_normalized_divb =
+        pin->GetOrAddBoolean("b_cleanup", "use_normalized_divb", false);
     params.Add("use_normalized_divb", use_normalized_divb);
 
     Real diagonal_alpha = pin->GetOrAddReal("b_cleanup", "diagonal_alpha", 0.0);
@@ -102,24 +120,25 @@ std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(ParameterInput *pin, std
     pkg->AddParam<>("tolerance", tolerance);
     pin->SetReal("b_cleanup/solver_params", "residual_tolerance", tolerance);
 
-    std::string prolong = pin->GetOrAddString("b_cleanup", "boundary_prolongation", "Linear");
+    std::string prolong =
+        pin->GetOrAddString("b_cleanup", "boundary_prolongation", "Linear");
 
     using PoissEq = PoissonEquation<p>;
     using prolongator_t = parthenon::solvers::ProlongationBlockInteriorZeroDirichlet;
-    using preconditioner_t =
-        parthenon::solvers::MGSolver<PoissEq, prolongator_t>;
+    using preconditioner_t = parthenon::solvers::MGSolver<PoissEq, prolongator_t>;
 
     std::shared_ptr<parthenon::solvers::SolverBase> psolver;
     PoissEq poisson = PoissEq(pin, "b_cleanup");
     //   if (solver == "MG") {
     //     parthenon::solvers::MGParams params(pin, "b_cleanup/solver_params");
-    //     psolver = std::make_shared<parthenon::solvers::MGSolver<p, rhs, PoissonEquation>>(
+    //     psolver = std::make_shared<parthenon::solvers::MGSolver<p, rhs,
+    //     PoissonEquation>>(
     //         pkg.get(), params, eq);
     //   } else
     if (solver == "CG") {
-        psolver = std::make_shared<
-            parthenon::solvers::CGSolver<PoissEq, preconditioner_t>>(
-            "base", "p", "rhs", pin, "b_cleanup/solver_params", poisson);
+        psolver =
+            std::make_shared<parthenon::solvers::CGSolver<PoissEq, preconditioner_t>>(
+                "base", "p", "rhs", pin, "b_cleanup/solver_params", poisson);
     } else if (solver == "BiCGSTAB") {
         psolver = std::make_shared<
             parthenon::solvers::BiCGSTABSolver<PoissEq, preconditioner_t>>(
@@ -133,8 +152,8 @@ std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(ParameterInput *pin, std
     // Setup flags for the solve variable "p"
     using namespace parthenon::refinement_ops;
     std::vector<MetadataFlag> flags{Metadata::Cell, Metadata::Independent,
-                                    Metadata::FillGhost, Metadata::WithFluxes,
-                                    Metadata::GMGRestrict, Metadata::GetUserFlag("StartupOnly")};
+        Metadata::FillGhost, Metadata::WithFluxes, Metadata::GMGRestrict,
+        Metadata::GetUserFlag("StartupOnly")};
     if (solver == "CG" || solver == "BiCGSTAB") {
         flags.push_back(Metadata::GMGProlongate);
     }
@@ -146,24 +165,25 @@ std::shared_ptr<KHARMAPackage> B_CleanupGMG::Initialize(ParameterInput *pin, std
     } else {
         PARTHENON_FAIL("Unknown prolongation method for Poisson boundaries.");
     }
-    mflux_comm.SetFluxName("custom_flux::"+p::name());
+    mflux_comm.SetFluxName("custom_flux::" + p::name());
 
     // Setup flux of the solve variable manually, as we need to sync its ghosts always,
     // not just for flux corrections
-    std::vector<MetadataFlag> flux_flags{Metadata::Face, Metadata::Derived, Metadata::OneCopy,
-                                    //Metadata::FillGhost, //Metadata::Flux,
-                                    Metadata::GetUserFlag("StartupOnly")};
+    std::vector<MetadataFlag> flux_flags{Metadata::Face, Metadata::Derived,
+        Metadata::OneCopy,
+        // Metadata::FillGhost, //Metadata::Flux,
+        Metadata::GetUserFlag("StartupOnly")};
     auto mflux = Metadata(flux_flags);
 
     // Declare them
     pkg->AddField(p::name(), mflux_comm);
-    pkg->AddField("custom_flux::"+p::name(), mflux);
+    pkg->AddField("custom_flux::" + p::name(), mflux);
 
     // rhs is the field that contains the desired rhs side
     auto m_rhs = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy,
-                           Metadata::GetUserFlag("StartupOnly")});
+        Metadata::GetUserFlag("StartupOnly")});
     pkg->AddField(rhs::name(), m_rhs);
-//#endif
+    // #endif
     return pkg;
 }
 
@@ -177,14 +197,16 @@ TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
 
     auto verbose = pmesh->packages.Get("Globals")->Param<int>("verbose");
 
-    //if (!pmesh->multigrid) throw std::runtime_error("Cannot clean w/GMG if Mesh not marked multigrid!  Set parthenon/mesh/multigrid=true!");
+    // if (!pmesh->multigrid) throw std::runtime_error("Cannot clean w/GMG if Mesh not
+    // marked multigrid!  Set parthenon/mesh/multigrid=true!");
 
     // auto fail_flag = pkg->Param<bool>("fail_without_convergence");
     // auto warn_flag = pkg->Param<bool>("warn_without_convergence");
     if (MPIRank0() && verbose > 0) {
         std::cout << "Cleaning divB to tolerance " << tolerance << std::endl;
-        // if (warn_flag) std::cout << "Convergence failure will produce a warning." << std::endl;
-        // if (fail_flag) std::cout << "Convergence failure will produce an error." << std::endl;
+        // if (warn_flag) std::cout << "Convergence failure will produce a warning." <<
+        // std::endl; if (fail_flag) std::cout << "Convergence failure will produce an
+        // error." << std::endl;
     }
 
     // Calculate/print inital max divB exactly as we would during run
@@ -193,11 +215,13 @@ TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
     if (divb_start < init_tolerance) {
         // If divB is "pretty good" and we allow not solving...
         if (MPIRank0())
-            std::cout << "Magnetic field divergence of " << divb_start << " is below tolerance. Skipping B field cleanup." << std::endl;
+            std::cout << "Magnetic field divergence of " << divb_start
+                      << " is below tolerance. Skipping B field cleanup." << std::endl;
         return TaskStatus::complete;
     } else {
-        if(MPIRank0())
-            std::cout << "Starting magnetic field divergence: " << divb_start << std::endl;
+        if (MPIRank0())
+            std::cout << "Starting magnetic field divergence: " << divb_start
+                      << std::endl;
     }
 
     // Initialize the divB variable, which we'll be solving against.
@@ -211,28 +235,31 @@ TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
         const IndexRange ib = md->GetBoundsI(IndexDomain::entire);
         const IndexRange jb = md->GetBoundsJ(IndexDomain::entire);
         const IndexRange kb = md->GetBoundsK(IndexDomain::entire);
-        pmb0->par_for("normalize_divB", 0, divb_rhs.GetDim(5)-1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        pmb0->par_for("normalize_divB", 0, divb_rhs.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e,
+            ib.s, ib.e,
+                      KOKKOS_LAMBDA(const int& b, const int& k, const int& j,
+                                    const int& i)
+            {
                 const auto& G = divb_rhs.GetCoords(b);
                 divb_rhs(b, CC, 0, k, j, i) /= G.gdet(Loci::center, j, i);
-            }
-        );
+            });
     }
 
     // make sure RHS is sync'd
-    //KHARMADriver::SyncAllBounds(md);
+    // KHARMADriver::SyncAllBounds(md);
 
     // Pull a switcheroo: avoid calling KHARMA's boundaries during this solve, ever.
     auto bound_pkg = pmesh->packages.Get<KHARMAPackage>("Boundaries");
     for (int i_bnd = 0; i_bnd < BOUNDARY_NFACES; i_bnd++) {
-        auto bface = (BoundaryFace) i_bnd;
+        auto bface = (BoundaryFace)i_bnd;
         pkg->KBoundaries[bface] = bound_pkg->KBoundaries[bface];
         bound_pkg->KBoundaries[bface] = nullptr;
     }
 
     std::cerr << "STARTING SOLVE" << std::endl;
     // Execute the solve
-    // Solver only syncs what it needs, so we don't need the container trick from B_Cleanup
+    // Solver only syncs what it needs, so we don't need the container trick from
+    // B_Cleanup
     MakeSolverTaskCollection(pmesh).Execute();
 
     // Recalculate divB max for post-solve check
@@ -243,7 +270,7 @@ TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
     }
 
     for (int i_bnd = 0; i_bnd < BOUNDARY_NFACES; i_bnd++) {
-        auto bface = (BoundaryFace) i_bnd;
+        auto bface = (BoundaryFace)i_bnd;
         bound_pkg->KBoundaries[bface] = pkg->KBoundaries[bface];
     }
 
@@ -262,7 +289,7 @@ TaskStatus B_CleanupGMG::CleanupDivergence(std::shared_ptr<MeshData<Real>>& md)
     return TaskStatus::complete;
 }
 
-TaskStatus B_CleanupGMG::ApplyPFace(MeshData<Real> *msolve, MeshData<Real> *md)
+TaskStatus B_CleanupGMG::ApplyPFace(MeshData<Real>* msolve, MeshData<Real>* md)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -275,13 +302,13 @@ TaskStatus B_CleanupGMG::ApplyPFace(MeshData<Real> *msolve, MeshData<Real> *md)
     // Apply on all physical faces, we'll be syncing/updating ghosts
     const IndexRange3 b = KDomain::GetRange(msolve, IndexDomain::interior, 0, 1);
     pmb0->par_for("gradient_P", 0, P.GetDim(5) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
             B(b, F1, 0, k, j, i) += P(b).flux(X1DIR, 0, k, j, i);
             B(b, F2, 0, k, j, i) += P(b).flux(X2DIR, 0, k, j, i);
             B(b, F3, 0, k, j, i) += P(b).flux(X3DIR, 0, k, j, i);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/b_cleanup_gmg/b_cleanup_gmg.hpp
+++ b/kharma/b_cleanup_gmg/b_cleanup_gmg.hpp
@@ -45,18 +45,21 @@ using namespace parthenon;
 using parthenon::BoundaryFunction::BCSide;
 
 #define VARIABLE(ns, varname)                                                            \
-  struct varname : public parthenon::variable_names::base_t<false> {                     \
-    template <class... Ts>                                                               \
-    KOKKOS_INLINE_FUNCTION varname(Ts &&...args)                                         \
-        : parthenon::variable_names::base_t<false>(std::forward<Ts>(args)...) {}         \
-    static std::string name() { return #ns "." #varname; }                               \
-  }
+    struct varname : public parthenon::variable_names::base_t<false>                     \
+    {                                                                                    \
+        template<class... Ts>                                                            \
+        KOKKOS_INLINE_FUNCTION varname(Ts&&... args)                                     \
+            : parthenon::variable_names::base_t<false>(std::forward<Ts>(args)...)        \
+        {}                                                                               \
+        static std::string name() { return #ns "." #varname; }                           \
+    }
 
 /**
  * This physics package uses Parthenon's Geometric Multigrid (GMG) solver to
  * minimize magnetic field divergence.  Only useful for resizing face-centered fields.
  */
-namespace B_CleanupGMG {
+namespace B_CleanupGMG
+{
 
 // New type-based variables: pre-declare variable names and get the VarMap() for free!
 // All of KHARMA will be switching to these eventually...
@@ -66,37 +69,44 @@ VARIABLE(b_clean_gmg, rhs);
 // Build type that selects only variables within our namespace. Internal solver
 // variables have the namespace of input variables prepended, so they will also be
 // selected by this type.
-struct any_bclean : public parthenon::variable_names::base_t<true> {
-  template <class... Ts>
-  KOKKOS_INLINE_FUNCTION any_bclean(Ts &&...args)
-      : base_t<true>(std::forward<Ts>(args)...) {}
-  static std::string name() { return "b_clean_gmg[.].*"; }
+struct any_bclean : public parthenon::variable_names::base_t<true>
+{
+    template<class... Ts>
+    KOKKOS_INLINE_FUNCTION any_bclean(Ts&&... args)
+        : base_t<true>(std::forward<Ts>(args)...)
+    {}
+    static std::string name() { return "b_clean_gmg[.].*"; }
 };
 
 // Pointwise Dirichet boundaries adapted for GMG, if we need those
-template <CoordinateDirection DIR, BCSide SIDE>
-auto GetBCDirichlet() {
-  return [](std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse) -> void {
-    using namespace parthenon;
-    using namespace parthenon::BoundaryFunction;
-    GenericBC<DIR, SIDE, BCType::FixedFace, any_bclean>(rc, coarse, 0.0);
-  };
+template<CoordinateDirection DIR, BCSide SIDE>
+auto GetBCDirichlet()
+{
+    return [](std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse) -> void
+    {
+        using namespace parthenon;
+        using namespace parthenon::BoundaryFunction;
+        GenericBC<DIR, SIDE, BCType::FixedFace, any_bclean>(rc, coarse, 0.0);
+    };
 }
 
 // Pointwise Dirichet boundaries adapted for GMG, if we need those
-template <CoordinateDirection DIR, BCSide SIDE>
-auto GetBCReflecting() {
-  return [](std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse) -> void {
-    using namespace parthenon;
-    using namespace parthenon::BoundaryFunction;
-    GenericBC<DIR, SIDE, BCType::Reflect, any_bclean>(rc, coarse);
-  };
+template<CoordinateDirection DIR, BCSide SIDE>
+auto GetBCReflecting()
+{
+    return [](std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse) -> void
+    {
+        using namespace parthenon;
+        using namespace parthenon::BoundaryFunction;
+        GenericBC<DIR, SIDE, BCType::Reflect, any_bclean>(rc, coarse);
+    };
 }
 
 /**
  * Declare fields, initialize parameters
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Single-call divergence cleanup.  Lots of MPI syncs, probably slow to use in task lists.
@@ -106,7 +116,7 @@ TaskStatus CleanupDivergence(std::shared_ptr<MeshData<Real>>& md);
 /**
  * Apply B -= grad(P) on faces to subtract divergence from the magnetic field
  */
-TaskStatus ApplyPFace(MeshData<Real> *msolve, MeshData<Real> *md);
+TaskStatus ApplyPFace(MeshData<Real>* msolve, MeshData<Real>* md);
 
 /**
  * Function to make this solver's task collection.

--- a/kharma/b_cleanup_gmg/poisson_equation.hpp
+++ b/kharma/b_cleanup_gmg/poisson_equation.hpp
@@ -24,7 +24,8 @@
 #include "b_cleanup_gmg.hpp"
 #include "domain.hpp"
 
-namespace B_CleanupGMG {
+namespace B_CleanupGMG
+{
 
 constexpr parthenon::TopologicalElement te = parthenon::TopologicalElement::CC;
 
@@ -35,261 +36,295 @@ constexpr parthenon::TopologicalElement te = parthenon::TopologicalElement::CC;
 // SetDiagonal need to be defined for interfacing this with solvers. The other methods
 // are internal, but can't be marked private or protected because they launch kernels
 // on device.
-template <class var_t>
-class PoissonEquation {
- public:
-  bool do_flux_cor = true;
-  bool set_flux_boundary = true;
-  bool include_flux_dx = false;
+template<class var_t>
+class PoissonEquation
+{
+  public:
+    bool do_flux_cor = true;
+    bool set_flux_boundary = true;
+    bool include_flux_dx = false;
 
-  using IndependentVars = parthenon::TypeList<var_t>;
+    using IndependentVars = parthenon::TypeList<var_t>;
 
-  PoissonEquation(parthenon::ParameterInput *pin, const std::string &label) {
-    do_flux_cor = pin->GetOrAddBoolean(label, "flux_correct", true);
-    set_flux_boundary = pin->GetOrAddBoolean(label, "set_flux_boundary", true);
-    include_flux_dx =
-        (pin->GetOrAddString(label, "boundary_prolongation", "Linear") == "Constant");
-  }
-
-  // Add tasks to calculate the result of the matrix A (which is implicitly defined by
-  // this class) being applied to x_t and store it in field out_t
-  parthenon::TaskID Ax(parthenon::TaskList &tl, parthenon::TaskID depends_on,
-                       std::shared_ptr<parthenon::MeshData<Real>> &md_mat,
-                       std::shared_ptr<parthenon::MeshData<Real>> &md_in,
-                       std::shared_ptr<parthenon::MeshData<Real>> &md_out) {
-    auto flux_res = tl.AddTask(depends_on, CalculateFluxes, md_mat, md_in);
-    if (set_flux_boundary) {
-      flux_res = tl.AddTask(flux_res, SetFluxBoundariesZero, md_in);
+    PoissonEquation(parthenon::ParameterInput* pin, const std::string& label)
+    {
+        do_flux_cor = pin->GetOrAddBoolean(label, "flux_correct", true);
+        set_flux_boundary = pin->GetOrAddBoolean(label, "set_flux_boundary", true);
+        include_flux_dx =
+            (pin->GetOrAddString(label, "boundary_prolongation", "Linear") == "Constant");
     }
-    // if (do_flux_cor && !(md_mat->grid.type() == parthenon::GridType::two_level_composite)) {
-    //   auto start_flxcor =
-    //       tl.AddTask(flux_res, parthenon::StartReceiveFluxCorrections, md_in);
-    //   auto send_flxcor =
-    //       tl.AddTask(flux_res, parthenon::LoadAndSendFluxCorrections, md_in);
-    //   auto recv_flxcor =
-    //       tl.AddTask(start_flxcor, parthenon::ReceiveFluxCorrections, md_in);
-    //   flux_res = tl.AddTask(recv_flxcor, parthenon::SetFluxCorrections, md_in);
-    // }
-    if (do_flux_cor && !(md_mat->grid.type() == parthenon::GridType::two_level_composite)) {
-      flux_res = parthenon::AddBoundaryExchangeTasks(flux_res, tl, md_in, md_in->GetMeshPointer()->multilevel);
+
+    // Add tasks to calculate the result of the matrix A (which is implicitly defined by
+    // this class) being applied to x_t and store it in field out_t
+    parthenon::TaskID Ax(parthenon::TaskList& tl, parthenon::TaskID depends_on,
+        std::shared_ptr<parthenon::MeshData<Real>>& md_mat,
+        std::shared_ptr<parthenon::MeshData<Real>>& md_in,
+        std::shared_ptr<parthenon::MeshData<Real>>& md_out)
+    {
+        auto flux_res = tl.AddTask(depends_on, CalculateFluxes, md_mat, md_in);
+        if (set_flux_boundary) {
+            flux_res = tl.AddTask(flux_res, SetFluxBoundariesZero, md_in);
+        }
+        // if (do_flux_cor && !(md_mat->grid.type() ==
+        // parthenon::GridType::two_level_composite)) {
+        //   auto start_flxcor =
+        //       tl.AddTask(flux_res, parthenon::StartReceiveFluxCorrections, md_in);
+        //   auto send_flxcor =
+        //       tl.AddTask(flux_res, parthenon::LoadAndSendFluxCorrections, md_in);
+        //   auto recv_flxcor =
+        //       tl.AddTask(start_flxcor, parthenon::ReceiveFluxCorrections, md_in);
+        //   flux_res = tl.AddTask(recv_flxcor, parthenon::SetFluxCorrections, md_in);
+        // }
+        if (do_flux_cor &&
+            !(md_mat->grid.type() == parthenon::GridType::two_level_composite)) {
+            flux_res = parthenon::AddBoundaryExchangeTasks(
+                flux_res, tl, md_in, md_in->GetMeshPointer()->multilevel);
+        }
+        if (set_flux_boundary) {
+            flux_res = tl.AddTask(flux_res, SetFluxBoundariesZero, md_in);
+        }
+        return tl.AddTask(flux_res, FluxMultiplyMatrix, md_in, md_out);
     }
-    if (set_flux_boundary) {
-      flux_res = tl.AddTask(flux_res, SetFluxBoundariesZero, md_in);
+
+    // Calculate an approximation to the diagonal of the matrix A and store it in diag_t.
+    // For a uniform grid or when flux correction is ignored, this diagonal calculation
+    // is exact. Exactness is (probably) not required since it is just used in Jacobi
+    // iterations.
+    parthenon::TaskStatus SetDiagonal(std::shared_ptr<parthenon::MeshData<Real>>& md_mat,
+        std::shared_ptr<parthenon::MeshData<Real>>& md_diag)
+    {
+        using namespace parthenon;
+        const int ndim = md_diag->GetMeshPointer()->ndim;
+        IndexRange ib = md_diag->GetBoundsI(IndexDomain::interior, te);
+        IndexRange jb = md_diag->GetBoundsJ(IndexDomain::interior, te);
+        IndexRange kb = md_diag->GetBoundsK(IndexDomain::interior, te);
+
+        auto pkg = md_diag->GetMeshPointer()->packages.Get("B_CleanupGMG");
+        const auto alpha = pkg->Param<Real>("diagonal_alpha");
+
+        int nblocks = md_diag->NumBlocks();
+        std::vector<bool> include_block(nblocks, true);
+
+        auto desc_diag = parthenon::MakePackDescriptor<var_t>(md_diag.get());
+        auto pack_diag = desc_diag.GetPack(md_diag.get(), include_block);
+        using TE = parthenon::TopologicalElement;
+        parthenon::par_for("StoreDiagonal", 0, pack_diag.GetNBlocks() - 1, kb.s, kb.e,
+            jb.s, jb.e, ib.s, ib.e,
+                           KOKKOS_LAMBDA(const int b, const int k, const int j,
+                                         const int i)
+            {
+                const auto& coords = pack_diag.GetCoordinates(b);
+                // Build the unigrid diagonal of the matrix
+                Real dx1 = coords.template Dxc<X1DIR>(k, j, i);
+                Real diag_elem = -2 / (dx1 * dx1) - alpha;
+                if (ndim > 1) {
+                    Real dx2 = coords.template Dxc<X2DIR>(k, j, i);
+                    diag_elem -= 2 / (dx2 * dx2) - alpha;
+                }
+                if (ndim > 2) {
+                    Real dx3 = coords.template Dxc<X3DIR>(k, j, i);
+                    diag_elem -= 2 / (dx3 * dx3) - alpha;
+                }
+                pack_diag(b, te, var_t(), k, j, i) = diag_elem;
+            });
+        return TaskStatus::complete;
     }
-    return tl.AddTask(flux_res, FluxMultiplyMatrix, md_in, md_out);
-  }
 
-  // Calculate an approximation to the diagonal of the matrix A and store it in diag_t.
-  // For a uniform grid or when flux correction is ignored, this diagonal calculation
-  // is exact. Exactness is (probably) not required since it is just used in Jacobi
-  // iterations.
-  parthenon::TaskStatus SetDiagonal(std::shared_ptr<parthenon::MeshData<Real>> &md_mat,
-                                    std::shared_ptr<parthenon::MeshData<Real>> &md_diag) {
-    using namespace parthenon;
-    const int ndim = md_diag->GetMeshPointer()->ndim;
-    IndexRange ib = md_diag->GetBoundsI(IndexDomain::interior, te);
-    IndexRange jb = md_diag->GetBoundsJ(IndexDomain::interior, te);
-    IndexRange kb = md_diag->GetBoundsK(IndexDomain::interior, te);
+    static parthenon::TaskStatus CalculateFluxes(
+        std::shared_ptr<parthenon::MeshData<Real>>& md_mat,
+        std::shared_ptr<parthenon::MeshData<Real>>& md)
+    {
+        using namespace parthenon;
+        const int ndim = md->GetMeshPointer()->ndim;
+        IndexRange ib = md->GetBoundsI(IndexDomain::interior, te);
+        IndexRange jb = md->GetBoundsJ(IndexDomain::interior, te);
+        IndexRange kb = md->GetBoundsK(IndexDomain::interior, te);
 
-    auto pkg = md_diag->GetMeshPointer()->packages.Get("B_CleanupGMG");
-    const auto alpha = pkg->Param<Real>("diagonal_alpha");
+        using TE = parthenon::TopologicalElement;
 
-    int nblocks = md_diag->NumBlocks();
-    std::vector<bool> include_block(nblocks, true);
+        int nblocks = md->NumBlocks();
+        std::vector<bool> include_block(nblocks, true);
 
-    auto desc_diag = parthenon::MakePackDescriptor<var_t>(md_diag.get());
-    auto pack_diag = desc_diag.GetPack(md_diag.get(), include_block);
-    using TE = parthenon::TopologicalElement;
-    parthenon::par_for(
-        "StoreDiagonal", 0, pack_diag.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          const auto &coords = pack_diag.GetCoordinates(b);
-          // Build the unigrid diagonal of the matrix
-          Real dx1 = coords.template Dxc<X1DIR>(k, j, i);
-          Real diag_elem = -2 / (dx1 * dx1) - alpha;
-          if (ndim > 1) {
-            Real dx2 = coords.template Dxc<X2DIR>(k, j, i);
-            diag_elem -= 2 / (dx2 * dx2) - alpha;
-          }
-          if (ndim > 2) {
-            Real dx3 = coords.template Dxc<X3DIR>(k, j, i);
-            diag_elem -= 2 / (dx3 * dx3) - alpha;
-          }
-          pack_diag(b, te, var_t(), k, j, i) = diag_elem;
-        });
-    return TaskStatus::complete;
-  }
+        auto desc =
+            parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
+        auto pack = desc.GetPack(md.get(), include_block);
+        parthenon::par_for("CaclulateFluxes", 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s,
+            jb.e, ib.s, ib.e,
+                           KOKKOS_LAMBDA(const int b, const int k, const int j,
+                                         const int i)
+            {
+                const auto& coords = pack.GetCoordinates(b);
+                Real dx1 = coords.template Dxc<X1DIR>(k, j, i);
+                pack.flux(b, X1DIR, var_t(), k, j, i) =
+                    1. / dx1 *
+                    (pack(b, te, var_t(), k, j, i - 1) - pack(b, te, var_t(), k, j, i));
+                if (i == ib.e)
+                    pack.flux(b, X1DIR, var_t(), k, j, i + 1) =
+                        1. / dx1 *
+                        (pack(b, te, var_t(), k, j, i) -
+                            pack(b, te, var_t(), k, j, i + 1));
 
-  static parthenon::TaskStatus
-  CalculateFluxes(std::shared_ptr<parthenon::MeshData<Real>> &md_mat,
-                  std::shared_ptr<parthenon::MeshData<Real>> &md) {
-    using namespace parthenon;
-    const int ndim = md->GetMeshPointer()->ndim;
-    IndexRange ib = md->GetBoundsI(IndexDomain::interior, te);
-    IndexRange jb = md->GetBoundsJ(IndexDomain::interior, te);
-    IndexRange kb = md->GetBoundsK(IndexDomain::interior, te);
+                if (ndim > 1) {
+                    Real dx2 = coords.template Dxc<X2DIR>(k, j, i);
+                    pack.flux(b, X2DIR, var_t(), k, j, i) =
+                        (pack(b, te, var_t(), k, j - 1, i) -
+                            pack(b, te, var_t(), k, j, i)) /
+                        dx2;
+                    if (j == jb.e)
+                        pack.flux(b, X2DIR, var_t(), k, j + 1, i) =
+                            (pack(b, te, var_t(), k, j, i) -
+                                pack(b, te, var_t(), k, j + 1, i)) /
+                            dx2;
+                }
 
-    using TE = parthenon::TopologicalElement;
+                if (ndim > 2) {
+                    Real dx3 = coords.template Dxc<X3DIR>(k, j, i);
+                    pack.flux(b, X3DIR, var_t(), k, j, i) =
+                        (pack(b, te, var_t(), k - 1, j, i) -
+                            pack(b, te, var_t(), k, j, i)) /
+                        dx3;
+                    if (k == kb.e)
+                        pack.flux(b, X2DIR, var_t(), k + 1, j, i) =
+                            (pack(b, te, var_t(), k, j, i) -
+                                pack(b, te, var_t(), k + 1, j, i)) /
+                            dx3;
+                }
+            });
+        return TaskStatus::complete;
+    }
 
-    int nblocks = md->NumBlocks();
-    std::vector<bool> include_block(nblocks, true);
+    static parthenon::TaskStatus SetFluxBoundariesZero(
+        std::shared_ptr<parthenon::MeshData<Real>>& md)
+    {
+        using namespace parthenon;
+        const int ndim = md->GetMeshPointer()->ndim;
+        IndexRange ib = md->GetBoundsI(IndexDomain::interior);
+        IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
+        IndexRange kb = md->GetBoundsK(IndexDomain::interior);
 
-    auto desc = parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
-    auto pack = desc.GetPack(md.get(), include_block);
-    parthenon::par_for(
-        "CaclulateFluxes", 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          const auto &coords = pack.GetCoordinates(b);
-          Real dx1 = coords.template Dxc<X1DIR>(k, j, i);
-          pack.flux(b, X1DIR, var_t(), k, j, i) =
-              1. / dx1 *
-              (pack(b, te, var_t(), k, j, i - 1) - pack(b, te, var_t(), k, j, i));
-          if (i == ib.e)
-            pack.flux(b, X1DIR, var_t(), k, j, i + 1) =
-                1. / dx1 *
-                (pack(b, te, var_t(), k, j, i) - pack(b, te, var_t(), k, j, i + 1));
+        using TE = parthenon::TopologicalElement;
 
-          if (ndim > 1) {
-            Real dx2 = coords.template Dxc<X2DIR>(k, j, i);
-            pack.flux(b, X2DIR, var_t(), k, j, i) =
-                (pack(b, te, var_t(), k, j - 1, i) - pack(b, te, var_t(), k, j, i)) / dx2;
-            if (j == jb.e)
-              pack.flux(b, X2DIR, var_t(), k, j + 1, i) =
-                  (pack(b, te, var_t(), k, j, i) - pack(b, te, var_t(), k, j + 1, i)) / dx2;
-          }
+        int nblocks = md->NumBlocks();
+        std::vector<bool> include_block(nblocks, true);
 
-          if (ndim > 2) {
-            Real dx3 = coords.template Dxc<X3DIR>(k, j, i);
-            pack.flux(b, X3DIR, var_t(), k, j, i) =
-                (pack(b, te, var_t(), k - 1, j, i) - pack(b, te, var_t(), k, j, i)) / dx3;
-            if (k == kb.e)
-              pack.flux(b, X2DIR, var_t(), k + 1, j, i) =
-                  (pack(b, te, var_t(), k, j, i) - pack(b, te, var_t(), k + 1, j, i)) / dx3;
-          }
-        });
-    return TaskStatus::complete;
-  }
+        auto desc =
+            parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
+        auto pack = desc.GetPack(md.get(), include_block);
+        const std::size_t scratch_size_in_bytes = 0;
+        const std::size_t scratch_level = 1;
 
-  static parthenon::TaskStatus
-  SetFluxBoundariesZero(std::shared_ptr<parthenon::MeshData<Real>> &md) {
-    using namespace parthenon;
-    const int ndim = md->GetMeshPointer()->ndim;
-    IndexRange ib = md->GetBoundsI(IndexDomain::interior);
-    IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
-    IndexRange kb = md->GetBoundsK(IndexDomain::interior);
+        const parthenon::Indexer3D idxers[6]{parthenon::Indexer3D(kb, jb, {ib.s, ib.s}),
+            parthenon::Indexer3D(kb, jb, {ib.e + 1, ib.e + 1}),
+            parthenon::Indexer3D(kb, {jb.s, jb.s}, ib),
+            parthenon::Indexer3D(kb, {jb.e + 1, jb.e + 1}, ib),
+            parthenon::Indexer3D({kb.s, kb.s}, jb, ib),
+            parthenon::Indexer3D({kb.e + 1, kb.e + 1}, jb, ib)};
+        constexpr int x1off[6]{-1, 1, 0, 0, 0, 0};
+        constexpr int x2off[6]{0, 0, -1, 1, 0, 0};
+        constexpr int x3off[6]{0, 0, 0, 0, -1, 1};
+        constexpr int dirs[6]{X1DIR, X1DIR, X2DIR, X2DIR, X3DIR, X3DIR};
+        constexpr bool do_side[6]{false, true, true, true, false, false};
+        parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "SetFluxBoundaries",
+            DevExecSpace(), scratch_size_in_bytes, scratch_level, 0,
+            pack.GetNBlocks() - 1,
+            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int b)
+            {
+                const auto& coords = pack.GetCoordinates(b);
+                for (int face = 0; face < ndim * 2; ++face) {
+                    const auto& idxer = idxers[face];
+                    const auto dir = dirs[face];
+                    // Impose the zero Dirichlet boundary condition
+                    // at the actual boundary
+                    if (pack.IsPhysicalBoundary(
+                            b, x3off[face], x2off[face], x1off[face]) &&
+                        do_side[face]) {
+                        parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, 0,
+                            idxer.size() - 1,
+                            [&](const int idx)
+                            {
+                                const auto [k, j, i] = idxer(idx);
+                                pack.flux(b, dir, var_t(), k, j, i) = 0.;
+                            });
+                    }
+                }
+            });
 
-    using TE = parthenon::TopologicalElement;
+        return TaskStatus::complete;
+    }
 
-    int nblocks = md->NumBlocks();
-    std::vector<bool> include_block(nblocks, true);
+    // Calculate A in_t = out_t (in the region covered by md) for a given set of fluxes
+    // calculated with in_t (which have possibly been corrected at coarse fine boundaries)
+    static parthenon::TaskStatus FluxMultiplyMatrix(
+        std::shared_ptr<parthenon::MeshData<Real>>& md,
+        std::shared_ptr<parthenon::MeshData<Real>>& md_out)
+    {
+        using namespace parthenon;
+        const int ndim = md->GetMeshPointer()->ndim;
+        IndexRange ib = md->GetBoundsI(IndexDomain::interior, te);
+        IndexRange jb = md->GetBoundsJ(IndexDomain::interior, te);
+        IndexRange kb = md->GetBoundsK(IndexDomain::interior, te);
 
-    auto desc = parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
-    auto pack = desc.GetPack(md.get(), include_block);
-    const std::size_t scratch_size_in_bytes = 0;
-    const std::size_t scratch_level = 1;
+        auto pkg = md->GetMeshPointer()->packages.Get("B_CleanupGMG");
+        const auto alpha = pkg->Param<Real>("diagonal_alpha");
 
-    const parthenon::Indexer3D idxers[6]{
-        parthenon::Indexer3D(kb, jb, {ib.s, ib.s}),
-        parthenon::Indexer3D(kb, jb, {ib.e + 1, ib.e + 1}),
-        parthenon::Indexer3D(kb, {jb.s, jb.s}, ib),
-        parthenon::Indexer3D(kb, {jb.e + 1, jb.e + 1}, ib),
-        parthenon::Indexer3D({kb.s, kb.s}, jb, ib),
-        parthenon::Indexer3D({kb.e + 1, kb.e + 1}, jb, ib)};
-    constexpr int x1off[6]{-1, 1, 0, 0, 0, 0};
-    constexpr int x2off[6]{0, 0, -1, 1, 0, 0};
-    constexpr int x3off[6]{0, 0, 0, 0, -1, 1};
-    constexpr int dirs[6]{X1DIR, X1DIR, X2DIR, X2DIR, X3DIR, X3DIR};
-    constexpr bool do_side[6]{false, true, true, true, false, false};
-    parthenon::par_for_outer(
-        DEFAULT_OUTER_LOOP_PATTERN, "SetFluxBoundaries", DevExecSpace(),
-        scratch_size_in_bytes, scratch_level, 0, pack.GetNBlocks() - 1,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int b) {
-          const auto &coords = pack.GetCoordinates(b);
-          for (int face = 0; face < ndim * 2; ++face) {
-            const auto &idxer = idxers[face];
-            const auto dir = dirs[face];
-            // Impose the zero Dirichlet boundary condition at the actual boundary
-            if (pack.IsPhysicalBoundary(b, x3off[face], x2off[face], x1off[face])
-                && do_side[face]) {
-                parthenon::par_for_inner(
-                    DEFAULT_INNER_LOOP_PATTERN, member, 0, idxer.size() - 1,
-                    [&](const int idx) {
-                      const auto [k, j, i] = idxer(idx);
-                      pack.flux(b, dir, var_t(), k, j, i) = 0.;
-                    });
-            }
-          }
-        });
+        int nblocks = md->NumBlocks();
+        std::vector<bool> include_block(nblocks, true);
 
-    return TaskStatus::complete;
-  }
+        static auto desc =
+            parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
+        static auto desc_out = parthenon::MakePackDescriptor<var_t>(md_out.get());
+        auto pack = desc.GetPack(md.get(), include_block);
+        auto pack_out = desc_out.GetPack(md_out.get(), include_block);
+        double norm = 0.;
+        parthenon::par_reduce(
+            "FluxMultiplyMatrix", 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
+            ib.e,
+            KOKKOS_LAMBDA(
+                const int b, const int k, const int j, const int i, double& local_result)
+            {
+                const auto& coords = pack.GetCoordinates(b);
+                Real dx1 = coords.template Dxc<X1DIR>(k, j, i);
+                pack_out(b, te, var_t(), k, j, i) =
+                    -alpha * pack(b, te, var_t(), k, j, i);
+                pack_out(b, te, var_t(), k, j, i) +=
+                    (pack.flux(b, X1DIR, var_t(), k, j, i) -
+                        pack.flux(b, X1DIR, var_t(), k, j, i + 1)) /
+                    dx1;
 
-  // Calculate A in_t = out_t (in the region covered by md) for a given set of fluxes
-  // calculated with in_t (which have possibly been corrected at coarse fine boundaries)
-  static parthenon::TaskStatus
-  FluxMultiplyMatrix(std::shared_ptr<parthenon::MeshData<Real>> &md,
-                     std::shared_ptr<parthenon::MeshData<Real>> &md_out) {
-    using namespace parthenon;
-    const int ndim = md->GetMeshPointer()->ndim;
-    IndexRange ib = md->GetBoundsI(IndexDomain::interior, te);
-    IndexRange jb = md->GetBoundsJ(IndexDomain::interior, te);
-    IndexRange kb = md->GetBoundsK(IndexDomain::interior, te);
+                if (ndim > 1) {
+                    Real dx2 = coords.template Dxc<X2DIR>(k, j, i);
+                    pack_out(b, te, var_t(), k, j, i) +=
+                        (pack.flux(b, X2DIR, var_t(), k, j, i) -
+                            pack.flux(b, X2DIR, var_t(), k, j + 1, i)) /
+                        dx2;
+                }
 
-    auto pkg = md->GetMeshPointer()->packages.Get("B_CleanupGMG");
-    const auto alpha = pkg->Param<Real>("diagonal_alpha");
+                if (ndim > 2) {
+                    Real dx3 = coords.template Dxc<X3DIR>(k, j, i);
+                    pack_out(b, te, var_t(), k, j, i) +=
+                        (pack.flux(b, X3DIR, var_t(), k, j, i) -
+                            pack.flux(b, X3DIR, var_t(), k + 1, j, i)) /
+                        dx3;
+                }
 
-    int nblocks = md->NumBlocks();
-    std::vector<bool> include_block(nblocks, true);
+                GReal Xnative[GR_DIM];
+                coords.coord(k, j, i, Loci::corner, Xnative);
+                if (m::abs(Xnative[1]) < coords.coords.startx(1) + 1.e-6 &&
+                    m::abs(Xnative[2]) < 1.e-6 && m::abs(Xnative[3]) < 1.e-6)
+                    pack_out(b, te, var_t(), k, j, i) = 0;
 
-    static auto desc =
-        parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
-    static auto desc_out = parthenon::MakePackDescriptor<var_t>(md_out.get());
-    auto pack = desc.GetPack(md.get(), include_block);
-    auto pack_out = desc_out.GetPack(md_out.get(), include_block);
-    double norm = 0.;
-    parthenon::par_reduce(
-        "FluxMultiplyMatrix", 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
-        ib.e, KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, double& local_result) {
-          const auto &coords = pack.GetCoordinates(b);
-          Real dx1 = coords.template Dxc<X1DIR>(k, j, i);
-          pack_out(b, te, var_t(), k, j, i) = -alpha * pack(b, te, var_t(), k, j, i);
-          pack_out(b, te, var_t(), k, j, i) +=
-              (pack.flux(b, X1DIR, var_t(), k, j, i) -
-               pack.flux(b, X1DIR, var_t(), k, j, i + 1)) /
-              dx1;
+                // local_result += pack_out(b, te, var_t(), k, j, i);
+            },
+            Kokkos::Sum<double>(norm));
+        // norm /= pack.GetNBlocks() * (kb.e-kb.s+1) * (jb.e-jb.s+1) * (ib.e-ib.s+1);
+        // parthenon::par_for(
+        //     "MatrixRenorm", 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
+        //     ib.e, KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+        //       pack_out(b, te, var_t(), k, j, i) -= norm;
+        //     });
 
-          if (ndim > 1) {
-            Real dx2 = coords.template Dxc<X2DIR>(k, j, i);
-            pack_out(b, te, var_t(), k, j, i) +=
-                (pack.flux(b, X2DIR, var_t(), k, j, i) -
-                 pack.flux(b, X2DIR, var_t(), k, j + 1, i)) /
-                dx2;
-          }
-
-          if (ndim > 2) {
-            Real dx3 = coords.template Dxc<X3DIR>(k, j, i);
-            pack_out(b, te, var_t(), k, j, i) +=
-                (pack.flux(b, X3DIR, var_t(), k, j, i) -
-                 pack.flux(b, X3DIR, var_t(), k + 1, j, i)) /
-                dx3;
-          }
-
-          GReal Xnative[GR_DIM];
-          coords.coord(k, j, i, Loci::corner, Xnative);
-          if (m::abs(Xnative[1]) < coords.coords.startx(1) + 1.e-6 && m::abs(Xnative[2]) < 1.e-6 && m::abs(Xnative[3]) < 1.e-6)
-            pack_out(b, te, var_t(), k, j, i) = 0;
-
-          //local_result += pack_out(b, te, var_t(), k, j, i);
-        }, Kokkos::Sum<double>(norm));
-    // norm /= pack.GetNBlocks() * (kb.e-kb.s+1) * (jb.e-jb.s+1) * (ib.e-ib.s+1);
-    // parthenon::par_for(
-    //     "MatrixRenorm", 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
-    //     ib.e, KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-    //       pack_out(b, te, var_t(), k, j, i) -= norm;
-    //     });
-
-    return TaskStatus::complete;
-  }
+        return TaskStatus::complete;
+    }
 };
 
 } // namespace B_CleanupGMG

--- a/kharma/b_cleanup_gmg/solver_tasks.cpp
+++ b/kharma/b_cleanup_gmg/solver_tasks.cpp
@@ -34,11 +34,11 @@
 #include "b_cleanup_gmg.hpp"
 
 #include <parthenon/parthenon.hpp>
-#include <solvers/solver_utils.hpp>
 #include <solvers/solver_base.hpp>
+#include <solvers/solver_utils.hpp>
 
-#include "poisson_equation.hpp"
 #include "kharma.hpp"
+#include "poisson_equation.hpp"
 
 #if DISABLE_GMG_CLEANUP
 
@@ -57,15 +57,16 @@ TaskCollection B_CleanupGMG::MakeSolverTaskCollection(Mesh* pmesh)
     // auto solver_name = pkg->Param<std::string>("solver");
     auto psolver =
         pkg->Param<std::shared_ptr<parthenon::solvers::SolverBase>>("solver_pointer");
-    auto poisson_eq =
-        pkg->Param<PoissonEquation<p>>("poisson_eq");
+    auto poisson_eq = pkg->Param<PoissonEquation<p>>("poisson_eq");
 
     // List out solver-related vars for faster MPI by skipping base variables
     // using FC = Metadata::FlagCollection;
     // static std::vector<std::string> solver_vars;
     // if (solver_vars.size() == 0) {
-    //     // Build the universe of variables to let Parthenon see when exchanging boundaries.
-    //     // This is built to exclude incidental variables like B field initialization stuff, EMFs, etc.
+    //     // Build the universe of variables to let Parthenon see when exchanging
+    //     boundaries.
+    //     // This is built to exclude incidental variables like B field initialization
+    //     stuff, EMFs, etc.
     //     // "Boundaries" packs in buffers e.g. Dirichlet boundaries
     //     auto solver_flags = FC({Metadata::GetUserFlag("B_CleanupGMG")});
     //     solver_vars = KHARMA::GetVariableNames(&(pmesh->packages), solver_flags);
@@ -73,18 +74,20 @@ TaskCollection B_CleanupGMG::MakeSolverTaskCollection(Mesh* pmesh)
 
     auto partitions = pmesh->GetDefaultBlockPartitions();
     const int num_partitions = partitions.size();
-    TaskRegion &region = tc.AddRegion(num_partitions);
+    TaskRegion& region = tc.AddRegion(num_partitions);
     std::cerr << "2" << std::endl;
     for (int i = 0; i < num_partitions; i++) {
-        auto &tl = region[i];
-        auto &md = pmesh->mesh_data.Add("base", partitions[i]);
-        auto &md_p = pmesh->mesh_data.Add("p", md, {p::name()});
-        auto &md_rhs = pmesh->mesh_data.Add("rhs", md, {p::name()});
+        auto& tl = region[i];
+        auto& md = pmesh->mesh_data.Add("base", partitions[i]);
+        auto& md_p = pmesh->mesh_data.Add("p", md, {p::name()});
+        auto& md_rhs = pmesh->mesh_data.Add("rhs", md, {p::name()});
 
         // Copy RHS to p, then to "rhs" stage
         // TF() is a macro for outputting function name string + function as args
-        auto t_copy_rhs = tl.AddTask(t_none, TF(solvers::utils::between_fields::CopyData<rhs, p>), md);
-        t_copy_rhs = tl.AddTask(t_copy_rhs, TF(solvers::utils::CopyData<parthenon::TypeList<p>>), md, md_rhs);
+        auto t_copy_rhs =
+            tl.AddTask(t_none, TF(solvers::utils::between_fields::CopyData<rhs, p>), md);
+        t_copy_rhs = tl.AddTask(
+            t_copy_rhs, TF(solvers::utils::CopyData<parthenon::TypeList<p>>), md, md_rhs);
 
         // Zero out p
         auto t_zero_p = tl.AddTask(t_copy_rhs, TF(solvers::utils::SetToZero<p>), md);

--- a/kharma/b_ct/b_ct.cpp
+++ b/kharma/b_ct/b_ct.cpp
@@ -44,19 +44,20 @@
 #include <stdexcept>
 
 using namespace parthenon;
+using parthenon::refinement_ops::ProlongateInternalAverage;
 using parthenon::refinement_ops::ProlongateSharedMinMod;
 using parthenon::refinement_ops::RestrictAverage;
-using parthenon::refinement_ops::ProlongateInternalAverage;
 
-std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> B_CT::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("B_CT");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Diagnostic flags
 
-    // Default to stopping execution when divB is large, which generally indicates something
-    // has gone wrong.  As always, can be disabled by the brave.
+    // Default to stopping execution when divB is large, which generally indicates
+    // something has gone wrong.  As always, can be disabled by the brave.
     bool kill_on_large_divb = pin->GetOrAddBoolean("b_field", "kill_on_large_divb", true);
     params.Add("kill_on_large_divb", kill_on_large_divb);
     Real kill_on_divb_over = pin->GetOrAddReal("b_field", "kill_on_divb_over", 1.e-3);
@@ -64,18 +65,23 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
 
     // TODO gs05_alpha, LDZ04 UCT1, LDZ07 UCT2?
     std::vector<std::string> ct_scheme_options = {"bs99", "gs05_0", "gs05_c", "sg07"};
-    std::string ct_scheme = pin->GetOrAddString("b_field", "ct_scheme", "gs05_c", ct_scheme_options);
+    std::string ct_scheme =
+        pin->GetOrAddString("b_field", "ct_scheme", "gs05_c", ct_scheme_options);
     params.Add("ct_scheme", ct_scheme);
 
-    // Use the default Parthenon prolongation operator, rather than the divergence-preserving one
-    // This relies entirely on the EMF communication for preserving the divergence
+    // Use the default Parthenon prolongation operator, rather than the
+    // divergence-preserving one This relies entirely on the EMF communication for
+    // preserving the divergence
     bool lazy_prolongation = pin->GetOrAddBoolean("b_field", "lazy_prolongation", false);
     // Need to preserve divergence if you refine/derefine during sim i.e. AMR
     if (lazy_prolongation && pin->GetString("parthenon/mesh", "refinement") == "adaptive")
-        throw std::runtime_error("Cannot use non-divergence-preserving prolongation in AMR!");
+        throw std::runtime_error(
+            "Cannot use non-divergence-preserving prolongation in AMR!");
 
-    // TODO don't set this unless we're reconnecting at boundaries (can't just check, we load Boundaries pkg later)
-    int reconnection_outer_buffer = pin->GetOrAddBoolean("b_field", "reconnection_outer_buffer", 5);
+    // TODO don't set this unless we're reconnecting at boundaries (can't just check, we
+    // load Boundaries pkg later)
+    int reconnection_outer_buffer =
+        pin->GetOrAddBoolean("b_field", "reconnection_outer_buffer", 5);
     params.Add("reconnection_outer_buffer", reconnection_outer_buffer);
 
     // FIELDS
@@ -84,24 +90,33 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
     // We don't mark these as "Conserved" else they'd be bundled
     // with all the cell vars in a bunch of places we don't want
     // Also note we *always* sync B field conserved var
-    std::vector<MetadataFlag> flags_cons_f = {Metadata::Real, Metadata::Face, Metadata::Independent, Metadata::Restart, Metadata::FillGhost,
-                                              Metadata::GetUserFlag("Explicit"), Metadata::GetUserFlag("SplitVector")};
+    std::vector<MetadataFlag> flags_cons_f = {Metadata::Real, Metadata::Face,
+        Metadata::Independent, Metadata::Restart, Metadata::FillGhost,
+        Metadata::GetUserFlag("Explicit"), Metadata::GetUserFlag("SplitVector")};
     auto m = Metadata(flags_cons_f);
     if (!lazy_prolongation)
-        m.RegisterRefinementOps<ProlongateSharedMinMod, RestrictAverage, ProlongateInternalOlivares>();
+        m.RegisterRefinementOps<ProlongateSharedMinMod, RestrictAverage,
+            ProlongateInternalOlivares>();
     else
-        m.RegisterRefinementOps<ProlongateSharedMinMod, RestrictAverage, ProlongateInternalAverage>();
+        m.RegisterRefinementOps<ProlongateSharedMinMod, RestrictAverage,
+            ProlongateInternalAverage>();
     pkg->AddField("cons.fB", m);
 
     // Cell-centered versions.  Needed for BS, not for other schemes.
-    // Probably will want to keep primitives for e.g. correct PtoU of MHD vars, but cons maybe can go
-    std::vector<MetadataFlag> flags_prim = {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::GetUserFlag("Primitive"),
-                                            Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Explicit"), Metadata::Vector};
-    std::vector<MetadataFlag> flags_cons = {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::Conserved, Metadata::WithFluxes,
-                                            Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Explicit"), Metadata::Vector};
+    // Probably will want to keep primitives for e.g. correct PtoU of MHD vars, but cons
+    // maybe can go
+    std::vector<MetadataFlag> flags_prim = {Metadata::Real, Metadata::Cell,
+        Metadata::Derived, Metadata::GetUserFlag("Primitive"),
+        Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Explicit"),
+        Metadata::Vector};
+    std::vector<MetadataFlag> flags_cons = {Metadata::Real, Metadata::Cell,
+        Metadata::Derived, Metadata::Conserved, Metadata::WithFluxes,
+        Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Explicit"),
+        Metadata::Vector};
 
     // KHARMA now (vaguely) supports restarting from dump (.phdf) files.
-    // To do so we need to read cell-centered primitive B and interpolate to faces, as we do with iharm3d restart files
+    // To do so we need to read cell-centered primitive B and interpolate to faces, as we
+    // do with iharm3d restart files
     if (pin->GetOrAddBoolean("b_field", "restart_from_prims", false)) {
         flags_prim.push_back(Metadata::Restart);
     }
@@ -113,12 +128,14 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
     pkg->AddField("cons.B", m);
 
     // EMF on edges.
-    std::vector<MetadataFlag> flags_emf = {Metadata::Real, Metadata::Edge, Metadata::Derived, Metadata::OneCopy, Metadata::FillGhost};
+    std::vector<MetadataFlag> flags_emf = {Metadata::Real, Metadata::Edge,
+        Metadata::Derived, Metadata::OneCopy, Metadata::FillGhost};
     m = Metadata(flags_emf);
     pkg->AddField("B_CT.emf", m);
 
     if (ct_scheme != "bs99") {
-        std::vector<MetadataFlag> flags_emf_c = {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
+        std::vector<MetadataFlag> flags_emf_c = {
+            Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
         m = Metadata(flags_emf_c, s_vector);
         pkg->AddField("B_CT.cemf", m);
     }
@@ -130,7 +147,7 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
     pkg->AddSource = B_CT::AddSource;
 
     // Also ensure that prims get filled, both during step and on boundaries
-    //pkg->MeshUtoP = B_CT::MeshUtoP;
+    // pkg->MeshUtoP = B_CT::MeshUtoP;
     pkg->BlockUtoP = B_CT::BlockUtoP;
     pkg->BoundaryUtoP = B_CT::BlockUtoP;
 
@@ -139,37 +156,45 @@ std::shared_ptr<KHARMAPackage> B_CT::Initialize(ParameterInput *pin, std::shared
 
     // The definition of MaxDivB we care about actually changes per-transport,
     // so calculating it is handled by the transport package
-    // We'd only ever need to declare or calculate divB for output (getting the max is independent)
+    // We'd only ever need to declare or calculate divB for output (getting the max is
+    // independent)
     if (KHARMA::FieldIsOutput(pin, "divB")) {
         pkg->BlockUserWorkBeforeOutput = B_CT::FillOutput;
-        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+        m = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
         pkg->AddField("divB", m);
     }
 
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
-    hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::max, B_CT::MaxDivB, "MaxDivB"));
-    // Event horizon magnetization.  Might be the same or different for different representations?
+    hst_vars.emplace_back(
+        parthenon::HistoryOutputVar(UserHistoryOperation::max, B_CT::MaxDivB, "MaxDivB"));
+    // Event horizon magnetization.  Might be the same or different for different
+    // representations?
     if (pin->GetBoolean("coordinates", "domain_intersects_eh")) {
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::phi>, "Phi_0"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::phi>, "Phi_EH"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::phi>, "Phi_5M"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::SumAt0<Reductions::Var::phi>, "Phi_0"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::SumAtEH<Reductions::Var::phi>, "Phi_EH"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::SumAt5M<Reductions::Var::phi>, "Phi_5M"));
     }
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     return pkg;
 }
 
-TaskStatus B_CT::MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse)
+TaskStatus B_CT::MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     // TODO later
-    for (int i=0; i < md->NumBlocks(); i++)
+    for (int i = 0; i < md->NumBlocks(); i++)
         B_CT::BlockUtoP(md->GetBlockData(i).get(), domain, coarse);
     return TaskStatus::complete;
 }
 
-TaskStatus B_CT::BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+TaskStatus B_CT::BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
     const int ndim = pmb->pmy_mesh->ndim;
@@ -180,8 +205,8 @@ TaskStatus B_CT::BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coa
     // Return if we're not syncing U & P at all (e.g. edges)
     if (B_Uf.GetDim(4) == 0) return TaskStatus::complete;
 
-    // We need one cell inside of the domain, since it will be updated by the domain-face field
-    // this oversteps "interior" by a zone
+    // We need one cell inside of the domain, since it will be updated by the domain-face
+    // field this oversteps "interior" by a zone
     IndexRange3 bct;
     if (domain == IndexDomain::interior || domain == IndexDomain::entire) {
         bct = KDomain::GetRange(rc, domain, coarse);
@@ -194,87 +219,102 @@ TaskStatus B_CT::BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coa
 
     // Average the primitive vals to zone centers
     pmb->par_for("UtoP_B_center", bc.ks, bc.ke, bc.js, bc.je, bc.is, bc.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-            B_P(V1, k, j, i) = (B_Uf(F1, 0, k, j, i) / G.gdet(Loci::face1, j, i)
-                              + B_Uf(F1, 0, k, j, i + 1) / G.gdet(Loci::face1, j, i + 1)) / 2;
-            B_P(V2, k, j, i) = (ndim > 1) ? (B_Uf(F2, 0, k, j, i) / G.gdet(Loci::face2, j, i)
-                                           + B_Uf(F2, 0, k, j + 1, i) / G.gdet(Loci::face2, j + 1, i)) / 2
-                                           : B_Uf(F2, 0, k, j, i) / G.gdet(Loci::face2, j, i);
-            B_P(V3, k, j, i) = (ndim > 2) ? (B_Uf(F3, 0, k, j, i) / G.gdet(Loci::face3, j, i)
-                                           + B_Uf(F3, 0, k + 1, j, i) / G.gdet(Loci::face3, j, i)) / 2
-                                           : B_Uf(F3, 0, k, j, i) / G.gdet(Loci::face3, j, i);
-        }
-    );
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
+            B_P(V1, k, j, i) =
+                (B_Uf(F1, 0, k, j, i) / G.gdet(Loci::face1, j, i) +
+                    B_Uf(F1, 0, k, j, i + 1) / G.gdet(Loci::face1, j, i + 1)) /
+                2;
+            B_P(V2, k, j, i) =
+                (ndim > 1)
+                    ? (B_Uf(F2, 0, k, j, i) / G.gdet(Loci::face2, j, i) +
+                          B_Uf(F2, 0, k, j + 1, i) / G.gdet(Loci::face2, j + 1, i)) /
+                          2
+                    : B_Uf(F2, 0, k, j, i) / G.gdet(Loci::face2, j, i);
+            B_P(V3, k, j, i) =
+                (ndim > 2) ? (B_Uf(F3, 0, k, j, i) / G.gdet(Loci::face3, j, i) +
+                                 B_Uf(F3, 0, k + 1, j, i) / G.gdet(Loci::face3, j, i)) /
+                                 2
+                           : B_Uf(F3, 0, k, j, i) / G.gdet(Loci::face3, j, i);
+        });
     // Recover conserved B at centers
-    pmb->par_for("UtoP_B_centerPtoU", 0, NVEC-1, bc.ks, bc.ke, bc.js, bc.je, bc.is, bc.ie,
-        KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+    pmb->par_for("UtoP_B_centerPtoU", 0, NVEC - 1, bc.ks, bc.ke, bc.js, bc.je, bc.is,
+        bc.ie,
+                 KOKKOS_LAMBDA(const int& v, const int& k, const int& j, const int& i)
+        {
             B_U(v, k, j, i) = B_P(v, k, j, i) * G.gdet(Loci::center, j, i);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus B_CT::DangerousPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse)
+TaskStatus B_CT::DangerousPtoU(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     auto B_Uf = md->PackVariables(std::vector<std::string>{"cons.fB"});
     auto B_U = md->PackVariables(std::vector<std::string>{"cons.B"});
     auto B_P = md->PackVariables(std::vector<std::string>{"prims.B"});
 
     // Figure out indices
-    const IndexRange block = IndexRange{0, B_Uf.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_Uf.GetDim(5) - 1};
 
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     // Average the primitive vals to faces and multiply by gdet
-    const IndexRange3 bf1 = (domain == IndexDomain::entire) ?
-                            KDomain::GetRange(md, domain, F1, coarse, 1, 0) :
-                            KDomain::GetRange(md, domain, F1, coarse);
-    pmb0->par_for("PtoU_B_F1", block.s, block.e, bf1.ks, bf1.ke, bf1.js, bf1.je, bf1.is, bf1.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+    const IndexRange3 bf1 = (domain == IndexDomain::entire)
+                                ? KDomain::GetRange(md, domain, F1, coarse, 1, 0)
+                                : KDomain::GetRange(md, domain, F1, coarse);
+    pmb0->par_for("PtoU_B_F1", block.s, block.e, bf1.ks, bf1.ke, bf1.js, bf1.je, bf1.is,
+        bf1.ie,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = B_Uf.GetCoords(b);
-            B_Uf(b, F1, 0, k, j, i) = G.gdet(Loci::face1, j, i) * (B_P(b, V1, k, j, i-1) + B_P(b, V1, k, j, i)) / 2;
-        }
-    );
-    const IndexRange3 bf2 = (domain == IndexDomain::entire) ?
-                            KDomain::GetRange(md, domain, F2, coarse, 1, 0) :
-                            KDomain::GetRange(md, domain, F2, coarse);
-    pmb0->par_for("PtoU_B_F2", block.s, block.e, bf2.ks, bf2.ke, bf2.js, bf2.je, bf2.is, bf2.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+            B_Uf(b, F1, 0, k, j, i) = G.gdet(Loci::face1, j, i) *
+                                      (B_P(b, V1, k, j, i - 1) + B_P(b, V1, k, j, i)) / 2;
+        });
+    const IndexRange3 bf2 = (domain == IndexDomain::entire)
+                                ? KDomain::GetRange(md, domain, F2, coarse, 1, 0)
+                                : KDomain::GetRange(md, domain, F2, coarse);
+    pmb0->par_for("PtoU_B_F2", block.s, block.e, bf2.ks, bf2.ke, bf2.js, bf2.je, bf2.is,
+        bf2.ie,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = B_Uf.GetCoords(b);
-            B_Uf(b, F2, 0, k, j, i) = G.gdet(Loci::face2, j, i) * (B_P(b, V2, k, j-1, i) + B_P(b, V2, k, j, i)) / 2;
-        }
-    );
-    const IndexRange3 bf3 = (domain == IndexDomain::entire) ?
-                            KDomain::GetRange(md, domain, F3, coarse, 1, 0) :
-                            KDomain::GetRange(md, domain, F3, coarse);
-    pmb0->par_for("PtoU_B_F3", block.s, block.e, bf3.ks, bf3.ke, bf3.js, bf3.je, bf3.is, bf3.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+            B_Uf(b, F2, 0, k, j, i) = G.gdet(Loci::face2, j, i) *
+                                      (B_P(b, V2, k, j - 1, i) + B_P(b, V2, k, j, i)) / 2;
+        });
+    const IndexRange3 bf3 = (domain == IndexDomain::entire)
+                                ? KDomain::GetRange(md, domain, F3, coarse, 1, 0)
+                                : KDomain::GetRange(md, domain, F3, coarse);
+    pmb0->par_for("PtoU_B_F3", block.s, block.e, bf3.ks, bf3.ke, bf3.js, bf3.je, bf3.is,
+        bf3.ie,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = B_Uf.GetCoords(b);
-            B_Uf(b, F3, 0, k, j, i) = G.gdet(Loci::face3, j, i) * (B_P(b, V3, k-1, j, i) + B_P(b, V3, k, j, i)) / 2;
-        }
-    );
+            B_Uf(b, F3, 0, k, j, i) = G.gdet(Loci::face3, j, i) *
+                                      (B_P(b, V3, k - 1, j, i) + B_P(b, V3, k, j, i)) / 2;
+        });
 
     // Make sure B on poles is still zero, even though we've interpolated
     if (pmb0->coords.coords.is_spherical()) {
-        for (int i=0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
+        for (int i = 0; i < md->GetMeshPointer()->GetNumMeshBlocksThisRank(); i++) {
             auto rc = md->GetBlockData(i);
             auto pmb = rc->GetBlockPointer();
             const IndexRange3 be = KDomain::GetRange(md, IndexDomain::entire, coarse);
-            const IndexRange3 bi2 = KDomain::GetRange(md, IndexDomain::interior, F2, coarse);
+            const IndexRange3 bi2 =
+                KDomain::GetRange(md, IndexDomain::interior, F2, coarse);
             auto B_Uf_block = rc->PackVariables(std::vector<std::string>{"cons.fB"});
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2)) {
                 pmb->par_for("B_Uf_boundary", be.ks, be.ke, be.is, be.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &i) {
+                             KOKKOS_LAMBDA(const int& k, const int& i)
+                    {
                         B_Uf_block(F2, 0, k, bi2.js, i) = 0.;
-                    }
-                );
+                    });
             }
             if (KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2)) {
                 pmb->par_for("B_Uf_boundary", be.ks, be.ke, be.is, be.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &i) {
+                             KOKKOS_LAMBDA(const int& k, const int& i)
+                    {
                         B_Uf_block(F2, 0, k, bi2.je, i) = 0.;
-                    }
-                );
+                    });
             }
         }
     }
@@ -282,21 +322,25 @@ TaskStatus B_CT::DangerousPtoU(MeshData<Real> *md, IndexDomain domain, bool coar
     // Also recover conserved B at centers, just in case
     // TODO would calling UtoP be more stable?
     const IndexRange3 bc = KDomain::GetRange(md, domain, CC, coarse);
-    pmb0->par_for("UtoP_B_centerPtoU", block.s, block.e, 0, NVEC-1, bc.ks, bc.ke, bc.js, bc.je, bc.is, bc.ie,
-        KOKKOS_LAMBDA (const int &b, const int &v, const int &k, const int &j, const int &i) {
+    pmb0->par_for("UtoP_B_centerPtoU", block.s, block.e, 0, NVEC - 1, bc.ks, bc.ke, bc.js,
+        bc.je, bc.is, bc.ie,
+                  KOKKOS_LAMBDA(const int& b, const int& v, const int& k, const int& j,
+                                const int& i)
+        {
             const auto& G = B_U.GetCoords(b);
             B_U(b, v, k, j, i) = B_P(b, v, k, j, i) * G.gdet(Loci::center, j, i);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus B_CT::CalculateEMF(MeshData<Real> *md)
+TaskStatus B_CT::CalculateEMF(MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
-    if (ndim < 2) throw std::runtime_error("Face-centered constrained transport does not support 1D! Use `flux_ct` instead.");
+    if (ndim < 2)
+        throw std::runtime_error("Face-centered constrained transport does not support "
+                                 "1D! Use `flux_ct` instead.");
 
     // EMF temporary
     auto& emf_pack = md->PackVariables(std::vector<std::string>{"B_CT.emf"});
@@ -304,7 +348,7 @@ TaskStatus B_CT::CalculateEMF(MeshData<Real> *md)
     // Figure out indices
     const IndexRange3 b = KDomain::GetRange(md, IndexDomain::interior, 0, 0);
     const IndexRange3 b1 = KDomain::GetRange(md, IndexDomain::interior, 0, 1);
-    const IndexRange block = IndexRange{0, emf_pack.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, emf_pack.GetDim(5) - 1};
 
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -312,35 +356,44 @@ TaskStatus B_CT::CalculateEMF(MeshData<Real> *md)
     // This is the base of most other schemes, which make corrections
     // It is the entirety of B&S '99
     auto& B_U = md->PackVariablesAndFluxes(std::vector<std::string>{"cons.B"});
-    pmb0->par_for("B_CT_emf_BS", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je, b1.is, b1.ie,
-        KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+    pmb0->par_for("B_CT_emf_BS", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je, b1.is,
+        b1.ie,
+        KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i)
+        {
             // The basic EMF per length along edges is the B field flux
             // We use this form rather than multiply by edge length here,
             // since the default restriction op averages values
             const auto& G = B_U.GetCoords(bl);
             if (ndim > 2) {
                 emf_pack(bl, E1, 0, k, j, i) =
-                    0.25*(-B_U(bl).flux(X2DIR, V3, k - 1, j, i) - B_U(bl).flux(X2DIR, V3, k, j, i)
-                         + B_U(bl).flux(X3DIR, V2, k, j - 1, i) + B_U(bl).flux(X3DIR, V2, k, j, i));
+                    0.25 * (-B_U(bl).flux(X2DIR, V3, k - 1, j, i) -
+                               B_U(bl).flux(X2DIR, V3, k, j, i) +
+                               B_U(bl).flux(X3DIR, V2, k, j - 1, i) +
+                               B_U(bl).flux(X3DIR, V2, k, j, i));
                 emf_pack(bl, E2, 0, k, j, i) =
-                    0.25*(-B_U(bl).flux(X3DIR, V1, k, j, i - 1) - B_U(bl).flux(X3DIR, V1, k, j, i)
-                         + B_U(bl).flux(X1DIR, V3, k - 1, j, i) + B_U(bl).flux(X1DIR, V3, k, j, i));
+                    0.25 * (-B_U(bl).flux(X3DIR, V1, k, j, i - 1) -
+                               B_U(bl).flux(X3DIR, V1, k, j, i) +
+                               B_U(bl).flux(X1DIR, V3, k - 1, j, i) +
+                               B_U(bl).flux(X1DIR, V3, k, j, i));
                 emf_pack(bl, E3, 0, k, j, i) =
-                    0.25*(-B_U(bl).flux(X1DIR, V2, k, j - 1, i) - B_U(bl).flux(X1DIR, V2, k, j, i)
-                        + B_U(bl).flux(X2DIR, V1, k, j, i - 1)  + B_U(bl).flux(X2DIR, V1, k, j, i));
+                    0.25 * (-B_U(bl).flux(X1DIR, V2, k, j - 1, i) -
+                               B_U(bl).flux(X1DIR, V2, k, j, i) +
+                               B_U(bl).flux(X2DIR, V1, k, j, i - 1) +
+                               B_U(bl).flux(X2DIR, V1, k, j, i));
             } else if (ndim > 1) {
                 emf_pack(bl, E1, 0, k, j, i) = -B_U(bl).flux(X2DIR, V3, k, j, i);
-                emf_pack(bl, E2, 0, k, j, i) =  B_U(bl).flux(X1DIR, V3, k, j, i);
+                emf_pack(bl, E2, 0, k, j, i) = B_U(bl).flux(X1DIR, V3, k, j, i);
                 emf_pack(bl, E3, 0, k, j, i) =
-                    0.25*(-B_U(bl).flux(X1DIR, V2, k, j - 1, i) - B_U(bl).flux(X1DIR, V2, k, j, i)
-                         + B_U(bl).flux(X2DIR, V1, k, j, i - 1) + B_U(bl).flux(X2DIR, V1, k, j, i));
+                    0.25 * (-B_U(bl).flux(X1DIR, V2, k, j - 1, i) -
+                               B_U(bl).flux(X1DIR, V2, k, j, i) +
+                               B_U(bl).flux(X2DIR, V1, k, j, i - 1) +
+                               B_U(bl).flux(X2DIR, V1, k, j, i));
             } else {
                 emf_pack(bl, E1, 0, k, j, i) = 0;
-                emf_pack(bl, E2, 0, k, j, i) =  B_U(bl).flux(X1DIR, V3, k, j, i);
+                emf_pack(bl, E2, 0, k, j, i) = B_U(bl).flux(X1DIR, V3, k, j, i);
                 emf_pack(bl, E3, 0, k, j, i) = -B_U(bl).flux(X1DIR, V2, k, j, i);
             }
-        }
-    );
+        });
     // All corrections require/are only necessary for 2D+
     if (ndim < 2) return TaskStatus::complete;
 
@@ -349,13 +402,17 @@ TaskStatus B_CT::CalculateEMF(MeshData<Real> *md)
         // Additional terms for Stone & Gardiner '09
         // Caclulate the EMF at zone centers with primitive B, U1-3
         PackIndexMap prims_map;
-        auto& P = md->PackVariables(std::vector<std::string>{"prims.uvec", "prims.B"}, prims_map);
+        auto& P = md->PackVariables(
+            std::vector<std::string>{"prims.uvec", "prims.B"}, prims_map);
         const VarMap m_p(prims_map, false);
         auto& emfc = md->PackVariables(std::vector<std::string>{"B_CT.cemf"});
         // Need this over whole domain to have halo around EMF caclulation
         const IndexRange3 be = KDomain::GetRange(md, IndexDomain::entire);
-        pmb0->par_for("B_CT_emfc", block.s, block.e, be.ks, be.ke, be.js, be.je, be.is, be.ie,
-            KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+        pmb0->par_for("B_CT_emfc", block.s, block.e, be.ks, be.ke, be.js, be.je, be.is,
+            be.ie,
+                      KOKKOS_LAMBDA(const int& bl, const int& k, const int& j,
+                                    const int& i)
+            {
                 const auto& G = P.GetCoords(bl);
                 Real gdet = G.gdet(Loci::center, j, i);
 
@@ -364,90 +421,127 @@ TaskStatus B_CT::CalculateEMF(MeshData<Real> *md)
                 GRMHD::calc_4vecs(G, P(bl), m_p, k, j, i, Loci::center, D);
 
                 // Calculate cell-center EMF w/v x B
-                emfc(bl, V1, k, j, i) = (D.bcon[2]*D.ucon[3] - D.bcon[3]*D.ucon[2]) * gdet;
-                emfc(bl, V2, k, j, i) = (D.bcon[3]*D.ucon[1] - D.bcon[1]*D.ucon[3]) * gdet;
-                emfc(bl, V3, k, j, i) = (D.bcon[1]*D.ucon[2] - D.bcon[2]*D.ucon[1]) * gdet;
-            }
-        );
+                emfc(bl, V1, k, j, i) =
+                    (D.bcon[2] * D.ucon[3] - D.bcon[3] * D.ucon[2]) * gdet;
+                emfc(bl, V2, k, j, i) =
+                    (D.bcon[3] * D.ucon[1] - D.bcon[1] * D.ucon[3]) * gdet;
+                emfc(bl, V3, k, j, i) =
+                    (D.bcon[1] * D.ucon[2] - D.bcon[2] * D.ucon[1]) * gdet;
+            });
 
         if (scheme == "gs05_0") {
-            pmb0->par_for("B_CT_emf_GS05_0", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je, b1.is, b1.ie,
-                KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+            pmb0->par_for("B_CT_emf_GS05_0", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je,
+                b1.is, b1.ie,
+                KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i)
+                {
                     const auto& G = emfc.GetCoords(bl);
                     // Just subtract centered emf from twice the face version
                     // More stable for planar flows even without anything fancy
                     if (ndim > 2) {
-                        emf_pack(bl, E1, 0, k, j, i) = 2 * emf_pack(bl, E1, 0, k, j, i)
-                            - 0.25*(emfc(bl, V1, k, j, i)      + emfc(bl, V1, k, j - 1, i)
-                                  + emfc(bl, V1, k, j - 1, i)  + emfc(bl, V1, k - 1, j - 1, i));
-                        emf_pack(bl, E2, 0, k, j, i) = 2 * emf_pack(bl, E2, 0, k, j, i)
-                            - 0.25*(emfc(bl, V2, k, j, i)      + emfc(bl, V2, k, j, i - 1)
-                                  + emfc(bl, V2, k - 1, j, i)  + emfc(bl, V2, k - 1, j, i - 1));
+                        emf_pack(bl, E1, 0, k, j, i) =
+                            2 * emf_pack(bl, E1, 0, k, j, i) -
+                            0.25 * (emfc(bl, V1, k, j, i) + emfc(bl, V1, k, j - 1, i) +
+                                       emfc(bl, V1, k, j - 1, i) +
+                                       emfc(bl, V1, k - 1, j - 1, i));
+                        emf_pack(bl, E2, 0, k, j, i) =
+                            2 * emf_pack(bl, E2, 0, k, j, i) -
+                            0.25 * (emfc(bl, V2, k, j, i) + emfc(bl, V2, k, j, i - 1) +
+                                       emfc(bl, V2, k - 1, j, i) +
+                                       emfc(bl, V2, k - 1, j, i - 1));
                     }
-                    emf_pack(bl, E3, 0, k, j, i) = 2 * emf_pack(bl, E3, 0, k, j, i)
-                        - 0.25*(emfc(bl, V3, k, j, i)     + emfc(bl, V3, k, j, i - 1)
-                              + emfc(bl, V3, k, j - 1, i) + emfc(bl, V3, k, j - 1, i - 1));
-                }
-            );
+                    emf_pack(bl, E3, 0, k, j, i) =
+                        2 * emf_pack(bl, E3, 0, k, j, i) -
+                        0.25 * (emfc(bl, V3, k, j, i) + emfc(bl, V3, k, j, i - 1) +
+                                   emfc(bl, V3, k, j - 1, i) +
+                                   emfc(bl, V3, k, j - 1, i - 1));
+                });
         } else if (scheme == "gs05_c" || scheme == "sg07") {
             auto& rho = md->PackVariablesAndFluxes(std::vector<std::string>{"cons.rho"});
-            pmb0->par_for("B_CT_emf_SG07", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je, b1.is, b1.ie,
-                KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
-                    // Following adapted closely from AthenaK, including clever use of the mass flux for the
-                    // sign of the contact mode.
+            pmb0->par_for("B_CT_emf_SG07", block.s, block.e, b1.ks, b1.ke, b1.js, b1.je,
+                b1.is, b1.ie,
+                KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i)
+                {
+                    // Following adapted closely from AthenaK, including clever use of the
+                    // mass flux for the sign of the contact mode.
                     if (ndim > 2) {
                         // Integrate EMF to the corner using GS07 i.e. GS05 E^c upwinding
-                        Real e1_l3 = (rho(bl).flux(X2DIR, 0, k-1, j, i) >= 0.0) ?
-                                    B_U(bl).flux(X3DIR, V2, k, j-1, i) - emfc(bl, V1, k-1, j-1, i) :
-                                    B_U(bl).flux(X3DIR, V2, k, j  , i) - emfc(bl, V1, k-1, j  , i);
-                        Real e1_r3 = (rho(bl).flux(X2DIR, 0, k  , j, i  ) >= 0.0) ?
-                                    B_U(bl).flux(X3DIR, V2, k, j-1, i) - emfc(bl, V1, k  , j-1, i) :
-                                    B_U(bl).flux(X3DIR, V2, k, j  , i) - emfc(bl, V1, k  , j  , i);
-                        Real e1_l2 = (rho(bl).flux(X3DIR, 0, k, j-1, i) >= 0.0) ?
-                                    -B_U(bl).flux(X2DIR, V3, k-1, j, i) - emfc(bl, V1, k-1, j-1, i) :
-                                    -B_U(bl).flux(X2DIR, V3, k  , j, i) - emfc(bl, V1, k  , j-1, i);
-                        Real e1_r2 = (rho(bl).flux(X3DIR, 0, k, j  , i) >= 0.0) ?
-                                    -B_U(bl).flux(X2DIR, V3, k-1, j, i) - emfc(bl, V1, k-1, j  , i) :
-                                    -B_U(bl).flux(X2DIR, V3, k  , j, i) - emfc(bl, V1, k  , j  , i);
-                        emf_pack(bl, E1, 0, k, j, i) += 0.25*(e1_l3 + e1_r3 + e1_l2 + e1_r2);
+                        Real e1_l3 = (rho(bl).flux(X2DIR, 0, k - 1, j, i) >= 0.0)
+                                         ? B_U(bl).flux(X3DIR, V2, k, j - 1, i) -
+                                               emfc(bl, V1, k - 1, j - 1, i)
+                                         : B_U(bl).flux(X3DIR, V2, k, j, i) -
+                                               emfc(bl, V1, k - 1, j, i);
+                        Real e1_r3 = (rho(bl).flux(X2DIR, 0, k, j, i) >= 0.0)
+                                         ? B_U(bl).flux(X3DIR, V2, k, j - 1, i) -
+                                               emfc(bl, V1, k, j - 1, i)
+                                         : B_U(bl).flux(X3DIR, V2, k, j, i) -
+                                               emfc(bl, V1, k, j, i);
+                        Real e1_l2 = (rho(bl).flux(X3DIR, 0, k, j - 1, i) >= 0.0)
+                                         ? -B_U(bl).flux(X2DIR, V3, k - 1, j, i) -
+                                               emfc(bl, V1, k - 1, j - 1, i)
+                                         : -B_U(bl).flux(X2DIR, V3, k, j, i) -
+                                               emfc(bl, V1, k, j - 1, i);
+                        Real e1_r2 = (rho(bl).flux(X3DIR, 0, k, j, i) >= 0.0)
+                                         ? -B_U(bl).flux(X2DIR, V3, k - 1, j, i) -
+                                               emfc(bl, V1, k - 1, j, i)
+                                         : -B_U(bl).flux(X2DIR, V3, k, j, i) -
+                                               emfc(bl, V1, k, j, i);
+                        emf_pack(bl, E1, 0, k, j, i) +=
+                            0.25 * (e1_l3 + e1_r3 + e1_l2 + e1_r2);
 
-                        Real e2_l3 = (rho(bl).flux(X1DIR, 0, k-1, j, i) >= 0.0) ?
-                                    -B_U(bl).flux(X3DIR, V1, k, j, i-1) - emfc(bl, V2, k-1, j, i-1) :
-                                    -B_U(bl).flux(X3DIR, V1, k, j, i  ) - emfc(bl, V2, k-1, j, i  );
-                        Real e2_r3 = (rho(bl).flux(X1DIR, 0, k  , j, i) >= 0.0) ?
-                                    -B_U(bl).flux(X3DIR, V1, k, j, i-1) - emfc(bl, V2, k  , j, i-1) :
-                                    -B_U(bl).flux(X3DIR, V1, k, j, i  ) - emfc(bl, V2, k  , j, i  );
-                        Real e2_l1 = (rho(bl).flux(X3DIR, 0, k, j, i-1) >= 0.0) ?
-                                    B_U(bl).flux(X1DIR, V3, k-1, j, i) - emfc(bl, V2, k-1, j, i-1) :
-                                    B_U(bl).flux(X1DIR, V3, k  , j, i) - emfc(bl, V2, k  , j, i-1);
-                        Real e2_r1 = (rho(bl).flux(X3DIR, 0, k, j, i  ) >= 0.0) ?
-                                    B_U(bl).flux(X1DIR, V3, k-1, j, i) - emfc(bl, V2, k-1, j, i  ) :
-                                    B_U(bl).flux(X1DIR, V3, k  , j, i) - emfc(bl, V2, k  , j, i  );
-                        emf_pack(bl, E2, 0, k, j, i) += 0.25*(e2_l3 + e2_r3 + e2_l1 + e2_r1);
+                        Real e2_l3 = (rho(bl).flux(X1DIR, 0, k - 1, j, i) >= 0.0)
+                                         ? -B_U(bl).flux(X3DIR, V1, k, j, i - 1) -
+                                               emfc(bl, V2, k - 1, j, i - 1)
+                                         : -B_U(bl).flux(X3DIR, V1, k, j, i) -
+                                               emfc(bl, V2, k - 1, j, i);
+                        Real e2_r3 = (rho(bl).flux(X1DIR, 0, k, j, i) >= 0.0)
+                                         ? -B_U(bl).flux(X3DIR, V1, k, j, i - 1) -
+                                               emfc(bl, V2, k, j, i - 1)
+                                         : -B_U(bl).flux(X3DIR, V1, k, j, i) -
+                                               emfc(bl, V2, k, j, i);
+                        Real e2_l1 = (rho(bl).flux(X3DIR, 0, k, j, i - 1) >= 0.0)
+                                         ? B_U(bl).flux(X1DIR, V3, k - 1, j, i) -
+                                               emfc(bl, V2, k - 1, j, i - 1)
+                                         : B_U(bl).flux(X1DIR, V3, k, j, i) -
+                                               emfc(bl, V2, k, j, i - 1);
+                        Real e2_r1 = (rho(bl).flux(X3DIR, 0, k, j, i) >= 0.0)
+                                         ? B_U(bl).flux(X1DIR, V3, k - 1, j, i) -
+                                               emfc(bl, V2, k - 1, j, i)
+                                         : B_U(bl).flux(X1DIR, V3, k, j, i) -
+                                               emfc(bl, V2, k, j, i);
+                        emf_pack(bl, E2, 0, k, j, i) +=
+                            0.25 * (e2_l3 + e2_r3 + e2_l1 + e2_r1);
                     }
 
-                    Real e3_l2 = (rho(bl).flux(X1DIR, 0, k, j-1, i) >= 0.0) ?
-                                B_U(bl).flux(X2DIR, V1, k, j, i-1) - emfc(bl, V3, k, j-1, i-1) :
-                                B_U(bl).flux(X2DIR, V1, k, j, i  ) - emfc(bl, V3, k, j-1, i  );
-                    Real e3_r2 = (rho(bl).flux(X1DIR, 0, k, j  , i) >= 0.0) ?
-                                B_U(bl).flux(X2DIR, V1, k, j, i-1) - emfc(bl, V3, k, j  , i-1) :
-                                B_U(bl).flux(X2DIR, V1, k, j, i  ) - emfc(bl, V3, k, j  , i  );
-                    Real e3_l1 = (rho(bl).flux(X2DIR, 0, k, j, i-1) >= 0.0) ?
-                                -B_U(bl).flux(X1DIR, V2, k, j-1, i) - emfc(bl, V3, k, j-1, i-1) :
-                                -B_U(bl).flux(X1DIR, V2, k, j  , i) - emfc(bl, V3, k, j  , i-1);
-                    Real e3_r1 = (rho(bl).flux(X2DIR, 0, k, j, i  ) >= 0.0) ?
-                                -B_U(bl).flux(X1DIR, V2, k, j-1, i) - emfc(bl, V3, k, j-1, i  ) :
-                                -B_U(bl).flux(X1DIR, V2, k, j  , i) - emfc(bl, V3, k, j  , i  );
-                    emf_pack(bl, E3, 0, k, j, i) += 0.25*(e3_l2 + e3_r2 + e3_l1 + e3_r1);
-                }
-            );
+                    Real e3_l2 = (rho(bl).flux(X1DIR, 0, k, j - 1, i) >= 0.0)
+                                     ? B_U(bl).flux(X2DIR, V1, k, j, i - 1) -
+                                           emfc(bl, V3, k, j - 1, i - 1)
+                                     : B_U(bl).flux(X2DIR, V1, k, j, i) -
+                                           emfc(bl, V3, k, j - 1, i);
+                    Real e3_r2 =
+                        (rho(bl).flux(X1DIR, 0, k, j, i) >= 0.0)
+                            ? B_U(bl).flux(X2DIR, V1, k, j, i - 1) -
+                                  emfc(bl, V3, k, j, i - 1)
+                            : B_U(bl).flux(X2DIR, V1, k, j, i) - emfc(bl, V3, k, j, i);
+                    Real e3_l1 = (rho(bl).flux(X2DIR, 0, k, j, i - 1) >= 0.0)
+                                     ? -B_U(bl).flux(X1DIR, V2, k, j - 1, i) -
+                                           emfc(bl, V3, k, j - 1, i - 1)
+                                     : -B_U(bl).flux(X1DIR, V2, k, j, i) -
+                                           emfc(bl, V3, k, j, i - 1);
+                    Real e3_r1 =
+                        (rho(bl).flux(X2DIR, 0, k, j, i) >= 0.0)
+                            ? -B_U(bl).flux(X1DIR, V2, k, j - 1, i) -
+                                  emfc(bl, V3, k, j - 1, i)
+                            : -B_U(bl).flux(X1DIR, V2, k, j, i) - emfc(bl, V3, k, j, i);
+                    emf_pack(bl, E3, 0, k, j, i) +=
+                        0.25 * (e3_l2 + e3_r2 + e3_l1 + e3_r1);
+                });
         }
     }
 
     return TaskStatus::complete;
 }
 
-TaskStatus B_CT::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+TaskStatus B_CT::AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
@@ -456,7 +550,7 @@ TaskStatus B_CT::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomai
     auto& emf_pack = md->PackVariables(std::vector<std::string>{"B_CT.emf"});
 
     // Figure out indices
-    const IndexRange block = IndexRange{0, emf_pack.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, emf_pack.GetDim(5) - 1};
 
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -464,123 +558,154 @@ TaskStatus B_CT::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomai
     auto& dB_Uf_dt = mdudt->PackVariables(std::vector<std::string>{"cons.fB"});
     // Circulation -> change in flux at face
     const IndexRange3 bf1 = KDomain::GetRange(md, domain, F1);
-    pmb0->par_for("B_CT_Circ_1", block.s, block.e, bf1.ks, bf1.ke, bf1.js, bf1.je, bf1.is, bf1.ie,
-        KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+    pmb0->par_for("B_CT_Circ_1", block.s, block.e, bf1.ks, bf1.ke, bf1.js, bf1.je, bf1.is,
+        bf1.ie,
+        KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i)
+        {
             const auto& G = dB_Uf_dt.GetCoords(bl);
-            dB_Uf_dt(bl, F1, 0, k, j, i) = (-G.Volume<E3>(k, j + 1, i) * emf_pack(bl, E3, 0, k, j + 1, i)
-                                           + G.Volume<E3>(k, j, i)     * emf_pack(bl, E3, 0, k, j, i));
+            dB_Uf_dt(bl, F1, 0, k, j, i) =
+                (-G.Volume<E3>(k, j + 1, i) * emf_pack(bl, E3, 0, k, j + 1, i) +
+                    G.Volume<E3>(k, j, i) * emf_pack(bl, E3, 0, k, j, i));
             if (ndim > 2)
-                dB_Uf_dt(bl, F1, 0, k, j, i) += (G.Volume<E2>(k + 1, j, i) * emf_pack(bl, E2, 0, k + 1, j, i)
-                                                - G.Volume<E2>(k, j, i)    * emf_pack(bl, E2, 0, k, j, i));
+                dB_Uf_dt(bl, F1, 0, k, j, i) +=
+                    (G.Volume<E2>(k + 1, j, i) * emf_pack(bl, E2, 0, k + 1, j, i) -
+                        G.Volume<E2>(k, j, i) * emf_pack(bl, E2, 0, k, j, i));
             dB_Uf_dt(bl, F1, 0, k, j, i) /= G.Volume<F1>(k, j, i);
-        }
-    );
+        });
     const IndexRange3 bf2 = KDomain::GetRange(md, domain, F2);
-    pmb0->par_for("B_CT_Circ_2", block.s, block.e, bf2.ks, bf2.ke, bf2.js, bf2.je, bf2.is, bf2.ie,
-        KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+    pmb0->par_for("B_CT_Circ_2", block.s, block.e, bf2.ks, bf2.ke, bf2.js, bf2.je, bf2.is,
+        bf2.ie,
+        KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i)
+        {
             const auto& G = dB_Uf_dt.GetCoords(bl);
-            dB_Uf_dt(bl, F2, 0, k, j, i) = (G.Volume<E3>(k, j, i + 1) * emf_pack(bl, E3, 0, k, j, i + 1)
-                                           - G.Volume<E3>(k, j, i)    * emf_pack(bl, E3, 0, k, j, i));
+            dB_Uf_dt(bl, F2, 0, k, j, i) =
+                (G.Volume<E3>(k, j, i + 1) * emf_pack(bl, E3, 0, k, j, i + 1) -
+                    G.Volume<E3>(k, j, i) * emf_pack(bl, E3, 0, k, j, i));
             if (ndim > 2)
-                dB_Uf_dt(bl, F2, 0, k, j, i) += (-G.Volume<E1>(k + 1, j, i) * emf_pack(bl, E1, 0, k + 1, j, i)
-                                                + G.Volume<E1>(k, j, i)     * emf_pack(bl, E1, 0, k, j, i));
+                dB_Uf_dt(bl, F2, 0, k, j, i) +=
+                    (-G.Volume<E1>(k + 1, j, i) * emf_pack(bl, E1, 0, k + 1, j, i) +
+                        G.Volume<E1>(k, j, i) * emf_pack(bl, E1, 0, k, j, i));
             dB_Uf_dt(bl, F2, 0, k, j, i) /= G.Volume<F2>(k, j, i);
-        }
-    );
+        });
     const IndexRange3 bf3 = KDomain::GetRange(md, domain, F3);
-    pmb0->par_for("B_CT_Circ_3", block.s, block.e, bf3.ks, bf3.ke, bf3.js, bf3.je, bf3.is, bf3.ie,
-        KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+    pmb0->par_for("B_CT_Circ_3", block.s, block.e, bf3.ks, bf3.ke, bf3.js, bf3.je, bf3.is,
+        bf3.ie,
+                  KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i)
+        {
             const auto& G = dB_Uf_dt.GetCoords(bl);
-            dB_Uf_dt(bl, F3, 0, k, j, i) = (- G.Volume<E2>(k, j, i + 1) * emf_pack(bl, E2, 0, k, j, i + 1)
-                                            + G.Volume<E2>(k, j, i)     * emf_pack(bl, E2, 0, k, j, i)
-                                            + G.Volume<E1>(k, j + 1, i) * emf_pack(bl, E1, 0, k, j + 1, i)
-                                            - G.Volume<E1>(k, j, i)     * emf_pack(bl, E1, 0, k, j, i)) / G.Volume<F3>(k, j, i);
-        }
-    );
+            dB_Uf_dt(bl, F3, 0, k, j, i) =
+                (-G.Volume<E2>(k, j, i + 1) * emf_pack(bl, E2, 0, k, j, i + 1) +
+                    G.Volume<E2>(k, j, i) * emf_pack(bl, E2, 0, k, j, i) +
+                    G.Volume<E1>(k, j + 1, i) * emf_pack(bl, E1, 0, k, j + 1, i) -
+                    G.Volume<E1>(k, j, i) * emf_pack(bl, E1, 0, k, j, i)) /
+                G.Volume<F3>(k, j, i);
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus B_CT::DerefinePoles(MeshData<Real> *md)
+TaskStatus B_CT::DerefinePoles(MeshData<Real>* md)
 {
-    // HYERIN (01/17/24) this routine is not general yet and only applies to polar boundaries for now.
+    // HYERIN (01/17/24) this routine is not general yet and only applies to polar
+    // boundaries for now.
     auto pmesh = md->GetMeshPointer();
     const uint nlevels = pmesh->packages.Get("ISMR")->Param<uint>("nlevels");
 
     // Figure out indices
     int ng = Globals::nghost;
-    for (int iblock=0; iblock < md->NumBlocks(); iblock++) {
+    for (int iblock = 0; iblock < md->NumBlocks(); iblock++) {
         auto& rc = md->GetBlockData(iblock);
         auto pmb = rc->GetBlockPointer();
         const auto& G = pmb->coords;
         auto B_Uf = rc->PackVariables(std::vector<std::string>{"cons.fB"});
         auto B_avg = rc->PackVariables(std::vector<std::string>{"ismr.fB_avg"});
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
-            BoundaryFace bface = (BoundaryFace) i;
+            BoundaryFace bface = (BoundaryFace)i;
             auto bname = KBoundaries::BoundaryName(bface);
             auto bdir = KBoundaries::BoundaryDirection(bface);
             auto domain = KBoundaries::BoundaryDomain(bface);
             auto binner = KBoundaries::BoundaryIsInner(bface);
             if (bdir == X2DIR && KBoundaries::IsPhysicalBoundary(pmb, bface)) {
                 // indices
-                // TODO also get ranges in cells from the beginning rather than using j_p & calculating j_c
+                // TODO also get ranges in cells from the beginning rather than using j_p
+                // & calculating j_c
                 IndexRange3 bCC = KDomain::GetRange(rc, IndexDomain::interior, CC);
                 // Note these are invalid in X2! We use them only for X1/X3 directions
                 IndexRange3 bF1 = KDomain::GetRange(rc, domain, F1, ng, -ng);
                 IndexRange3 bF3 = KDomain::GetRange(rc, domain, F3, ng, -ng);
                 const int j_f = (binner) ? bCC.js : bCC.je + 1; // last physical face
-                const int jps = (binner) ? j_f + (nlevels - 1) : j_f - (nlevels - 1); // start of the lowest level of derefinement
-                const IndexRange j_p = IndexRange{(binner) ? j_f : jps, (binner) ? jps : j_f};  // Range of x2 to be de-refined
-                const int offset = (binner) ? 1 : -1; // offset to read the physical face values
-                const int point_out = offset; // if F2 B field at j_f + offset face is positive when pointing out of the cell, +1.
+                const int jps =
+                    (binner) ? j_f + (nlevels - 1)
+                             : j_f - (nlevels -
+                                         1); // start of the lowest level of derefinement
+                const IndexRange j_p = IndexRange{(binner) ? j_f : jps,
+                    (binner) ? jps : j_f}; // Range of x2 to be de-refined
+                const int offset =
+                    (binner) ? 1 : -1; // offset to read the physical face values
+                const int point_out =
+                    offset; // if F2 B field at j_f + offset face is positive when
+                            // pointing out of the cell, +1.
 
                 // Should we allow flux through the pole?
-                auto &bpars = pmesh->packages.Get("Boundaries")->AllParams();
-                const bool allow_flux = binner ? bpars.Get<bool>("excise_flux_inner_x2"):
-                                                 bpars.Get<bool>("excise_flux_outer_x2");
+                auto& bpars = pmesh->packages.Get("Boundaries")->AllParams();
+                const bool allow_flux = binner ? bpars.Get<bool>("excise_flux_inner_x2")
+                                               : bpars.Get<bool>("excise_flux_outer_x2");
 
                 // F1 average
-                pmb->par_for("B_CT_derefine_poles_avg_F1", bCC.ks, bCC.ke, j_p.s, j_p.e, bF1.is, bF1.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                        const int coarse_cell_len = m::pow(2, ((binner) ? jps - j : j - jps) + 1);
+                pmb->par_for("B_CT_derefine_poles_avg_F1", bCC.ks, bCC.ke, j_p.s, j_p.e,
+                    bF1.is, bF1.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
+                        const int coarse_cell_len =
+                            m::pow(2, ((binner) ? jps - j : j - jps) + 1);
                         const int j_c = j + ((binner) ? 0 : -1); // cell center
-                        const int k_fine = (k - ng) % coarse_cell_len; // this fine cell's k-index within the coarse cell
-                        const int k_start = k - k_fine; // starting k-index of the coarse cell
+                        const int k_fine =
+                            (k - ng) % coarse_cell_len; // this fine cell's k-index within
+                                                        // the coarse cell
+                        const int k_start =
+                            k - k_fine; // starting k-index of the coarse cell
 
-                        // average over fine cells within the coarse cell we're in
+                        // average over fine cells within the coarse cell we're
+                        // in
                         Real avg = 0.;
                         for (int ktemp = 0; ktemp < coarse_cell_len; ++ktemp)
-                            avg += B_Uf(F1, 0, k_start + ktemp, j_c, i) * G.Volume<F1>(k_start + ktemp, j_c, i);
+                            avg += B_Uf(F1, 0, k_start + ktemp, j_c, i) *
+                                   G.Volume<F1>(k_start + ktemp, j_c, i);
                         avg /= coarse_cell_len;
 
                         B_avg(F1, 0, k, j_c, i) = avg;
-                    }
-                );
+                    });
                 // F2 average
-                pmb->par_for("B_CT_derefine_poles_avg_F2", bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                        const int coarse_cell_len = m::pow(2, ((binner) ? jps - j : j - jps) + 1);
+                pmb->par_for("B_CT_derefine_poles_avg_F2", bCC.ks, bCC.ke, j_p.s, j_p.e,
+                    bCC.is, bCC.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
+                        const int coarse_cell_len =
+                            m::pow(2, ((binner) ? jps - j : j - jps) + 1);
                         // fine cell's k index within the coarse cell
                         const int k_fine = (k - ng) % coarse_cell_len;
                         // starting k-index of the coarse cell
                         const int k_start = k - k_fine;
 
                         if (!allow_flux && j == j_f) {
-                            // The fine cells have 0 fluxes through the physical-ghost boundaries.
+                            // The fine cells have 0 fluxes through the
+                            // physical-ghost boundaries.
                             B_avg(F2, 0, k, j, i) = 0.;
                         } else { // average the fine cells
                             Real avg = 0.;
                             for (int ktemp = 0; ktemp < coarse_cell_len; ++ktemp)
-                                avg += B_Uf(F2, 0, k_start + ktemp, j, i) * G.Volume<F2>(k_start + ktemp, j, i);
+                                avg += B_Uf(F2, 0, k_start + ktemp, j, i) *
+                                       G.Volume<F2>(k_start + ktemp, j, i);
                             avg /= coarse_cell_len;
 
                             B_avg(F2, 0, k, j, i) = avg;
                         }
-                    }
-                );
+                    });
                 // F3 average
-                pmb->par_for("B_CT_derefine_poles_avg_F3", bF3.ks, bF3.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                pmb->par_for("B_CT_derefine_poles_avg_F3", bF3.ks, bF3.ke, j_p.s, j_p.e,
+                    bCC.is, bCC.ie,
+                    KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         // the current level of derefinement at given j
                         const int current_lv = ((binner) ? jps - j : j - jps);
                         // half of the coarse cell's length
@@ -594,87 +719,125 @@ TaskStatus B_CT::DerefinePoles(MeshData<Real> *md)
                         const int k_start = k - k_fine;
                         const int k_half = k_start + c_half;
                         // end k-index of the coarse cell
-                        const int k_end  = k_start + coarse_cell_len;
+                        const int k_end = k_start + coarse_cell_len;
 
                         if ((k - ng) % coarse_cell_len == 0) {
                             // Don't modify faces of the coarse cells
-                            B_avg(F3, 0, k, j_c, i) = B_Uf(F3, 0, k, j_c, i) * G.Volume<F3>(k, j_c, i);
+                            B_avg(F3, 0, k, j_c, i) =
+                                B_Uf(F3, 0, k, j_c, i) * G.Volume<F3>(k, j_c, i);
                         } else {
-                            // F3: The internal faces will take care of the divB=0. The two faces of the coarse cell will remain unchanged.
-                            // First calculate the very central internal face. In other words, deal with the highest level internal face first.
-                            // Sum of F2 fluxes in the left and right half of the coarse cell each.
+                            // F3: The internal faces will take care of the divB=0. The
+                            // two faces of the coarse cell will remain unchanged. First
+                            // calculate the very central internal face. In other words,
+                            // deal with the highest level internal face first. Sum of F2
+                            // fluxes in the left and right half of the coarse cell each.
                             Real c_left_v = 0., c_right_v = 0.;
                             for (int ktemp = 0; ktemp < c_half; ++ktemp) {
-                                c_left_v  += B_Uf(F2, 0, k_half - 1 - ktemp, j + offset, i) * G.Volume<F2>(k_half - 1 - ktemp, j + offset, i);
-                                c_right_v += B_Uf(F2, 0, k_half   + ktemp, j + offset, i) * G.Volume<F2>(k_half     + ktemp, j + offset, i);
+                                c_left_v +=
+                                    B_Uf(F2, 0, k_half - 1 - ktemp, j + offset, i) *
+                                    G.Volume<F2>(k_half - 1 - ktemp, j + offset, i);
+                                c_right_v += B_Uf(F2, 0, k_half + ktemp, j + offset, i) *
+                                             G.Volume<F2>(k_half + ktemp, j + offset, i);
                             }
-                            const Real B_start = B_Uf(F3, 0, k_start, j_c, i) * G.Volume<F3>(k_start, j_c, i);
-                            const Real B_end   = B_Uf(F3, 0, k_end,   j_c, i) * G.Volume<F3>(k_end,   j_c, i);
-                            const Real B_center = (B_start + B_end + point_out * (c_right_v - c_left_v)) / 2.;
+                            const Real B_start = B_Uf(F3, 0, k_start, j_c, i) *
+                                                 G.Volume<F3>(k_start, j_c, i);
+                            const Real B_end =
+                                B_Uf(F3, 0, k_end, j_c, i) * G.Volume<F3>(k_end, j_c, i);
+                            const Real B_center =
+                                (B_start + B_end + point_out * (c_right_v - c_left_v)) /
+                                2.;
 
-                            if (k == k_half) { // if at the center, then store the calculated value.
+                            if (k == k_half) { // if at the center, then store the
+                                               // calculated value.
                                 B_avg(F3, 0, k, j_c, i) = B_center;
-                            } else if (k < k_half) { // interpolate between B_start and B_center
-                                B_avg(F3, 0, k, j_c, i) = ((c_half - k_fine) * B_start + k_fine * B_center) / (c_half);
-                            } else if (k > k_half) { // interpolate between B_end and B_center
-                                B_avg(F3, 0, k, j_c, i) = ((k_fine - c_half) * B_end + (coarse_cell_len - k_fine) * B_center) / (c_half);
+                            } else if (k < k_half) { // interpolate between B_start and
+                                                     // B_center
+                                B_avg(F3, 0, k, j_c, i) =
+                                    ((c_half - k_fine) * B_start + k_fine * B_center) /
+                                    (c_half);
+                            } else if (k >
+                                       k_half) { // interpolate between B_end and B_center
+                                B_avg(F3, 0, k, j_c, i) =
+                                    ((k_fine - c_half) * B_end +
+                                        (coarse_cell_len - k_fine) * B_center) /
+                                    (c_half);
                             }
                         }
-                    }
-                );
+                    });
 
                 // F1 write
-                pmb->par_for("B_CT_derefine_poles_F1", bCC.ks, bCC.ke, j_p.s, j_p.e, bF1.is, bF1.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                pmb->par_for("B_CT_derefine_poles_F1", bCC.ks, bCC.ke, j_p.s, j_p.e,
+                    bF1.is, bF1.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         int j_c = j + ((binner) ? 0 : -1); // cell center
-                        B_Uf(F1, 0, k, j_c, i) = B_avg(F1, 0, k, j_c, i) / G.Volume<F1>(k, j_c, i);
-                    }
-                );
+                        B_Uf(F1, 0, k, j_c, i) =
+                            B_avg(F1, 0, k, j_c, i) / G.Volume<F1>(k, j_c, i);
+                    });
                 // F2 write
-                pmb->par_for("B_CT_derefine_poles_F2", bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                        B_Uf(F2, 0, k, j, i) = B_avg(F2, 0, k, j, i) / G.Volume<F2>(k, j, i);
-                    }
-                );
+                pmb->par_for("B_CT_derefine_poles_F2", bCC.ks, bCC.ke, j_p.s, j_p.e,
+                    bCC.is, bCC.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
+                        B_Uf(F2, 0, k, j, i) =
+                            B_avg(F2, 0, k, j, i) / G.Volume<F2>(k, j, i);
+                    });
                 // F3 write
-                pmb->par_for("B_CT_derefine_poles_F3", bF3.ks, bF3.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                pmb->par_for("B_CT_derefine_poles_F3", bF3.ks, bF3.ke, j_p.s, j_p.e,
+                    bCC.is, bCC.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         int j_c = j + ((binner) ? 0 : -1); // cell center
-                        B_Uf(F3, 0, k, j_c, i) = B_avg(F3, 0, k, j_c, i) / G.Volume<F3>(k, j_c, i);
-                    }
-                );
+                        B_Uf(F3, 0, k, j_c, i) =
+                            B_avg(F3, 0, k, j_c, i) / G.Volume<F3>(k, j_c, i);
+                    });
 
                 // Average the primitive vals to zone centers
                 const int ndim = rc->GetMeshPointer()->ndim;
                 auto B_U = rc->PackVariables(std::vector<std::string>{"cons.B"});
                 auto B_P = rc->PackVariables(std::vector<std::string>{"prims.B"});
-                pmb->par_for("UtoP_B_center", bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                pmb->par_for("UtoP_B_center", bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is,
+                    bCC.ie,
+                    KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         int j_c = j + ((binner) ? 0 : -1); // cell center
-                        B_P(V1, k, j_c, i) = (B_Uf(F1, 0, k, j_c, i) / G.gdet(Loci::face1, j_c, i)
-                                        + B_Uf(F1, 0, k, j_c, i + 1) / G.gdet(Loci::face1, j_c, i + 1)) / 2;
-                        B_P(V2, k, j_c, i) = (ndim > 1) ? (B_Uf(F2, 0, k, j_c, i) / G.gdet(Loci::face2, j_c, i)
-                                                    + B_Uf(F2, 0, k, j_c + 1, i) / G.gdet(Loci::face2, j_c + 1, i)) / 2
-                                                    : B_Uf(F2, 0, k, j_c, i) / G.gdet(Loci::face2, j_c, i);
-                        B_P(V3, k, j_c, i) = (ndim > 2) ? (B_Uf(F3, 0, k, j_c, i) / G.gdet(Loci::face3, j_c, i)
-                                                    + B_Uf(F3, 0, k + 1, j_c, i) / G.gdet(Loci::face3, j_c, i)) / 2
-                                                    : B_Uf(F3, 0, k, j_c, i) / G.gdet(Loci::face3, j_c, i);
-                    }
-                );
+                        B_P(V1, k, j_c, i) =
+                            (B_Uf(F1, 0, k, j_c, i) / G.gdet(Loci::face1, j_c, i) +
+                                B_Uf(F1, 0, k, j_c, i + 1) /
+                                    G.gdet(Loci::face1, j_c, i + 1)) /
+                            2;
+                        B_P(V2, k, j_c, i) =
+                            (ndim > 1)
+                                ? (B_Uf(F2, 0, k, j_c, i) / G.gdet(Loci::face2, j_c, i) +
+                                      B_Uf(F2, 0, k, j_c + 1, i) /
+                                          G.gdet(Loci::face2, j_c + 1, i)) /
+                                      2
+                                : B_Uf(F2, 0, k, j_c, i) / G.gdet(Loci::face2, j_c, i);
+                        B_P(V3, k, j_c, i) =
+                            (ndim > 2)
+                                ? (B_Uf(F3, 0, k, j_c, i) / G.gdet(Loci::face3, j_c, i) +
+                                      B_Uf(F3, 0, k + 1, j_c, i) /
+                                          G.gdet(Loci::face3, j_c, i)) /
+                                      2
+                                : B_Uf(F3, 0, k, j_c, i) / G.gdet(Loci::face3, j_c, i);
+                    });
                 // Recover conserved B at centers
-                pmb->par_for("UtoP_B_centerPtoU", 0, NVEC-1, bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+                pmb->par_for("UtoP_B_centerPtoU", 0, NVEC - 1, bCC.ks, bCC.ke, j_p.s,
+                    j_p.e, bCC.is, bCC.ie,
+                             KOKKOS_LAMBDA(const int& v, const int& k, const int& j,
+                                           const int& i)
+                    {
                         int j_c = j + ((binner) ? 0 : -1); // cell center
-                        B_U(v, k, j_c, i) = B_P(v, k, j_c, i) * G.gdet(Loci::center, j_c, i);
-                    }
-                );
+                        B_U(v, k, j_c, i) =
+                            B_P(v, k, j_c, i) * G.gdet(Loci::center, j_c, i);
+                    });
             }
         }
     }
     return TaskStatus::complete;
 }
 
-double B_CT::MaxDivB(MeshData<Real> *md)
+double B_CT::MaxDivB(MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
@@ -686,23 +849,26 @@ double B_CT::MaxDivB(MeshData<Real> *md)
     const IndexRange ib = md->GetBoundsI(IndexDomain::interior);
     const IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
     const IndexRange kb = md->GetBoundsK(IndexDomain::interior);
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
     double max_divb;
     Kokkos::Max<double> max_reducer(max_divb);
-    pmb0->par_reduce("divB_max", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, double &local_result) {
+    pmb0->par_reduce(
+        "divB_max", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(
+            const int& b, const int& k, const int& j, const int& i, double& local_result)
+        {
             const auto& G = B_U.GetCoords(b);
             double local_divb = m::abs(face_div(G, B_U(b), ndim, k, j, i));
             if (local_divb > local_result) local_result = local_divb;
-        }
-    , max_reducer);
+        },
+        max_reducer);
 
     return max_divb;
 }
-double B_CT::BlockMaxDivB(MeshBlockData<Real> *rc)
+double B_CT::BlockMaxDivB(MeshBlockData<Real>* rc)
 {
     const int ndim = KDomain::GetNDim(rc);
 
@@ -715,17 +881,19 @@ double B_CT::BlockMaxDivB(MeshBlockData<Real> *rc)
 
     double max_divb;
     Kokkos::Max<double> max_reducer(max_divb);
-    pmb->par_reduce("divB_max", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+    pmb->par_reduce(
+        "divB_max", b.ks, b.ke, b.js, b.je, b.is, b.ie,
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+        {
             const auto& G = B_U.GetCoords();
             double local_divb = m::abs(face_div(G, B_U, ndim, k, j, i));
             if (local_divb > local_result) local_result = local_divb;
-        }
-    , max_reducer);
+        },
+        max_reducer);
 
     return max_divb;
 }
-double B_CT::GlobalMaxDivB(MeshData<Real> *md, bool all_reduce)
+double B_CT::GlobalMaxDivB(MeshData<Real>* md, bool all_reduce)
 {
     if (all_reduce) {
         Reductions::StartToAll<Real>(md, 2, MaxDivB(md), MPI_MAX);
@@ -736,7 +904,7 @@ double B_CT::GlobalMaxDivB(MeshData<Real> *md, bool all_reduce)
     }
 }
 
-TaskStatus B_CT::PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
+TaskStatus B_CT::PrintGlobalMaxDivB(MeshData<Real>* md, bool kill_on_large_divb)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -761,7 +929,7 @@ TaskStatus B_CT::PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
 
 // TODO unify these by adding FillOutputMesh option
 
-void B_CT::CalcDivB(MeshData<Real> *md, std::string divb_field_name)
+void B_CT::CalcDivB(MeshData<Real>* md, std::string divb_field_name)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
@@ -773,20 +941,20 @@ void B_CT::CalcDivB(MeshData<Real> *md, std::string divb_field_name)
     const IndexRange ib = md->GetBoundsI(IndexDomain::interior);
     const IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
     const IndexRange kb = md->GetBoundsK(IndexDomain::interior);
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
     // See MaxDivB for details
     pmb0->par_for("calc_divB", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = B_U.GetCoords(b);
             divB(b, 0, k, j, i) = face_div(G, B_U(b), ndim, k, j, i);
-        }
-    );
+        });
 }
 
-void B_CT::FillOutput(MeshBlock *pmb, ParameterInput *pin)
+void B_CT::FillOutput(MeshBlock* pmb, ParameterInput* pin)
 {
     // This is called after the step, use "base" container
     auto rc = pmb->meshblock_data.Get("base");
@@ -799,12 +967,12 @@ void B_CT::FillOutput(MeshBlock *pmb, ParameterInput *pin)
     const IndexRange ib = rc->GetBoundsI(IndexDomain::interior);
     const IndexRange jb = rc->GetBoundsJ(IndexDomain::interior);
     const IndexRange kb = rc->GetBoundsK(IndexDomain::interior);
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     pmb->par_for("divB_output", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             const auto& G = B_U.GetCoords();
             divB(0, k, j, i) = face_div(G, B_U, ndim, k, j, i);
-        }
-    );
+        });
 }

--- a/kharma/b_ct/b_ct.hpp
+++ b/kharma/b_ct/b_ct.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_ct.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,46 +45,49 @@
  * This physics package implements Constrained Transport of a split face-centered B field.
  * Any CT implementations should probably go here.
  */
-namespace B_CT {
+namespace B_CT
+{
 /**
  * Declare fields, initialize (few) parameters
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Get the primitive variables, which in Parthenon's nomenclature are "derived"
- * 
- * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
- * 
+ *
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost
+ * zones.
+ *
  * input: Conserved B = sqrt(-g) * B^i
  * output: Primitive B = B^i
  */
-TaskStatus BlockUtoP(MeshBlockData<Real> *mbd, IndexDomain domain, bool coarse=false);
-TaskStatus MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
+TaskStatus BlockUtoP(MeshBlockData<Real>* mbd, IndexDomain domain, bool coarse = false);
+TaskStatus MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse = false);
 
 /**
  * Interpolate primitive B to faces, then multiply by gdet
  * DANGEROUS as it replaces conserved field state. Only used for resizing runs,
  * and only with B_Cleanup::CleanupDivergence directly afterward!
  */
-TaskStatus DangerousPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
+TaskStatus DangerousPtoU(MeshData<Real>* md, IndexDomain domain, bool coarse = false);
 
 /**
  * Calculate the EMF around edges of faces caused by the flux of B field
  * through each face.
  */
-TaskStatus CalculateEMF(MeshData<Real> *md);
+TaskStatus CalculateEMF(MeshData<Real>* md);
 
 /**
  * Calculate the change in magnetic field on faces for this step,
  * from the EMFs at edges.
  */
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 
 /**
  * Derefine face-centered B at poles without introducing divergence
  */
-TaskStatus DerefinePoles(MeshData<Real> *md);
+TaskStatus DerefinePoles(MeshData<Real>* md);
 
 /**
  * Calculate maximum corner-centered divergence of magnetic field,
@@ -92,24 +95,24 @@ TaskStatus DerefinePoles(MeshData<Real> *md);
  * Used as a Parthenon History function, so must take exactly the
  * listed arguments
  */
-double MaxDivB(MeshData<Real> *md);
-double BlockMaxDivB(MeshBlockData<Real> *rc);
+double MaxDivB(MeshData<Real>* md);
+double BlockMaxDivB(MeshBlockData<Real>* rc);
 
 /**
  * Returns the global maximum value, rather than the maximum over this rank's MeshData
  */
-double GlobalMaxDivB(MeshData<Real> *md, bool all_reduce=false);
+double GlobalMaxDivB(MeshData<Real>* md, bool all_reduce = false);
 
 /**
  * Diagnostics printed/computed after each step
  * Currently just max divB
  */
-TaskStatus PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb=false);
+TaskStatus PrintGlobalMaxDivB(MeshData<Real>* md, bool kill_on_large_divb = false);
 
 /**
  * Diagnostics function should print divB, and optionally stop execution if it's large
  */
-inline TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+inline TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto& params = md->GetMeshPointer()->block_list[0]->packages.Get("B_CT")->AllParams();
     return PrintGlobalMaxDivB(md, params.Get<bool>("kill_on_large_divb"));
@@ -118,11 +121,11 @@ inline TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
 /**
  * Fill fields which are calculated only for output to file, i.e., divB
  */
-void FillOutput(MeshBlock *pmb, ParameterInput *pin);
+void FillOutput(MeshBlock* pmb, ParameterInput* pin);
 /**
  * Fill field "name" with divB
  */
-void CalcDivB(MeshData<Real> *md, std::string divb_field_name="divB");
+void CalcDivB(MeshData<Real>* md, std::string divb_field_name = "divB");
 
 // BOUNDARY FUNCTIONS
 // Maintaining zero divergence for face fields on boundaries takes some extra work
@@ -130,44 +133,51 @@ void CalcDivB(MeshData<Real> *md, std::string divb_field_name="divB");
 /**
  * Don't allow EMF inside of a boundary, effectively making it a superconducting surface*
  * Used for Dirichlet and reflecting conditions.
- * 
+ *
  * *mostly. I think
  */
-void ZeroBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse);
+void ZeroBoundaryEMF(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& emfpack, bool coarse);
 
 /**
- * Average all EMFs corresponding to the coordinate pole location, e.g. usually all E1 on X2 faces
+ * Average all EMFs corresponding to the coordinate pole location, e.g. usually all E1 on
+ * X2 faces
  */
-void AverageBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse);
+void AverageBoundaryEMF(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& emfpack, bool coarse);
 
 /**
- * Subtract the average B3 from each face, as if a loop reconnected across the polar boundary.
- * Preserves divB, since differences across cells remain the same after subtracting a constant.
+ * Subtract the average B3 from each face, as if a loop reconnected across the polar
+ * boundary. Preserves divB, since differences across cells remain the same after
+ * subtracting a constant.
  */
-void ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse);
+void ReconnectBoundaryB3(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& emfpack, bool coarse);
 
 /**
- * Reset an outflow condition to have no divergence, even if a field line exits the domain.
- * Could maybe be used on other boundaries, but resets the perpendicular face so use with caution.
+ * Reset an outflow condition to have no divergence, even if a field line exits the
+ * domain. Could maybe be used on other boundaries, but resets the perpendicular face so
+ * use with caution.
  */
-void DestructiveBoundaryClean(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &fpack, bool coarse);
+void DestructiveBoundaryClean(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& fpack, bool coarse);
 
 /**
- * Take the curl over the whole domain. Defined in-header since it's templated on face and NDIM
+ * Take the curl over the whole domain. Defined in-header since it's templated on face and
+ * NDIM
  */
 template<TE el, int NDIM>
-inline void EdgeCurl(MeshBlockData<Real> *rc, const GridVector& A,
-                                     const VariablePack<Real>& B_U, IndexDomain domain)
+inline void EdgeCurl(MeshBlockData<Real>* rc, const GridVector& A,
+    const VariablePack<Real>& B_U, IndexDomain domain)
 {
     auto pmb = rc->GetBlockPointer();
-    const auto &G = pmb->coords;
+    const auto& G = pmb->coords;
     IndexRange3 bB = KDomain::GetRange(rc, domain, el);
-    pmb->par_for(
-        "EdgeCurl", bB.ks, bB.ke, bB.js, bB.je, bB.is, bB.ie,
-        KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+    pmb->par_for("EdgeCurl", bB.ks, bB.ke, bB.js, bB.je, bB.is, bB.ie,
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             B_CT::edge_curl<el, NDIM>(G, A, B_U, k, j, i);
-        }
-    );
+        });
 }
 
 }

--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -42,7 +42,8 @@
 #include "inverter.hpp"
 #include "kharma.hpp"
 
-void B_CT::ZeroBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse)
+void B_CT::ZeroBoundaryEMF(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& emfpack, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
     const BoundaryFace bface = KBoundaries::BoundaryFaceOf(domain);
@@ -50,7 +51,7 @@ void B_CT::ZeroBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const Va
     const int bdir = KBoundaries::BoundaryDirection(bface);
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     // Select edges which lie on the domain face, zero only those
-    for (auto &el : OrthogonalEdges(bdir)) {
+    for (auto& el : OrthogonalEdges(bdir)) {
         auto b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
         int i_face = (binner) ? b.ie : b.is;
         int j_face = (binner) ? b.je : b.js;
@@ -58,16 +59,16 @@ void B_CT::ZeroBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const Va
         IndexRange ib = (bdir == 1) ? IndexRange{i_face, i_face} : IndexRange{b.is, b.ie};
         IndexRange jb = (bdir == 2) ? IndexRange{j_face, j_face} : IndexRange{b.js, b.je};
         IndexRange kb = (bdir == 3) ? IndexRange{k_face, k_face} : IndexRange{b.ks, b.ke};
-        pmb->par_for(
-            "zero_EMF_" + bname, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+        pmb->par_for("zero_EMF_" + bname, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 emfpack(el, 0, k, j, i) = 0;
-            }
-        );
+            });
     }
 }
 
-void B_CT::AverageBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &emfpack, bool coarse)
+void B_CT::AverageBoundaryEMF(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& emfpack, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
     const BoundaryFace bface = KBoundaries::BoundaryFaceOf(domain);
@@ -76,17 +77,17 @@ void B_CT::AverageBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const int ndim = KDomain::GetNDim(rc);
 
-    for (auto &el : OrthogonalEdges(bdir)) {
+    for (auto& el : OrthogonalEdges(bdir)) {
         if (bdir == X2DIR && el == E3 && pmb->coords.coords.is_spherical()) {
             // X3 EMF must be zero *on* polar face, since edge size is 0
             IndexRange3 b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
-            pmb->par_for(
-                "zero_polar_EMF3_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+            pmb->par_for("zero_polar_EMF3_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     emfpack(el, 0, k, j, i) = 0;
-                }
-            );
-        } else if (ndim < 3 && ((bdir == X2DIR && el == E1) || (bdir == X1DIR && el == E2))) {
+                });
+        } else if (ndim < 3 &&
+                   ((bdir == X2DIR && el == E1) || (bdir == X1DIR && el == E2))) {
             // In 2D, "averaging" should just mean not zeroing E1 on X2 or E2 on X1
             continue;
         } else {
@@ -124,9 +125,10 @@ void B_CT::AverageBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const
                     inner_dir = X1DIR;
                 }
             }
-            parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_EMF_" + bname, pmb->exec_space,
-                0, 1, outer.s, outer.e,
-                KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& o) {
+            parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_EMF_" + bname,
+                pmb->exec_space, 0, 1, outer.s, outer.e,
+                KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& o)
+                {
                     double emf_sum = 0.;
                     Kokkos::Sum<double> sum_reducer(emf_sum);
 
@@ -140,25 +142,31 @@ void B_CT::AverageBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const
                     int len;
                     if (inner_dir == X1DIR) {
                         len = bi.ie - bi.is;
-                        parthenon::par_reduce_inner(inner_loop_pattern_ttr_tag, member, bi.is, bi.ie - 1,
-                            [&](const int& i, double& local_result) {
+                        parthenon::par_reduce_inner(
+                            inner_loop_pattern_ttr_tag, member, bi.is, bi.ie - 1,
+                            [&](const int& i, double& local_result)
+                            {
                                 local_result += emfpack(el, 0, kk, jj, i);
-                            }
-                        , sum_reducer);
+                            },
+                            sum_reducer);
                     } else if (inner_dir == X2DIR) {
                         len = bi.je - bi.js;
-                        parthenon::par_reduce_inner(inner_loop_pattern_ttr_tag, member, bi.js, bi.je - 1,
-                            [&](const int& j, double& local_result) {
+                        parthenon::par_reduce_inner(
+                            inner_loop_pattern_ttr_tag, member, bi.js, bi.je - 1,
+                            [&](const int& j, double& local_result)
+                            {
                                 local_result += emfpack(el, 0, kk, j, ii);
-                            }
-                        , sum_reducer);
+                            },
+                            sum_reducer);
                     } else {
                         len = bi.ke - bi.ks;
-                        parthenon::par_reduce_inner(inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke - 1,
-                            [&](const int& k, double& local_result) {
+                        parthenon::par_reduce_inner(
+                            inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke - 1,
+                            [&](const int& k, double& local_result)
+                            {
                                 local_result += emfpack(el, 0, k, jj, ii);
-                            }
-                        , sum_reducer);
+                            },
+                            sum_reducer);
                     }
                     member.team_barrier();
 
@@ -168,30 +176,30 @@ void B_CT::AverageBoundaryEMF(MeshBlockData<Real> *rc, IndexDomain domain, const
                     // Set all EMFs identically (even ghosts, to keep divB)
                     if (inner_dir == X1DIR) {
                         parthenon::par_for_inner(member, b.is, b.ie,
-                            [&](const int& i) {
+                            [&](const int& i)
+                            {
                                 emfpack(el, 0, kk, jj, i) = emf_av;
-                            }
-                        );
+                            });
                     } else if (inner_dir == X2DIR) {
                         parthenon::par_for_inner(member, b.js, b.je,
-                            [&](const int& j) {
+                            [&](const int& j)
+                            {
                                 emfpack(el, 0, kk, j, ii) = emf_av;
-                            }
-                        );
+                            });
                     } else {
                         parthenon::par_for_inner(member, b.ks, b.ke,
-                            [&](const int& k) {
+                            [&](const int& k)
+                            {
                                 emfpack(el, 0, k, jj, ii) = emf_av;
-                            }
-                        );
+                            });
                     }
-                }
-            );
+                });
         }
     }
 }
 
-void B_CT::DestructiveBoundaryClean(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &fpack, bool coarse)
+void B_CT::DestructiveBoundaryClean(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& fpack, bool coarse)
 {
     // Set XN faces to keep clean divergence at outflow XN boundary
     // Feels wrong to work backward from no divergence, but they are just outflow...
@@ -202,7 +210,8 @@ void B_CT::DestructiveBoundaryClean(MeshBlockData<Real> *rc, IndexDomain domain,
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const TopologicalElement face = FaceOf(bdir);
     // Correct last domain face, too
-    auto b = KDomain::GetRange(rc, domain, face, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
+    auto b =
+        KDomain::GetRange(rc, domain, face, (binner) ? 0 : -1, (binner) ? 1 : 0, coarse);
     // Need the coordinates for this boundary, uniquely
     auto G = pmb->coords;
     const int ndim = pmb->pmy_mesh->ndim;
@@ -210,71 +219,89 @@ void B_CT::DestructiveBoundaryClean(MeshBlockData<Real> *rc, IndexDomain domain,
         const int i_face = (binner) ? b.ie : b.is;
         for (int iadd = 0; iadd <= (b.ie - b.is); iadd++) {
             const int i = (binner) ? i_face - iadd : i_face + iadd;
-            const int last_rank_f  = (binner) ? i + 1 : i - 1;
-            const int last_rank_c  = (binner) ? i     : i - 1;
-            const int outward_sign = (binner) ? -1.   : 1.;
-            pmb->par_for(
-                "correct_face_vector_" + bname, b.ks, b.ke, b.js, b.je, i, i,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    // Other faces have been updated, just need to clean divergence
-                    // Subtract off their contributions to find ours. Note our partner face contributes differently,
-                    // depending on whether we're the i+1 "outward" face, or the i "innward" face
-                    Real new_face = - (-outward_sign) * fpack(F1, 0, k, j, last_rank_f) * G.Volume<F1>(k, j, last_rank_f)
-                                    - (fpack(F2, 0, k, j + 1, last_rank_c) * G.Volume<F2>(k, j + 1, last_rank_c)
-                                        - fpack(F2, 0, k, j, last_rank_c) * G.Volume<F2>(k, j, last_rank_c));
+            const int last_rank_f = (binner) ? i + 1 : i - 1;
+            const int last_rank_c = (binner) ? i : i - 1;
+            const int outward_sign = (binner) ? -1. : 1.;
+            pmb->par_for("correct_face_vector_" + bname, b.ks, b.ke, b.js, b.je, i, i,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    // Other faces have been updated, just need to clean
+                    // divergence Subtract off their contributions to find ours.
+                    // Note our partner face contributes differently, depending
+                    // on whether we're the i+1 "outward" face, or the i
+                    // "innward" face
+                    Real new_face = -(-outward_sign) * fpack(F1, 0, k, j, last_rank_f) *
+                                        G.Volume<F1>(k, j, last_rank_f) -
+                                    (fpack(F2, 0, k, j + 1, last_rank_c) *
+                                            G.Volume<F2>(k, j + 1, last_rank_c) -
+                                        fpack(F2, 0, k, j, last_rank_c) *
+                                            G.Volume<F2>(k, j, last_rank_c));
                     if (ndim > 2)
-                        new_face -= fpack(F3, 0, k + 1, j, last_rank_c) * G.Volume<F3>(k + 1, j, last_rank_c)
-                                    - fpack(F3, 0, k, j, last_rank_c) * G.Volume<F3>(k, j, last_rank_c);
+                        new_face -= fpack(F3, 0, k + 1, j, last_rank_c) *
+                                        G.Volume<F3>(k + 1, j, last_rank_c) -
+                                    fpack(F3, 0, k, j, last_rank_c) *
+                                        G.Volume<F3>(k, j, last_rank_c);
 
-                    fpack(F1, 0, k, j, i) = outward_sign * new_face / G.Volume<F1>(k, j, i);
-                }
-            );
+                    fpack(F1, 0, k, j, i) =
+                        outward_sign * new_face / G.Volume<F1>(k, j, i);
+                });
         }
     } else if (bdir == X2DIR) {
         const int j_face = (binner) ? b.je : b.js;
         for (int jadd = 0; jadd <= (b.je - b.js); jadd++) {
             const int j = (binner) ? j_face - jadd : j_face + jadd;
-            const int last_rank_f  = (binner) ? j + 1 : j - 1;
-            const int last_rank_c  = (binner) ? j     : j - 1;
-            const int outward_sign = (binner) ? -1.   : 1.;
-            pmb->par_for(
-                "correct_face_vector_" + bname, b.ks, b.ke, j, j, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    Real new_face = - (-outward_sign) * fpack(F2, 0, k, last_rank_f, i) * G.Volume<F2>(k, last_rank_f, i)
-                                    - (fpack(F1, 0, k, last_rank_c, i + 1) * G.Volume<F1>(k, last_rank_c, i + 1)
-                                        - fpack(F1, 0, k, last_rank_c, i) * G.Volume<F1>(k, last_rank_c, i));
+            const int last_rank_f = (binner) ? j + 1 : j - 1;
+            const int last_rank_c = (binner) ? j : j - 1;
+            const int outward_sign = (binner) ? -1. : 1.;
+            pmb->par_for("correct_face_vector_" + bname, b.ks, b.ke, j, j, b.is, b.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    Real new_face = -(-outward_sign) * fpack(F2, 0, k, last_rank_f, i) *
+                                        G.Volume<F2>(k, last_rank_f, i) -
+                                    (fpack(F1, 0, k, last_rank_c, i + 1) *
+                                            G.Volume<F1>(k, last_rank_c, i + 1) -
+                                        fpack(F1, 0, k, last_rank_c, i) *
+                                            G.Volume<F1>(k, last_rank_c, i));
                     if (ndim > 2)
-                        new_face -= fpack(F3, 0, k + 1, last_rank_c, i) * G.Volume<F3>(k + 1, last_rank_c, i)
-                                    - fpack(F3, 0, k, last_rank_c, i) * G.Volume<F3>(k, last_rank_c, i);
+                        new_face -= fpack(F3, 0, k + 1, last_rank_c, i) *
+                                        G.Volume<F3>(k + 1, last_rank_c, i) -
+                                    fpack(F3, 0, k, last_rank_c, i) *
+                                        G.Volume<F3>(k, last_rank_c, i);
 
-                    fpack(F2, 0, k, j, i) = outward_sign * new_face / G.Volume<F2>(k, j, i);
-                }
-            );
+                    fpack(F2, 0, k, j, i) =
+                        outward_sign * new_face / G.Volume<F2>(k, j, i);
+                });
         }
     } else {
         const int k_face = (binner) ? b.ie : b.is;
         for (int kadd = 0; kadd <= (b.ie - b.is); kadd++) {
             const int k = (binner) ? k_face - kadd : k_face + kadd;
-            const int last_rank_f  = (binner) ? k + 1 : k - 1;
-            const int last_rank_c  = (binner) ? k     : k - 1;
-            const int outward_sign = (binner) ? -1.   : 1.;
-            pmb->par_for(
-                "correct_face_vector_" + bname, k, k, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    Real new_face = - (-outward_sign) * fpack(F3, 0, last_rank_f, j, i) * G.Volume<F3>(last_rank_f, j, i)
-                                    - (fpack(F1, 0, last_rank_c, j, i + 1) * G.Volume<F1>(last_rank_c, j, i + 1)
-                                        - fpack(F1, 0, last_rank_c, j, i) * G.Volume<F1>(last_rank_c, j, i))
-                                    - (fpack(F2, 0, last_rank_c, j + 1, i) * G.Volume<F2>(last_rank_c, j + 1, i)
-                                        - fpack(F2, 0, last_rank_c, j, i) * G.Volume<F2>(last_rank_c, j, i));
+            const int last_rank_f = (binner) ? k + 1 : k - 1;
+            const int last_rank_c = (binner) ? k : k - 1;
+            const int outward_sign = (binner) ? -1. : 1.;
+            pmb->par_for("correct_face_vector_" + bname, k, k, b.js, b.je, b.is, b.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    Real new_face = -(-outward_sign) * fpack(F3, 0, last_rank_f, j, i) *
+                                        G.Volume<F3>(last_rank_f, j, i) -
+                                    (fpack(F1, 0, last_rank_c, j, i + 1) *
+                                            G.Volume<F1>(last_rank_c, j, i + 1) -
+                                        fpack(F1, 0, last_rank_c, j, i) *
+                                            G.Volume<F1>(last_rank_c, j, i)) -
+                                    (fpack(F2, 0, last_rank_c, j + 1, i) *
+                                            G.Volume<F2>(last_rank_c, j + 1, i) -
+                                        fpack(F2, 0, last_rank_c, j, i) *
+                                            G.Volume<F2>(last_rank_c, j, i));
 
-                    fpack(F3, 0, k, j, i) = outward_sign * new_face / G.Volume<F3>(k, j, i);
-                }
-            );
+                    fpack(F3, 0, k, j, i) =
+                        outward_sign * new_face / G.Volume<F3>(k, j, i);
+                });
         }
     }
 }
 
-void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, const VariablePack<Real> &fpack, bool coarse)
+void B_CT::ReconnectBoundaryB3(MeshBlockData<Real>* rc, IndexDomain domain,
+    const VariablePack<Real>& fpack, bool coarse)
 {
     // We're also sometimes called on coarse buffers with or without AMR.
     // Use of transmitting polar conditions when coarse buffers matter (e.g., refinement
@@ -291,17 +318,21 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
     // Pull cell-centered values, as we need to update fluid primitives
     // TODO standardize on passing Packs or Datas...
     PackIndexMap prims_map, cons_map;
-    auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    auto U = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    auto P = rc->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+    auto U = rc->PackVariables(
+        std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
     const auto& G = pmb->coords;
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
-    const int reconnection_outer_buffer = pmb->packages.Get("B_CT")->Param<int>("reconnection_outer_buffer");
+    const int reconnection_outer_buffer =
+        pmb->packages.Get("B_CT")->Param<int>("reconnection_outer_buffer");
 
-    const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+    const Floors::Prescription floors =
+        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
     // Don't be fooled, this function does *not* support/preserve EMHD values
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
@@ -309,48 +340,56 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
     IndexRange3 b = KDomain::GetRange(rc, domain, F3, coarse);
     IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, F3, coarse);
     const int jf = (binner) ? bi.js : bi.je; // j index of last zone next to pole
-    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_B3_" + bname, pmb->exec_space,
-        0, 1, 0, fpack.GetDim(4)-1, b.is, b.ie - reconnection_outer_buffer,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int &v, const int& i) {
+    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_B3_" + bname,
+        pmb->exec_space, 0, 1, 0, fpack.GetDim(4) - 1, b.is,
+        b.ie - reconnection_outer_buffer,
+        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& v, const int& i)
+        {
             // Sum the first rank of B3
             double B3_sum = 0.;
             Kokkos::Sum<double> sum_reducer(B3_sum);
-            parthenon::par_reduce_inner(inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke - 1,
-                [&](const int& k, double& local_result) {
+            parthenon::par_reduce_inner(
+                inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke - 1,
+                [&](const int& k, double& local_result)
+                {
                     local_result += fpack(F3, v, k, jf, i);
-                }
-            , sum_reducer);
+                },
+                sum_reducer);
             member.team_barrier();
 
             // Calculate the average and modify all B3 identically
             // This will preserve their differences->divergence
             const double B3_av = B3_sum / (bi.ke - bi.ks);
             parthenon::par_for_inner(member, b.ks, b.ke,
-                [&](const int& k) {
+                [&](const int& k)
+                {
                     fpack(F3, v, k, jf, i) -= B3_av;
-                }
-            );
+                });
             member.team_barrier();
 
-            // Update cell-centered conserved & primitive B, and cell primitive fluid variables, in the zones we touched
-            parthenon::par_for_inner(member, b.ks, b.ke-1, // iterate over all *cells* k
-                [&](const int& k) {
-                    P(m_p.B3, k, jf, i) =  (fpack(F3, 0, k, jf, i) / G.gdet(Loci::face3, jf, i)
-                                        + fpack(F3, 0, k + 1, jf, i) / G.gdet(Loci::face3, jf, i)) / 2;
-                    U(m_u.B3, k, jf, i) = P(m_p.B3, k, jf, i) * G.gdet(Loci::center, jf, i);
+            // Update cell-centered conserved & primitive B, and cell primitive fluid
+            // variables, in the zones we touched
+            parthenon::par_for_inner(member, b.ks,
+                b.ke - 1, // iterate over all *cells* k
+                [&](const int& k)
+                {
+                    P(m_p.B3, k, jf, i) =
+                        (fpack(F3, 0, k, jf, i) / G.gdet(Loci::face3, jf, i) +
+                            fpack(F3, 0, k + 1, jf, i) / G.gdet(Loci::face3, jf, i)) /
+                        2;
+                    U(m_u.B3, k, jf, i) =
+                        P(m_p.B3, k, jf, i) * G.gdet(Loci::center, jf, i);
 
                     // Recover primitive GRMHD variables from our modified U
-                    Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              25, 1e-12, false);
+                    Inverter::u_to_p<Inverter::Type::kastaun>(
+                        G, U, m_u, gam, k, jf, i, P, m_p, Loci::center, 25, 1e-12, false);
                     // Floor them
                     // TODO THIS IS IN FLUID FRAME
-                    int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
+                    int fflag = Floors::apply_geo_floors(
+                        G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Recalculate U on anything we floored
                     if (fflag)
                         GRMHD::p_to_u(G, P, m_p, gam, k, jf, i, U, m_u, Loci::center);
-
-                }
-            );
-        }
-    );
+                });
+        });
 }

--- a/kharma/b_ct/b_ct_functions.hpp
+++ b/kharma/b_ct/b_ct_functions.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_ct_functions.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,16 +42,16 @@
 #include <parthenon/parthenon.hpp>
 
 // Device functions for B_CT package
-namespace B_CT {
+namespace B_CT
+{
 
 template<typename Global>
-KOKKOS_INLINE_FUNCTION Real face_div(const GRCoordinates &G, Global &v, const int &ndim, const int &k, const int &j, const int &i)
+KOKKOS_INLINE_FUNCTION Real face_div(const GRCoordinates& G, Global& v, const int& ndim,
+    const int& k, const int& j, const int& i)
 {
     Real du = (v(F1, 0, k, j, i + 1) - v(F1, 0, k, j, i)) / G.Dxc<1>(k, j, i);
-    if (ndim > 1)
-        du += (v(F2, 0, k, j + 1, i) - v(F2, 0, k, j, i)) / G.Dxc<2>(k, j, i);
-    if (ndim > 2)
-        du += (v(F3, 0, k + 1, j, i) - v(F3, 0, k, j, i)) / G.Dxc<3>(k, j, i);
+    if (ndim > 1) du += (v(F2, 0, k, j + 1, i) - v(F2, 0, k, j, i)) / G.Dxc<2>(k, j, i);
+    if (ndim > 2) du += (v(F3, 0, k + 1, j, i) - v(F3, 0, k, j, i)) / G.Dxc<3>(k, j, i);
     return du;
 }
 
@@ -61,30 +61,30 @@ KOKKOS_INLINE_FUNCTION Real face_div(const GRCoordinates &G, Global &v, const in
  * Note this is backward-difference: face N borders cells N-1 & N
  */
 template<CoordinateDirection DIR>
-KOKKOS_FORCEINLINE_FUNCTION double face_grad(const GRCoordinates& G, const VariablePack<Real>& P,
-                                          const int& k, const int& j, const int& i)
+KOKKOS_FORCEINLINE_FUNCTION double face_grad(const GRCoordinates& G,
+    const VariablePack<Real>& P, const int& k, const int& j, const int& i)
 {
     // Backward gradient to cell faces
     if constexpr (DIR == X1DIR) {
-        return (P(0, k, j, i) - P(0, k, j, i-1)) / G.Dxc<1>(k, j, i);
+        return (P(0, k, j, i) - P(0, k, j, i - 1)) / G.Dxc<1>(k, j, i);
     } else if constexpr (DIR == X2DIR) {
-        return (P(0, k, j, i) - P(0, k, j-1, i)) / G.Dxc<2>(k, j, i);
+        return (P(0, k, j, i) - P(0, k, j - 1, i)) / G.Dxc<2>(k, j, i);
     } else if constexpr (DIR == X3DIR) {
-        return (P(0, k, j, i) - P(0, k-1, j, i)) / G.Dxc<3>(k, j, i);
+        return (P(0, k, j, i) - P(0, k - 1, j, i)) / G.Dxc<3>(k, j, i);
     }
 }
 
 template<TE el, int NDIM>
-KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& A, const VariablePack<Real>& B_U,
-                                    const int& k, const int& j, const int& i)
+KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& A,
+    const VariablePack<Real>& B_U, const int& k, const int& j, const int& i)
 {
     if constexpr (NDIM == 2) {
         if constexpr (el == TE::F1) {
             // A3,2 derivative
-            B_U(F1, 0, k, j, i) =   (A(V3, k, j + 1, i) - A(V3, k, j, i)) / G.Dxc<2>(j);
+            B_U(F1, 0, k, j, i) = (A(V3, k, j + 1, i) - A(V3, k, j, i)) / G.Dxc<2>(j);
         } else if constexpr (el == TE::F2) {
             // A3,1 derivative;
-            B_U(F2, 0, k, j, i) = - (A(V3, k, j, i + 1) - A(V3, k, j, i)) / G.Dxc<1>(i);
+            B_U(F2, 0, k, j, i) = -(A(V3, k, j, i + 1) - A(V3, k, j, i)) / G.Dxc<1>(i);
         } else if constexpr (el == TE::F3) {
             B_U(F3, 0, k, j, i) = 0.;
         }
@@ -94,27 +94,30 @@ KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& 
         if constexpr (el == TE::F1) {
             // A3,2 derivative
             const Real A3c2f = (A(V3, k, j + 1, i) + A(V3, k + 1, j + 1, i)) / 2;
-            const Real A3c2b = (A(V3, k, j, i)     + A(V3, k + 1, j, i)) / 2;
+            const Real A3c2b = (A(V3, k, j, i) + A(V3, k + 1, j, i)) / 2;
             // A2,3 derivative
             const Real A2c3f = (A(V2, k + 1, j, i) + A(V2, k + 1, j + 1, i)) / 2;
-            const Real A2c3b = (A(V2, k, j, i)     + A(V2, k, j + 1, i)) / 2;
-            B_U(F1, 0, k, j, i) = (A3c2f - A3c2b) / G.Dxc<2>(j) - (A2c3f - A2c3b) / G.Dxc<3>(k);
+            const Real A2c3b = (A(V2, k, j, i) + A(V2, k, j + 1, i)) / 2;
+            B_U(F1, 0, k, j, i) =
+                (A3c2f - A3c2b) / G.Dxc<2>(j) - (A2c3f - A2c3b) / G.Dxc<3>(k);
         } else if constexpr (el == TE::F2) {
             // A1,3 derivative
             const Real A1c3f = (A(V1, k + 1, j, i) + A(V1, k + 1, j, i + 1)) / 2;
-            const Real A1c3b = (A(V1, k, j, i)     + A(V1, k, j, i + 1)) / 2;
+            const Real A1c3b = (A(V1, k, j, i) + A(V1, k, j, i + 1)) / 2;
             // A3,1 derivative
             const Real A3c1f = (A(V3, k, j, i + 1) + A(V3, k + 1, j, i + 1)) / 2;
-            const Real A3c1b = (A(V3, k, j, i)     + A(V3, k + 1, j, i)) / 2;
-            B_U(F2, 0, k, j, i) = (A1c3f - A1c3b) / G.Dxc<3>(k) - (A3c1f - A3c1b) / G.Dxc<1>(i);
+            const Real A3c1b = (A(V3, k, j, i) + A(V3, k + 1, j, i)) / 2;
+            B_U(F2, 0, k, j, i) =
+                (A1c3f - A1c3b) / G.Dxc<3>(k) - (A3c1f - A3c1b) / G.Dxc<1>(i);
         } else if constexpr (el == TE::F3) {
             // A2,1 derivative
             const Real A2c1f = (A(V2, k, j, i + 1) + A(V2, k, j + 1, i + 1)) / 2;
-            const Real A2c1b = (A(V2, k, j, i)     + A(V2, k, j + 1, i)) / 2;
+            const Real A2c1b = (A(V2, k, j, i) + A(V2, k, j + 1, i)) / 2;
             // A1,2 derivative
             const Real A1c2f = (A(V1, k, j + 1, i) + A(V1, k, j + 1, i + 1)) / 2;
-            const Real A1c2b = (A(V1, k, j, i)     + A(V1, k, j, i + 1)) / 2;
-            B_U(F3, 0, k, j, i) = (A2c1f - A2c1b) / G.Dxc<1>(i) - (A1c2f - A1c2b) / G.Dxc<2>(j);
+            const Real A1c2b = (A(V1, k, j, i) + A(V1, k, j, i + 1)) / 2;
+            B_U(F3, 0, k, j, i) =
+                (A2c1f - A2c1b) / G.Dxc<1>(i) - (A1c2f - A1c2b) / G.Dxc<2>(j);
         }
     }
 }
@@ -123,64 +126,71 @@ KOKKOS_INLINE_FUNCTION void edge_curl(const GRCoordinates& G, const GridVector& 
 // TODO move it into Parthenon!
 
 template<int diff_face, int diff_side, int offset, int DIM>
-KOKKOS_FORCEINLINE_FUNCTION Real F(const ParArrayND<Real, VariableState> &fine, const Coordinates_t &coords, int l, int m, int n, int fk, int fj, int fi)
+KOKKOS_FORCEINLINE_FUNCTION Real F(const ParArrayND<Real, VariableState>& fine,
+    const Coordinates_t& coords, int l, int m, int n, int fk, int fj, int fi)
 {
     // Trivial directions
-    if constexpr (diff_face+1 > DIM)
-        return 0.;
+    if constexpr (diff_face + 1 > DIM) return 0.;
     // TODO compile-time error on misuse? (diff_face == diff_side etc)
-    constexpr int df_is_k = 2*(diff_face == V3 && DIM > 2);
-    constexpr int df_is_j = 2*(diff_face == V2 && DIM > 1);
-    constexpr int df_is_i = 2*(diff_face == V1 && DIM > 0);
+    constexpr int df_is_k = 2 * (diff_face == V3 && DIM > 2);
+    constexpr int df_is_j = 2 * (diff_face == V2 && DIM > 1);
+    constexpr int df_is_i = 2 * (diff_face == V1 && DIM > 0);
     constexpr int ds_is_k = (diff_side == V3 && DIM > 2);
     constexpr int ds_is_j = (diff_side == V2 && DIM > 1);
     constexpr int ds_is_i = (diff_side == V1 && DIM > 0);
     constexpr int of_is_k = (offset == V3 && DIM > 2);
     constexpr int of_is_j = (offset == V2 && DIM > 1);
     constexpr int of_is_i = (offset == V1 && DIM > 0);
-    return fine(diff_face, l, m, n,  fk+df_is_k+ds_is_k+of_is_k, fj+df_is_j+ds_is_j+of_is_j, fi+df_is_i+ds_is_i+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+df_is_k+ds_is_k+of_is_k, fj+df_is_j+ds_is_j+of_is_j, fi+df_is_i+ds_is_i+of_is_i)
-         - fine(diff_face, l, m, n,  fk+ds_is_k+of_is_k        , fj+ds_is_j+of_is_j        , fi+ds_is_i+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+ds_is_k+of_is_k        , fj+ds_is_j+of_is_j        , fi+ds_is_i+of_is_i)
-         - fine(diff_face, l, m, n,  fk+df_is_k+of_is_k        , fj+df_is_j+of_is_j        , fi+df_is_i+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+df_is_k+of_is_k        , fj+df_is_j+of_is_j        , fi+df_is_i+of_is_i)
-         + fine(diff_face, l, m, n,  fk+of_is_k                , fj+of_is_j                , fi+of_is_i)
-      * coords.FaceArea<diff_face+1>(fk+of_is_k                , fj+of_is_j                , fi+of_is_i);
+    return fine(diff_face, l, m, n, fk + df_is_k + ds_is_k + of_is_k,
+               fj + df_is_j + ds_is_j + of_is_j, fi + df_is_i + ds_is_i + of_is_i) *
+               coords.FaceArea<diff_face + 1>(fk + df_is_k + ds_is_k + of_is_k,
+                   fj + df_is_j + ds_is_j + of_is_j, fi + df_is_i + ds_is_i + of_is_i) -
+           fine(diff_face, l, m, n, fk + ds_is_k + of_is_k, fj + ds_is_j + of_is_j,
+               fi + ds_is_i + of_is_i) *
+               coords.FaceArea<diff_face + 1>(fk + ds_is_k + of_is_k,
+                   fj + ds_is_j + of_is_j, fi + ds_is_i + of_is_i) -
+           fine(diff_face, l, m, n, fk + df_is_k + of_is_k, fj + df_is_j + of_is_j,
+               fi + df_is_i + of_is_i) *
+               coords.FaceArea<diff_face + 1>(fk + df_is_k + of_is_k,
+                   fj + df_is_j + of_is_j, fi + df_is_i + of_is_i) +
+           fine(diff_face, l, m, n, fk + of_is_k, fj + of_is_j, fi + of_is_i) *
+               coords.FaceArea<diff_face + 1>(fk + of_is_k, fj + of_is_j, fi + of_is_i);
 }
 
-struct ProlongateInternalOlivares {
-  static constexpr bool OperationRequired(TopologicalElement fel,
-                                          TopologicalElement cel) {
-    // We will always be filling some locations of fine element fel with others of the same element.
-    // However, the chosen coarse element cel defines our *domain*
-    return IsSubmanifold(fel, cel);
-  }
+struct ProlongateInternalOlivares
+{
+    static constexpr bool OperationRequired(
+        TopologicalElement fel, TopologicalElement cel)
+    {
+        // We will always be filling some locations of fine element fel with others of the
+        // same element. However, the chosen coarse element cel defines our *domain*
+        return IsSubmanifold(fel, cel);
+    }
 
-  template <int DIM, TopologicalElement fel = TopologicalElement::CC,
-            TopologicalElement cel = TopologicalElement::CC>
-  KOKKOS_FORCEINLINE_FUNCTION static void
-  Do(const int l, const int m, const int n, const int k, const int j, const int i,
-     const IndexRange &ckb, const IndexRange &cjb, const IndexRange &cib,
-     const IndexRange &kb, const IndexRange &jb, const IndexRange &ib,
-     const Coordinates_t &coords, const Coordinates_t &coarse_coords,
-     const ParArrayND<Real, VariableState> *,
-     const ParArrayND<Real, VariableState> *pfine) {
+    template<int DIM, TopologicalElement fel = TopologicalElement::CC,
+        TopologicalElement cel = TopologicalElement::CC>
+    KOKKOS_FORCEINLINE_FUNCTION static void Do(const int l, const int m, const int n,
+        const int k, const int j, const int i, const IndexRange& ckb,
+        const IndexRange& cjb, const IndexRange& cib, const IndexRange& kb,
+        const IndexRange& jb, const IndexRange& ib, const Coordinates_t& coords,
+        const Coordinates_t& coarse_coords, const ParArrayND<Real, VariableState>*,
+        const ParArrayND<Real, VariableState>* pfine)
+    {
 
         // Definitely exit on what we can't handle
         // This is never hit as currently compiled in KHARMA
-        if constexpr (fel != TE::F1 && fel != TE::F2 && fel != TE::F3)
-            return;
+        if constexpr (fel != TE::F1 && fel != TE::F2 && fel != TE::F3) return;
 
         // Handle permutations "naturally."
         // Olivares et al. is fond of listing x1 versions which permute,
         // this makes translating/checking those easier
         constexpr int me = static_cast<int>(fel) % 3;
-        constexpr int next = (me+1) % 3;
-        constexpr int third = (me+2) % 3;
+        constexpr int next = (me + 1) % 3;
+        constexpr int third = (me + 2) % 3;
 
         // Fine array, indices
         // Note the boundaries are *always the interior*
-        auto &fine = *pfine;
+        auto& fine = *pfine;
         const int fi = (DIM > 0) ? (i - cib.s) * 2 + ib.s : ib.s;
         const int fj = (DIM > 1) ? (j - cjb.s) * 2 + jb.s : jb.s;
         const int fk = (DIM > 2) ? (k - ckb.s) * 2 + kb.s : kb.s;
@@ -191,36 +201,57 @@ struct ProlongateInternalOlivares {
         // 2. differences of squares of zone dimesnions (Toth)
         // 3. heuristic based on flux difference of top vs bottom halves (Olivares)
         // constexpr Real a[3] = {0., 0., 0.};
-        const Real a[3] = {(SQR(coords.Dxc<2>(fj)) - SQR(coords.Dxc<3>(fk))) / (SQR(coords.Dxc<2>(fj)) + SQR(coords.Dxc<3>(fk))),
-                           (SQR(coords.Dxc<3>(fk)) - SQR(coords.Dxc<1>(fi))) / (SQR(coords.Dxc<3>(fk)) + SQR(coords.Dxc<1>(fi))),
-                           (SQR(coords.Dxc<1>(fi)) - SQR(coords.Dxc<2>(fj))) / (SQR(coords.Dxc<1>(fi)) + SQR(coords.Dxc<2>(fj)))};
+        const Real a[3] = {(SQR(coords.Dxc<2>(fj)) - SQR(coords.Dxc<3>(fk))) /
+                               (SQR(coords.Dxc<2>(fj)) + SQR(coords.Dxc<3>(fk))),
+            (SQR(coords.Dxc<3>(fk)) - SQR(coords.Dxc<1>(fi))) /
+                (SQR(coords.Dxc<3>(fk)) + SQR(coords.Dxc<1>(fi))),
+            (SQR(coords.Dxc<1>(fi)) - SQR(coords.Dxc<2>(fj))) /
+                (SQR(coords.Dxc<1>(fi)) + SQR(coords.Dxc<2>(fj)))};
 
         // Coefficients for each term evaluating the four sub-faces
         const Real coeff[4][4] = {{3 + a[next], 1 - a[next], 3 - a[third], 1 + a[third]},
-                                  {3 + a[next], 1 - a[next], 1 + a[third], 3 - a[third]},
-                                  {1 - a[next], 3 + a[next], 3 - a[third], 1 + a[third]},
-                                  {1 - a[next], 3 + a[next], 1 + a[third], 3 - a[third]}};
+            {3 + a[next], 1 - a[next], 1 + a[third], 3 - a[third]},
+            {1 - a[next], 3 + a[next], 3 - a[third], 1 + a[third]},
+            {1 - a[next], 3 + a[next], 1 + a[third], 3 - a[third]}};
 
-        constexpr int diff_k = (me == V3 && DIM > 2), diff_j = (me == V2 && DIM > 1), diff_i = (me == V1 && DIM > 0);
+        constexpr int diff_k = (me == V3 && DIM > 2), diff_j = (me == V2 && DIM > 1),
+                      diff_i = (me == V1 && DIM > 0);
 
         // Iterate through the 4 sub-faces
-        for (int elem=0; elem < 4; elem++) {
+        for (int elem = 0; elem < 4; elem++) {
             // Make sure we can offset in other directions before doing so, though
-            const int off_i = (DIM > 0) ? (elem%2)*(me == V2) + (elem/2)*(me == V3) + (me == V1) : 0;
-            const int off_j = (DIM > 1) ? (elem%2)*(me == V3) + (elem/2)*(me == V1) + (me == V2) : 0;
-            const int off_k = (DIM > 2) ? (elem%2)*(me == V1) + (elem/2)*(me == V2) + (me == V3) : 0;
+            const int off_i =
+                (DIM > 0) ? (elem % 2) * (me == V2) + (elem / 2) * (me == V3) + (me == V1)
+                          : 0;
+            const int off_j =
+                (DIM > 1) ? (elem % 2) * (me == V3) + (elem / 2) * (me == V1) + (me == V2)
+                          : 0;
+            const int off_k =
+                (DIM > 2) ? (elem % 2) * (me == V1) + (elem / 2) * (me == V2) + (me == V3)
+                          : 0;
 
-            fine(me, l, m, n, fk+off_k, fj+off_j, fi+off_i) = (
-                // Average faces on either side of us in selected direction (diff), on each of the 4 sub-faces (off)
-                0.5*(fine(me, l, m, n, fk+off_k-diff_k, fj+off_j-diff_j, fi+off_i-diff_i)
-                   * coords.Volume<fel>(fk+off_k-diff_k, fj+off_j-diff_j, fi+off_i-diff_i)
-                   + fine(me, l, m, n, fk+off_k+diff_k, fj+off_j+diff_j, fi+off_i+diff_i)
-                   * coords.Volume<fel>(fk+off_k+diff_k, fj+off_j+diff_j, fi+off_i+diff_i)) +
-                1./16*(coeff[elem][0]*F<next, me,   -1,DIM>(fine, coords, l, m, n, fk, fj, fi)
-                     + coeff[elem][1]*F<next, me,third,DIM>(fine, coords, l, m, n, fk, fj, fi)
-                     + coeff[elem][2]*F<third,me,  -1,DIM>(fine, coords, l, m, n, fk, fj, fi)
-                     + coeff[elem][3]*F<third,me,next,DIM>(fine, coords, l, m, n, fk, fj, fi))
-                ) / coords.Volume<fel>(fk+off_k, fj+off_j, fi+off_i);
+            fine(me, l, m, n, fk + off_k, fj + off_j, fi + off_i) =
+                (
+                    // Average faces on either side of us in selected direction (diff), on
+                    // each of the 4 sub-faces (off)
+                    0.5 * (fine(me, l, m, n, fk + off_k - diff_k, fj + off_j - diff_j,
+                               fi + off_i - diff_i) *
+                                  coords.Volume<fel>(fk + off_k - diff_k,
+                                      fj + off_j - diff_j, fi + off_i - diff_i) +
+                              fine(me, l, m, n, fk + off_k + diff_k, fj + off_j + diff_j,
+                                  fi + off_i + diff_i) *
+                                  coords.Volume<fel>(fk + off_k + diff_k,
+                                      fj + off_j + diff_j, fi + off_i + diff_i)) +
+                    1. / 16 *
+                        (coeff[elem][0] *
+                                F<next, me, -1, DIM>(fine, coords, l, m, n, fk, fj, fi) +
+                            coeff[elem][1] * F<next, me, third, DIM>(
+                                                 fine, coords, l, m, n, fk, fj, fi) +
+                            coeff[elem][2] *
+                                F<third, me, -1, DIM>(fine, coords, l, m, n, fk, fj, fi) +
+                            coeff[elem][3] * F<third, me, next, DIM>(
+                                                 fine, coords, l, m, n, fk, fj, fi))) /
+                coords.Volume<fel>(fk + off_k, fj + off_j, fi + off_i);
         }
     }
 };

--- a/kharma/b_flux_ct/b_flux_ct.cpp
+++ b/kharma/b_flux_ct/b_flux_ct.cpp
@@ -46,48 +46,56 @@ using namespace parthenon;
 namespace B_FluxCT
 {
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("B_FluxCT");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Diagnostic & inadvisable flags
-    // This enables flux corrections to ensure divB preservation even with zero flux of B2 on the polar "face."
-    // It effectively makes the pole a superconducting rod
+    // This enables flux corrections to ensure divB preservation even with zero flux of B2
+    // on the polar "face." It effectively makes the pole a superconducting rod
     // TODO unify all these options into zero_flux_B and bflux0_B
     bool spherical = pin->GetBoolean("coordinates", "spherical");
     bool fix_polar_flux = pin->GetOrAddBoolean("b_field", "fix_polar_flux", spherical);
     params.Add("fix_polar_flux", fix_polar_flux);
-    // These options do a similar fix to the inner and outer radial edges, which is less commonly necessary.
-    // They require constant (Dirichlet) boundary conditions
-    // These are the "Bflux0" prescription designed by Hyerin Cho
+    // These options do a similar fix to the inner and outer radial edges, which is less
+    // commonly necessary. They require constant (Dirichlet) boundary conditions These are
+    // the "Bflux0" prescription designed by Hyerin Cho
     bool fix_flux_x1 = pin->GetOrAddBoolean("b_field", "fix_flux_x1", false);
-    // Split out options. Turn off inner edge by default if inner bound is within EH (TODO turn on/off based on BOUNDARIES)
+    // Split out options. Turn off inner edge by default if inner bound is within EH (TODO
+    // turn on/off based on BOUNDARIES)
     bool r_in_eh = spherical && pin->GetBoolean("coordinates", "domain_intersects_eh");
-    bool fix_flux_inner_x1 = pin->GetOrAddBoolean("b_field", "fix_flux_inner_x1", fix_flux_x1 && !r_in_eh);
+    bool fix_flux_inner_x1 =
+        pin->GetOrAddBoolean("b_field", "fix_flux_inner_x1", fix_flux_x1 && !r_in_eh);
     params.Add("fix_flux_inner_x1", fix_flux_inner_x1);
-    bool fix_flux_outer_x1 = pin->GetOrAddBoolean("b_field", "fix_flux_outer_x1", fix_flux_x1);
+    bool fix_flux_outer_x1 =
+        pin->GetOrAddBoolean("b_field", "fix_flux_outer_x1", fix_flux_x1);
     params.Add("fix_flux_outer_x1", fix_flux_outer_x1);
     // Bflux0 on x2.  NOT good for polar boundaries
     bool fix_flux_x2 = pin->GetOrAddBoolean("b_field", "fix_flux_x2", false);
-    bool fix_flux_inner_x2 = pin->GetOrAddBoolean("b_field", "fix_flux_inner_x2", fix_flux_x2);
+    bool fix_flux_inner_x2 =
+        pin->GetOrAddBoolean("b_field", "fix_flux_inner_x2", fix_flux_x2);
     params.Add("fix_flux_inner_x2", fix_flux_inner_x2);
-    bool fix_flux_outer_x2 = pin->GetOrAddBoolean("b_field", "fix_flux_outer_x2", fix_flux_x2);
+    bool fix_flux_outer_x2 =
+        pin->GetOrAddBoolean("b_field", "fix_flux_outer_x2", fix_flux_x2);
     params.Add("fix_flux_outer_x2", fix_flux_outer_x2);
-    // This reverts to a more ham-fisted fix which explicitly disallows flux crossing the X1 face.
-    // This version requires *inverted* B1 across the face, potentially just using reflecting conditions for B
-    // Using this version is tremendously inadvisable: consult your simulator before applying.
+    // This reverts to a more ham-fisted fix which explicitly disallows flux crossing the
+    // X1 face. This version requires *inverted* B1 across the face, potentially just
+    // using reflecting conditions for B Using this version is tremendously inadvisable:
+    // consult your simulator before applying.
     bool use_old_flux_fix = pin->GetOrAddBoolean("b_field", "use_old_flux_fix", false);
     params.Add("use_old_flux_fix", use_old_flux_fix);
 
     // KHARMA requires some kind of field transport if there is a magnetic field allocated
     // Use this if you actually want to disable all magnetic field flux corrections,
-    // and allow a field divergence to grow unchecked, usually for debugging or comparison reasons
+    // and allow a field divergence to grow unchecked, usually for debugging or comparison
+    // reasons
     bool disable_flux_ct = pin->GetOrAddBoolean("b_field", "disable_flux_ct", false);
     params.Add("disable_flux_ct", disable_flux_ct);
 
-    // Default to stopping execution when divB is large, which generally indicates something
-    // has gone wrong.  As always, can be disabled by the brave.
+    // Default to stopping execution when divB is large, which generally indicates
+    // something has gone wrong.  As always, can be disabled by the brave.
     bool kill_on_large_divb = pin->GetOrAddBoolean("b_field", "kill_on_large_divb", true);
     params.Add("kill_on_large_divb", kill_on_large_divb);
     Real kill_on_divb_over = pin->GetOrAddReal("b_field", "kill_on_divb_over", 1.e-3);
@@ -106,14 +114,18 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
                                               : Metadata::GetUserFlag("Explicit");
 
     // Flags for B fields
-    // We always mark conserved B to be sync'd for consistency, since it's strictly required for B_CT/AMR
-    std::vector<MetadataFlag> flags_prim = {Metadata::Real, Metadata::Derived, Metadata::GetUserFlag("Primitive"),
-                                            Metadata::Cell, Metadata::GetUserFlag("MHD"), areWeImplicit, Metadata::Vector};
-    std::vector<MetadataFlag> flags_cons = {Metadata::Real, Metadata::Independent, Metadata::Restart, Metadata::FillGhost, Metadata::WithFluxes, Metadata::Conserved,
-                                            Metadata::Cell, Metadata::GetUserFlag("MHD"), areWeImplicit, Metadata::Vector};
+    // We always mark conserved B to be sync'd for consistency, since it's strictly
+    // required for B_CT/AMR
+    std::vector<MetadataFlag> flags_prim = {Metadata::Real, Metadata::Derived,
+        Metadata::GetUserFlag("Primitive"), Metadata::Cell, Metadata::GetUserFlag("MHD"),
+        areWeImplicit, Metadata::Vector};
+    std::vector<MetadataFlag> flags_cons = {Metadata::Real, Metadata::Independent,
+        Metadata::Restart, Metadata::FillGhost, Metadata::WithFluxes, Metadata::Conserved,
+        Metadata::Cell, Metadata::GetUserFlag("MHD"), areWeImplicit, Metadata::Vector};
 
     // KHARMA now (vaguely) supports restarting from dump (.phdf) files.
-    // To do so we need to read cell-centered primitive B and interpolate to faces, as we do with iharm3d restart files
+    // To do so we need to read cell-centered primitive B and interpolate to faces, as we
+    // do with iharm3d restart files
     if (pin->GetOrAddBoolean("b_field", "restart_from_prims", false)) {
         flags_prim.push_back(Metadata::Restart);
     }
@@ -124,12 +136,16 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     pkg->AddField("cons.B", m);
 
     // Declare EMF temporary variables, to avoid malloc/free during each step
-    // Technically these are edge-centered but we only need the interior + 1-zone halo anyway, so we store as a vector
-    std::vector<MetadataFlag> flags_emf = {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
+    // Technically these are edge-centered but we only need the interior + 1-zone halo
+    // anyway, so we store as a vector
+    std::vector<MetadataFlag> flags_emf = {
+        Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
     m = Metadata(flags_emf, s_vector);
     pkg->AddField("emf", m);
-    if (packages->Get("Globals")->Param<std::string>("problem") == "resize_restart_kharma") {
-        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::FillGhost, Metadata::Vector});
+    if (packages->Get("Globals")->Param<std::string>("problem") ==
+        "resize_restart_kharma") {
+        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
+            Metadata::FillGhost, Metadata::Vector});
         pkg->AddField("B_Save", m);
     }
 
@@ -151,31 +167,39 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // The definition of MaxDivB we care about actually changes per-transport,
     // so calculating it is handled by the transport package
-    // We'd only ever need to declare or calculate divB for output (getting the max is independent)
+    // We'd only ever need to declare or calculate divB for output (getting the max is
+    // independent)
 
     if (KHARMA::FieldIsOutput(pin, "divB")) {
         pkg->BlockUserWorkBeforeOutput = B_FluxCT::FillOutput;
-        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+        m = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
         pkg->AddField("divB", m);
     }
 
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
-    hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::max, B_FluxCT::MaxDivB, "MaxDivB"));
-    // Event horizon magnetization.  Might be the same or different for different representations?
+    hst_vars.emplace_back(parthenon::HistoryOutputVar(
+        UserHistoryOperation::max, B_FluxCT::MaxDivB, "MaxDivB"));
+    // Event horizon magnetization.  Might be the same or different for different
+    // representations?
     if (pin->GetBoolean("coordinates", "domain_intersects_eh")) {
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::phi>, "Phi_0"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::phi>, "Phi_EH"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::phi>, "Phi_5M"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::SumAt0<Reductions::Var::phi>, "Phi_0"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::SumAtEH<Reductions::Var::phi>, "Phi_EH"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::SumAt5M<Reductions::Var::phi>, "Phi_5M"));
     }
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     return pkg;
 }
 
 // TODO template and use as a model for future
-TaskStatus MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse)
+TaskStatus MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -186,19 +210,24 @@ TaskStatus MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse)
     IndexRange ib = bounds.GetBoundsI(domain);
     IndexRange jb = bounds.GetBoundsJ(domain);
     IndexRange kb = bounds.GetBoundsK(domain);
-    IndexRange vec = IndexRange{0, B_U.GetDim(4)-1};
-    IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    IndexRange vec = IndexRange{0, B_U.GetDim(4) - 1};
+    IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
-    pmb0->par_for("UtoP_B_FluxCT_Mesh", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &mu, const int &k, const int &j, const int &i) {
+    pmb0->par_for("UtoP_B_FluxCT_Mesh", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s,
+        jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int& b,
+                      const int& mu,
+                      const int& k,
+                      const int& j,
+                      const int& i)
+        {
             const auto& G = B_U.GetCoords(b);
             // Update the primitive B-fields
             B_P(b, mu, k, j, i) = B_U(b, mu, k, j, i) / G.gdet(Loci::center, j, i);
-        }
-    );
+        });
     return TaskStatus::complete;
 }
-TaskStatus BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+TaskStatus BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -211,18 +240,18 @@ TaskStatus BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const IndexRange ib = bounds.GetBoundsI(domain);
     const IndexRange jb = bounds.GetBoundsJ(domain);
     const IndexRange kb = bounds.GetBoundsK(domain);
-    const IndexRange vec = IndexRange({0, B_U.GetDim(4)-1});
+    const IndexRange vec = IndexRange({0, B_U.GetDim(4) - 1});
 
     pmb->par_for("UtoP_B_FluxCT_Block", vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &mu, const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& mu, const int& k, const int& j, const int& i)
+        {
             // Update the primitive B-fields
             B_P(mu, k, j, i) = B_U(mu, k, j, i) / G.gdet(Loci::center, j, i);
-        }
-    );
+        });
     return TaskStatus::complete;
 }
 
-void MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse)
+void MeshPtoU(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -233,18 +262,23 @@ void MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse)
     IndexRange ib = bounds.GetBoundsI(domain);
     IndexRange jb = bounds.GetBoundsJ(domain);
     IndexRange kb = bounds.GetBoundsK(domain);
-    IndexRange vec = IndexRange{0, B_U.GetDim(4)-1};
-    IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    IndexRange vec = IndexRange{0, B_U.GetDim(4) - 1};
+    IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
-    pmb0->par_for("PtoU_B_FluxCT_Mesh", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &mu, const int &k, const int &j, const int &i) {
+    pmb0->par_for("PtoU_B_FluxCT_Mesh", block.s, block.e, vec.s, vec.e, kb.s, kb.e, jb.s,
+        jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int& b,
+                      const int& mu,
+                      const int& k,
+                      const int& j,
+                      const int& i)
+        {
             const auto& G = B_U.GetCoords(b);
             // Update the primitive B-fields
             B_U(b, mu, k, j, i) = B_P(b, mu, k, j, i) * G.gdet(Loci::center, j, i);
-        }
-    );
+        });
 }
-void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void BlockPtoU(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -257,17 +291,17 @@ void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const IndexRange ib = bounds.GetBoundsI(domain);
     const IndexRange jb = bounds.GetBoundsJ(domain);
     const IndexRange kb = bounds.GetBoundsK(domain);
-    const IndexRange vec = IndexRange({0, B_U.GetDim(4)-1});
+    const IndexRange vec = IndexRange({0, B_U.GetDim(4) - 1});
 
     pmb->par_for("PtoU_B_FluxCT_Block", vec.s, vec.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &mu, const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& mu, const int& k, const int& j, const int& i)
+        {
             // Update the conserved B-fields
             B_U(mu, k, j, i) = B_P(mu, k, j, i) * G.gdet(Loci::center, j, i);
-        }
-    );
+        });
 }
 
-void FixFlux(MeshData<Real> *md)
+void FixFlux(MeshData<Real>* md)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     auto& params = pmb0->packages.Get("B_FluxCT")->AllParams();
@@ -310,7 +344,7 @@ void FixFlux(MeshData<Real> *md)
 
 // INTERNAL
 
-void FluxCT(MeshData<Real> *md)
+void FluxCT(MeshData<Real>* md)
 {
     // Pointers
     auto pmesh = md->GetMeshPointer();
@@ -327,7 +361,7 @@ void FluxCT(MeshData<Real> *md)
     const IndexRange ib = md->GetBoundsI(IndexDomain::interior);
     const IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
     const IndexRange kb = md->GetBoundsK(IndexDomain::interior);
-    const IndexRange block = IndexRange{0, B_F.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_F.GetDim(5) - 1};
     // One zone halo on the *right only*, except for k in 2D
     const IndexRange il = IndexRange{ib.s, ib.e + 1};
     const IndexRange jl = IndexRange{jb.s, jb.e + 1};
@@ -335,47 +369,64 @@ void FluxCT(MeshData<Real> *md)
 
     // Calculate emf around each face
     pmb0->par_for("flux_ct_emf", block.s, block.e, kl.s, kl.e, jl.s, jl.e, il.s, il.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             if (ndim > 2) {
-                emf_pack(b, V1, k, j, i) =  0.25 * (B_F(b).flux(X2DIR, V3, k, j, i) + B_F(b).flux(X2DIR, V3, k-1, j, i) -
-                                            B_F(b).flux(X3DIR, V2, k, j, i) - B_F(b).flux(X3DIR, V2, k, j-1, i));
-                emf_pack(b, V2, k, j, i) = 0.25 * (B_F(b).flux(X3DIR, V1, k, j, i) + B_F(b).flux(X3DIR, V1, k, j, i-1) -
-                                            B_F(b).flux(X1DIR, V3, k, j, i) - B_F(b).flux(X1DIR, V3, k-1, j, i));
+                emf_pack(b, V1, k, j, i) =
+                    0.25 * (B_F(b).flux(X2DIR, V3, k, j, i) +
+                               B_F(b).flux(X2DIR, V3, k - 1, j, i) -
+                               B_F(b).flux(X3DIR, V2, k, j, i) -
+                               B_F(b).flux(X3DIR, V2, k, j - 1, i));
+                emf_pack(b, V2, k, j, i) =
+                    0.25 * (B_F(b).flux(X3DIR, V1, k, j, i) +
+                               B_F(b).flux(X3DIR, V1, k, j, i - 1) -
+                               B_F(b).flux(X1DIR, V3, k, j, i) -
+                               B_F(b).flux(X1DIR, V3, k - 1, j, i));
             }
-            emf_pack(b, V3, k, j, i) =  0.25 * (B_F(b).flux(X1DIR, V2, k, j, i) + B_F(b).flux(X1DIR, V2, k, j-1, i) -
-                                        B_F(b).flux(X2DIR, V1, k, j, i) - B_F(b).flux(X2DIR, V1, k, j, i-1));
-        }
-    );
+            emf_pack(b, V3, k, j, i) = 0.25 * (B_F(b).flux(X1DIR, V2, k, j, i) +
+                                                  B_F(b).flux(X1DIR, V2, k, j - 1, i) -
+                                                  B_F(b).flux(X2DIR, V1, k, j, i) -
+                                                  B_F(b).flux(X2DIR, V1, k, j, i - 1));
+        });
 
     // Rewrite EMFs as fluxes, after Toth (2000)
     // Note that zeroing FX(BX) is *necessary* -- this flux gets filled by GetFlux
-    // Note these each have different domains, eg il vs ib.  The former extends one index farther if appropriate
+    // Note these each have different domains, eg il vs ib.  The former extends one index
+    // farther if appropriate
     pmb0->par_for("flux_ct_1", block.s, block.e, kb.s, kb.e, jb.s, jb.e, il.s, il.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
-            B_F(b).flux(X1DIR, V1, k, j, i) =  0.0;
-            B_F(b).flux(X1DIR, V2, k, j, i) =  0.5 * (emf_pack(b, V3, k, j, i) + emf_pack(b, V3, k, j+1, i));
-            if (ndim > 2) B_F(b).flux(X1DIR, V3, k, j, i) = -0.5 * (emf_pack(b, V2, k, j, i) + emf_pack(b, V2, k+1, j, i));
-        }
-    );
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
+            B_F(b).flux(X1DIR, V1, k, j, i) = 0.0;
+            B_F(b).flux(X1DIR, V2, k, j, i) =
+                0.5 * (emf_pack(b, V3, k, j, i) + emf_pack(b, V3, k, j + 1, i));
+            if (ndim > 2)
+                B_F(b).flux(X1DIR, V3, k, j, i) =
+                    -0.5 * (emf_pack(b, V2, k, j, i) + emf_pack(b, V2, k + 1, j, i));
+        });
     pmb0->par_for("flux_ct_2", block.s, block.e, kb.s, kb.e, jl.s, jl.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
-            B_F(b).flux(X2DIR, V1, k, j, i) = -0.5 * (emf_pack(b, V3, k, j, i) + emf_pack(b, V3, k, j, i+1));
-            B_F(b).flux(X2DIR, V2, k, j, i) =  0.0;
-            if (ndim > 2) B_F(b).flux(X2DIR, V3, k, j, i) =  0.5 * (emf_pack(b, V1, k, j, i) + emf_pack(b, V1, k+1, j, i));
-        }
-    );
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
+            B_F(b).flux(X2DIR, V1, k, j, i) =
+                -0.5 * (emf_pack(b, V3, k, j, i) + emf_pack(b, V3, k, j, i + 1));
+            B_F(b).flux(X2DIR, V2, k, j, i) = 0.0;
+            if (ndim > 2)
+                B_F(b).flux(X2DIR, V3, k, j, i) =
+                    0.5 * (emf_pack(b, V1, k, j, i) + emf_pack(b, V1, k + 1, j, i));
+        });
     if (ndim > 2) {
         pmb0->par_for("flux_ct_3", block.s, block.e, kl.s, kl.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
-                B_F(b).flux(X3DIR, V1, k, j, i) =  0.5 * (emf_pack(b, V2, k, j, i) + emf_pack(b, V2, k, j, i+1));
-                B_F(b).flux(X3DIR, V2, k, j, i) = -0.5 * (emf_pack(b, V1, k, j, i) + emf_pack(b, V1, k, j+1, i));
-                B_F(b).flux(X3DIR, V3, k, j, i) =  0.0;
-            }
-        );
+            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+            {
+                B_F(b).flux(X3DIR, V1, k, j, i) =
+                    0.5 * (emf_pack(b, V2, k, j, i) + emf_pack(b, V2, k, j, i + 1));
+                B_F(b).flux(X3DIR, V2, k, j, i) =
+                    -0.5 * (emf_pack(b, V1, k, j, i) + emf_pack(b, V1, k, j + 1, i));
+                B_F(b).flux(X3DIR, V3, k, j, i) = 0.0;
+            });
     }
 }
 
-void ZeroBoundaryFlux(MeshData<Real> *md, IndexDomain domain, bool coarse)
+void ZeroBoundaryFlux(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     // TODO write ONE implementation for any boundary
     auto pmesh = md->GetMeshPointer();
@@ -389,7 +440,7 @@ void ZeroBoundaryFlux(MeshData<Real> *md, IndexDomain domain, bool coarse)
     // g | p | p
     //----------- 1
     // g | p | p ...
-    //xxx-------- 0
+    // xxx-------- 0
     // g | g | g
     //-1   0   1
     // The flux through 'x' is not important for updating a physical zone,
@@ -406,7 +457,7 @@ void ZeroBoundaryFlux(MeshData<Real> *md, IndexDomain domain, bool coarse)
     const IndexRange ibf = IndexRange{ib.s, ib.e + 1};
     const IndexRange jbf = IndexRange{jb.s, jb.e + 1};
     // Won't need X3 faces
-    //const IndexRange kbf = IndexRange{kb.s, kb.e + (ndim > 2)};
+    // const IndexRange kbf = IndexRange{kb.s, kb.e + (ndim > 2)};
     // For sides
     const IndexRange ibs = IndexRange{ib.s - 1, ib.e + 1};
     const IndexRange jbs = IndexRange{jb.s - (ndim > 1), jb.e + (ndim > 1)};
@@ -415,67 +466,73 @@ void ZeroBoundaryFlux(MeshData<Real> *md, IndexDomain domain, bool coarse)
     // Make sure the polar EMFs are 0 when performing fluxCT
     // Compare this section with calculation of emf3 in FluxCT:
     // these changes ensure that boundary emfs emf3(i,js,k)=0, etc.
-    for (auto &pmb : pmesh->block_list) {
+    for (auto& pmb : pmesh->block_list) {
         auto& rc = pmb->meshblock_data.Get(md->StageName());
         auto& B_F = rc->PackVariablesAndFluxes(std::vector<std::string>{"cons.B"});
 
         if (domain == IndexDomain::inner_x2 &&
             KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2)) {
             pmb->par_for("fix_flux_b_l", kbs.s, kbs.e, jbf.s, jbf.s, ibs.s, ibs.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     B_F.flux(X2DIR, V1, k, j, i) = 0.;
                     B_F.flux(X2DIR, V3, k, j, i) = 0.;
-                    B_F.flux(X1DIR, V2, k, j-1, i) = -B_F.flux(X1DIR, V2, k, j, i);
-                    if (ndim > 2) B_F.flux(X3DIR, V2, k, j-1, i) = -B_F.flux(X3DIR, V2, k, j, i);
-                }
-            );
+                    B_F.flux(X1DIR, V2, k, j - 1, i) = -B_F.flux(X1DIR, V2, k, j, i);
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V2, k, j - 1, i) = -B_F.flux(X3DIR, V2, k, j, i);
+                });
         }
 
         if (domain == IndexDomain::outer_x2 &&
             KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2)) {
             pmb->par_for("fix_flux_b_r", kbs.s, kbs.e, jbf.e, jbf.e, ibs.s, ibs.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     B_F.flux(X2DIR, V1, k, j, i) = 0.;
                     B_F.flux(X2DIR, V3, k, j, i) = 0.;
                     B_F.flux(X1DIR, V2, k, j, i) = -B_F.flux(X1DIR, V2, k, j - 1, i);
-                    if (ndim > 2) B_F.flux(X3DIR, V2, k, j, i) = -B_F.flux(X3DIR, V2, k, j - 1, i);
-                }
-            );
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V2, k, j, i) = -B_F.flux(X3DIR, V2, k, j - 1, i);
+                });
         }
         // These boundary conditions need to arrange for B1 to be inverted in ghost cells.
         // This is no longer pure outflow, but might be thought of as a "nicer" version of
         // reflecting conditions:
-        // 1. Since B1 is inverted, B1 on the domain face will tend to 0 (it's not quite reflected, but basically)
+        // 1. Since B1 is inverted, B1 on the domain face will tend to 0 (it's not quite
+        // reflected, but basically)
         //    (obviously don't enable this for monopole test problems!)
-        // 2. However, B2 and B3 are normal outflow conditions -- despite the fluxes here, the outflow
+        // 2. However, B2 and B3 are normal outflow conditions -- despite the fluxes here,
+        // the outflow
         //    conditions will set them equal to the last zone.
         if (domain == IndexDomain::inner_x1 &&
             KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x1)) {
             pmb->par_for("fix_flux_b_in_old", kbs.s, kbs.e, jbs.s, jbs.e, ibf.s, ibf.s,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     B_F.flux(X1DIR, V2, k, j, i) = 0.;
                     B_F.flux(X1DIR, V3, k, j, i) = 0.;
                     B_F.flux(X2DIR, V1, k, j, i - 1) = -B_F.flux(X2DIR, V1, k, j, i);
-                    if (ndim > 2) B_F.flux(X3DIR, V1, k, j, i - 1) = -B_F.flux(X3DIR, V1, k, j, i);
-                }
-            );
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V1, k, j, i - 1) = -B_F.flux(X3DIR, V1, k, j, i);
+                });
         }
 
         if (domain == IndexDomain::outer_x1 &&
             KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x1)) {
             pmb->par_for("fix_flux_b_out_old", kbs.s, kbs.e, jbs.s, jbs.e, ibf.e, ibf.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     B_F.flux(X1DIR, V2, k, j, i) = 0.;
                     B_F.flux(X1DIR, V3, k, j, i) = 0.;
                     B_F.flux(X2DIR, V1, k, j, i) = -B_F.flux(X2DIR, V1, k, j, i - 1);
-                    if (ndim > 2) B_F.flux(X3DIR, V1, k, j, i) = -B_F.flux(X3DIR, V1, k, j, i - 1);
-                }
-            );
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V1, k, j, i) = -B_F.flux(X3DIR, V1, k, j, i - 1);
+                });
         }
     }
 }
 
-void Bflux0(MeshData<Real> *md, IndexDomain domain, bool coarse)
+void Bflux0(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = pmesh->block_list[0];
@@ -491,7 +548,7 @@ void Bflux0(MeshData<Real> *md, IndexDomain domain, bool coarse)
     const IndexRange ibf = IndexRange{ib.s, ib.e + 1};
     const IndexRange jbf = IndexRange{jb.s, jb.e + 1};
     // Won't need X3 faces
-    //const IndexRange kbf = IndexRange{kb.s, kb.e + (ndim > 2)};
+    // const IndexRange kbf = IndexRange{kb.s, kb.e + (ndim > 2)};
     // For sides
     const IndexRange ibs = IndexRange{ib.s - 1, ib.e + 1};
     const IndexRange jbs = IndexRange{jb.s - (ndim > 1), jb.e + (ndim > 1)};
@@ -500,76 +557,102 @@ void Bflux0(MeshData<Real> *md, IndexDomain domain, bool coarse)
     // Make sure the polar EMFs are 0 when performing fluxCT
     // Compare this section with calculation of emf3 in FluxCT:
     // these changes ensure that boundary emfs emf3(i,js,k)=0, etc.
-    for (auto &pmb : pmesh->block_list) {
+    for (auto& pmb : pmesh->block_list) {
         auto& rc = pmb->meshblock_data.Get(md->StageName());
         auto& B_F = rc->PackVariablesAndFluxes(std::vector<std::string>{"cons.B"});
 
-        // "Bflux0" prescription for keeping divB~=0 on zone corners of the interior & exterior X1 faces
-        // Courtesy of & implemented by Hyerin Cho
-        // Allows nonzero flux across X1 boundary but still keeps divB=0 (turns out effectively to have 0 flux)
-        // Usable only for Dirichlet conditions
+        // "Bflux0" prescription for keeping divB~=0 on zone corners of the interior &
+        // exterior X1 faces Courtesy of & implemented by Hyerin Cho Allows nonzero flux
+        // across X1 boundary but still keeps divB=0 (turns out effectively to have 0
+        // flux) Usable only for Dirichlet conditions
         if (domain == IndexDomain::inner_x1 &&
-            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x1))
-        {
-            pmb->par_for("fix_flux_b_in", kbs.s, kbs.e, jbs.s, jbs.e, ibf.s, ibf.s, // Hyerin (12/28/22) for 1st & 2nd prescription
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    // Allows nonzero flux across X1 boundary but still keeps divB=0 (turns out effectively to have 0 flux)
-                    if (ndim > 1) B_F.flux(X2DIR, V1, k, j, i-1) = -B_F.flux(X2DIR, V1, k, j, i) + B_F.flux(X1DIR, V2, k, j, i) + B_F.flux(X1DIR, V2, k, j-1, i);
-                    if (ndim > 2) B_F.flux(X3DIR, V1, k, j, i-1) = -B_F.flux(X3DIR, V1, k, j, i) + B_F.flux(X1DIR, V3, k, j, i) + B_F.flux(X1DIR, V3, k-1, j, i);
-                }
-            );
-
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x1)) {
+            pmb->par_for("fix_flux_b_in", kbs.s, kbs.e, jbs.s, jbs.e, ibf.s,
+                ibf.s, // Hyerin (12/28/22) for 1st & 2nd prescription
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    // Allows nonzero flux across X1 boundary but still keeps
+                    // divB=0 (turns out effectively to have 0 flux)
+                    if (ndim > 1)
+                        B_F.flux(X2DIR, V1, k, j, i - 1) =
+                            -B_F.flux(X2DIR, V1, k, j, i) + B_F.flux(X1DIR, V2, k, j, i) +
+                            B_F.flux(X1DIR, V2, k, j - 1, i);
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V1, k, j, i - 1) =
+                            -B_F.flux(X3DIR, V1, k, j, i) + B_F.flux(X1DIR, V3, k, j, i) +
+                            B_F.flux(X1DIR, V3, k - 1, j, i);
+                });
         }
         if (domain == IndexDomain::inner_x2 &&
-            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2))
-        {
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2)) {
             pmb->par_for("fix_flux_b_in", kbs.s, kbs.e, jbf.s, jbf.s, ibs.s, ibs.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    if (ndim > 2) B_F.flux(X3DIR, V2, k, j-1, i) = -B_F.flux(X3DIR, V2, k, j, i) + B_F.flux(X2DIR, V3, k, j, i) + B_F.flux(X2DIR, V3, k-1, j, i);
-                    if (ndim > 1) B_F.flux(X1DIR, V2, k, j-1, i) = -B_F.flux(X1DIR, V2, k, j, i) + B_F.flux(X2DIR, V1, k, j, i) + B_F.flux(X2DIR, V1, k, j, i-1);
-                }
-            );
-
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V2, k, j - 1, i) =
+                            -B_F.flux(X3DIR, V2, k, j, i) + B_F.flux(X2DIR, V3, k, j, i) +
+                            B_F.flux(X2DIR, V3, k - 1, j, i);
+                    if (ndim > 1)
+                        B_F.flux(X1DIR, V2, k, j - 1, i) =
+                            -B_F.flux(X1DIR, V2, k, j, i) + B_F.flux(X2DIR, V1, k, j, i) +
+                            B_F.flux(X2DIR, V1, k, j, i - 1);
+                });
         }
 
         // OUTER
         if (domain == IndexDomain::outer_x1 &&
-            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x1))
-        {
-            pmb->par_for("fix_flux_b_out", kbs.s, kbs.e, jbs.s, jbs.e, ibf.e, ibf.e, // Hyerin (12/28/22) for 1st & 2nd prescription
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    // (02/06/23) 2nd prescription that allows nonzero flux across X1 boundary but still keeps divB=0
-                    if (ndim > 1) B_F.flux(X2DIR, V1, k, j, i) = -B_F.flux(X2DIR, V1, k, j, i-1) + B_F.flux(X1DIR, V2, k, j, i) + B_F.flux(X1DIR, V2, k, j-1, i);
-                    if (ndim > 2) B_F.flux(X3DIR, V1, k, j, i) = -B_F.flux(X3DIR, V1, k, j, i-1) + B_F.flux(X1DIR, V3, k, j, i) + B_F.flux(X1DIR, V3, k-1, j, i);
-                }
-            );
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x1)) {
+            pmb->par_for("fix_flux_b_out", kbs.s, kbs.e, jbs.s, jbs.e, ibf.e,
+                ibf.e, // Hyerin (12/28/22) for 1st & 2nd prescription
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    // (02/06/23) 2nd prescription that allows nonzero flux
+                    // across X1 boundary but still keeps divB=0
+                    if (ndim > 1)
+                        B_F.flux(X2DIR, V1, k, j, i) = -B_F.flux(X2DIR, V1, k, j, i - 1) +
+                                                       B_F.flux(X1DIR, V2, k, j, i) +
+                                                       B_F.flux(X1DIR, V2, k, j - 1, i);
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V1, k, j, i) = -B_F.flux(X3DIR, V1, k, j, i - 1) +
+                                                       B_F.flux(X1DIR, V3, k, j, i) +
+                                                       B_F.flux(X1DIR, V3, k - 1, j, i);
+                });
         }
         if (domain == IndexDomain::outer_x2 &&
-            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2))
-        {
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2)) {
             pmb->par_for("fix_flux_b_out", kbs.s, kbs.e, jbf.e, jbf.e, ibs.s, ibs.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                    if (ndim > 2) B_F.flux(X3DIR, V2, k, j, i) = -B_F.flux(X3DIR, V2, k, j-1, i) + B_F.flux(X2DIR, V3, k, j, i) + B_F.flux(X2DIR, V3, k-1, j, i);
-                    if (ndim > 1) B_F.flux(X1DIR, V2, k, j, i) = -B_F.flux(X1DIR, V2, k, j-1, i) + B_F.flux(X2DIR, V1, k, j, i) + B_F.flux(X2DIR, V1, k, j, i-1);
-                }
-            );
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    if (ndim > 2)
+                        B_F.flux(X3DIR, V2, k, j, i) = -B_F.flux(X3DIR, V2, k, j - 1, i) +
+                                                       B_F.flux(X2DIR, V3, k, j, i) +
+                                                       B_F.flux(X2DIR, V3, k - 1, j, i);
+                    if (ndim > 1)
+                        B_F.flux(X1DIR, V2, k, j, i) = -B_F.flux(X1DIR, V2, k, j - 1, i) +
+                                                       B_F.flux(X2DIR, V1, k, j, i) +
+                                                       B_F.flux(X2DIR, V1, k, j, i - 1);
+                });
         }
     }
 }
 
-IndexRange ValidDivBX1(MeshBlock *pmb)
+IndexRange ValidDivBX1(MeshBlock* pmb)
 {
-    // All user, physical (not MPI/periodic) boundary conditions in X1 will generate divB on corners
-    // intersecting the interior & exterior faces. Don't report these zones, as we expect it.
-    const IndexRange ibl = pmb->meshblock_data.Get("base")->GetBoundsI(IndexDomain::interior);
-    bool avoid_inner = (!pmb->packages.Get("B_FluxCT")->Param<bool>("fix_flux_inner_x1") &&
-        KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x1));
-    bool avoid_outer = (!pmb->packages.Get("B_FluxCT")->Param<bool>("fix_flux_outer_x1") &&
-        KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x1));
+    // All user, physical (not MPI/periodic) boundary conditions in X1 will generate divB
+    // on corners intersecting the interior & exterior faces. Don't report these zones, as
+    // we expect it.
+    const IndexRange ibl =
+        pmb->meshblock_data.Get("base")->GetBoundsI(IndexDomain::interior);
+    bool avoid_inner =
+        (!pmb->packages.Get("B_FluxCT")->Param<bool>("fix_flux_inner_x1") &&
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x1));
+    bool avoid_outer =
+        (!pmb->packages.Get("B_FluxCT")->Param<bool>("fix_flux_outer_x1") &&
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x1));
     return IndexRange{ibl.s + (avoid_inner), ibl.e + (!avoid_outer)};
 }
 
-double MaxDivB(MeshData<Real> *md)
+double MaxDivB(MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
@@ -583,7 +666,7 @@ double MaxDivB(MeshData<Real> *md)
 
     const IndexRange jb = IndexRange{jbl.s, jbl.e + (ndim > 1)};
     const IndexRange kb = IndexRange{kbl.s, kbl.e + (ndim > 2)};
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     // TODO Keep zone of max! See timestep calc
     // Will need to translate them back to KS to make them useful though
@@ -598,13 +681,16 @@ double MaxDivB(MeshData<Real> *md)
 
         double max_divb_block;
         Kokkos::Max<double> max_reducer(max_divb_block);
-        pmb->par_reduce("divB_max", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+        pmb->par_reduce(
+            "divB_max", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 const auto& G = B_U.GetCoords(b);
-                const double local_divb = m::abs(corner_div(G, B_U(b), k, j, i, ndim > 2));
+                const double local_divb =
+                    m::abs(corner_div(G, B_U(b), k, j, i, ndim > 2));
                 if (local_divb > local_result) local_result = local_divb;
-            }
-        , max_reducer);
+            },
+            max_reducer);
 
         if (max_divb_block > max_divb) max_divb = max_divb_block;
     }
@@ -612,7 +698,7 @@ double MaxDivB(MeshData<Real> *md)
     return max_divb;
 }
 
-double GlobalMaxDivB(MeshData<Real> *md, bool all_reduce)
+double GlobalMaxDivB(MeshData<Real>* md, bool all_reduce)
 {
     if (all_reduce) {
         Reductions::StartToAll<Real>(md, 2, MaxDivB(md), MPI_MAX);
@@ -623,7 +709,7 @@ double GlobalMaxDivB(MeshData<Real> *md, bool all_reduce)
     }
 }
 
-TaskStatus PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
+TaskStatus PrintGlobalMaxDivB(MeshData<Real>* md, bool kill_on_large_divb)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
@@ -640,7 +726,8 @@ TaskStatus PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
             printf("Max DivB: %g\n", divb_max);
         }
         if (kill_on_large_divb) {
-            if (divb_max > pmb0->packages.Get("B_FluxCT")->Param<Real>("kill_on_divb_over"))
+            if (divb_max >
+                pmb0->packages.Get("B_FluxCT")->Param<Real>("kill_on_divb_over"))
                 throw std::runtime_error("DivB exceeds maximum! Quitting...");
         }
     }
@@ -650,7 +737,7 @@ TaskStatus PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb)
 
 // TODO unify these by adding FillOutputMesh option
 
-void CalcDivB(MeshData<Real> *md, std::string divb_field_name)
+void CalcDivB(MeshData<Real>* md, std::string divb_field_name)
 {
     auto pmesh = md->GetMeshPointer();
     const int ndim = pmesh->ndim;
@@ -665,7 +752,7 @@ void CalcDivB(MeshData<Real> *md, std::string divb_field_name)
 
     const IndexRange jb = IndexRange{jbl.s, jbl.e + (ndim > 1)};
     const IndexRange kb = IndexRange{kbl.s, kbl.e + (ndim > 2)};
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     // See MaxDivB for details
     for (int b = block.s; b <= block.e; ++b) {
@@ -674,14 +761,14 @@ void CalcDivB(MeshData<Real> *md, std::string divb_field_name)
         const IndexRange ib = ValidDivBX1(pmb);
 
         pmb->par_for("calc_divB", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 const auto& G = B_U.GetCoords(b);
                 divB(b, 0, k, j, i) = corner_div(G, B_U(b), k, j, i, ndim > 2);
-            }
-        );
+            });
     }
 }
-void FillOutput(MeshBlock *pmb, ParameterInput *pin)
+void FillOutput(MeshBlock* pmb, ParameterInput* pin)
 {
     auto rc = pmb->meshblock_data.Get("base").get();
     const int ndim = pmb->pmy_mesh->ndim;
@@ -695,16 +782,16 @@ void FillOutput(MeshBlock *pmb, ParameterInput *pin)
 
     const IndexRange jb = IndexRange{jbl.s, jbl.e + (ndim > 1)};
     const IndexRange kb = IndexRange{kbl.s, kbl.e + (ndim > 2)};
-    const IndexRange block = IndexRange{0, B_U.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, B_U.GetDim(5) - 1};
 
     const IndexRange ib = ValidDivBX1(pmb);
 
     pmb->par_for("divB_output", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             const auto& G = B_U.GetCoords();
             divB(0, k, j, i) = corner_div(G, B_U, k, j, i, ndim > 2);
-        }
-    );
+        });
 }
 
 } // namespace B_FluxCT

--- a/kharma/b_flux_ct/b_flux_ct.hpp
+++ b/kharma/b_flux_ct/b_flux_ct.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_flux_ct.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,65 +42,68 @@
 #include <memory>
 
 /**
- * 
+ *
  * This physics package implements B field transport with Flux-CT (Toth 2000)
  *
  * This requires only the magnetic field value at cell centers
- * 
+ *
  * This implementation includes conversion from "primitive" to "conserved" B and back
  */
-namespace B_FluxCT {
+namespace B_FluxCT
+{
 /**
  * Declare fields, initialize parameters
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Get the primitive variables, which in Parthenon's nomenclature are "derived".
  * Also applies floors to the calculated primitives, and fixes up any inversion errors
- * 
- * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
- * 
+ *
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost
+ * zones.
+ *
  * input: Conserved B = sqrt(-gdet) * B^i
  * output: Primitive B = B^i
  */
-TaskStatus BlockUtoP(MeshBlockData<Real> *md, IndexDomain domain, bool coarse=false);
-TaskStatus MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
+TaskStatus BlockUtoP(MeshBlockData<Real>* md, IndexDomain domain, bool coarse = false);
+TaskStatus MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse = false);
 
 /**
  * Reverse of the above.  Only used alone during initialization.
  * Generally, use Flux::BlockPtoU/Flux::MeshPtoU
  */
-void BlockPtoU(MeshBlockData<Real> *md, IndexDomain domain, bool coarse=false);
-void MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
+void BlockPtoU(MeshBlockData<Real>* md, IndexDomain domain, bool coarse = false);
+void MeshPtoU(MeshData<Real>* md, IndexDomain domain, bool coarse = false);
 
 /**
  * Apply all flux corrections required by this package to ensure small divB
  */
-void FixFlux(MeshData<Real> *md);
+void FixFlux(MeshData<Real>* md);
 
 /**
  * Modify the B field fluxes to take a constrained-transport step as in Toth (2000)
  */
-void FluxCT(MeshData<Real> *md);
+void FluxCT(MeshData<Real>* md);
 
 /**
  * Modify the B field fluxes just beyond the polar (or radial) boundary so as to
  * ensure no flux through the boundary after applying FluxCT
  */
-void ZeroBoundaryFlux(MeshData<Real> *md, IndexDomain domain, bool coarse);
+void ZeroBoundaryFlux(MeshData<Real>* md, IndexDomain domain, bool coarse);
 
 /**
  * Modify the B field fluxes just beyond the radial (or polar) boundary so as to
- * ensure the magnetic divergence is zero, even 
+ * ensure the magnetic divergence is zero, even
  */
-void Bflux0(MeshData<Real> *md, IndexDomain domain, bool coarse);
+void Bflux0(MeshData<Real>* md, IndexDomain domain, bool coarse);
 
 /**
  * Alternate B field fix for X1 boundary, keeps zero divergence while permitting flux
  * through the boundary, at the cost of a short non-local solve.
  */
-TaskStatus FixX1Flux(MeshData<Real> *md);
+TaskStatus FixX1Flux(MeshData<Real>* md);
 
 /**
  * Calculate maximum corner-centered divergence of magnetic field,
@@ -108,25 +111,25 @@ TaskStatus FixX1Flux(MeshData<Real> *md);
  * Used as a Parthenon History function, so must take exactly the
  * listed arguments
  */
-double MaxDivB(MeshData<Real> *md);
+double MaxDivB(MeshData<Real>* md);
 
 /**
  * Returns the global maximum value, rather than the maximum over this rank's MeshData
- * 
+ *
  * By default, only returns the correct value on rank 0 for printing
  */
-double GlobalMaxDivB(MeshData<Real> *md, bool all_reduce=false);
+double GlobalMaxDivB(MeshData<Real>* md, bool all_reduce = false);
 
 /**
  * Diagnostics printed/computed after each step
  * Currently just max divB
  */
-TaskStatus PrintGlobalMaxDivB(MeshData<Real> *md, bool kill_on_large_divb=false);
+TaskStatus PrintGlobalMaxDivB(MeshData<Real>* md, bool kill_on_large_divb = false);
 
 /**
  * Diagnostics function should print divB, and optionally stop execution if it's large
  */
-inline TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+inline TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto& params = md->GetMeshPointer()->packages.Get("B_FluxCT")->AllParams();
     return PrintGlobalMaxDivB(md, params.Get<bool>("kill_on_large_divb"));
@@ -135,10 +138,10 @@ inline TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
 /**
  * Fill fields which are calculated only for output to file, i.e., divB
  */
-void FillOutput(MeshBlock *pmb, ParameterInput *pin);
+void FillOutput(MeshBlock* pmb, ParameterInput* pin);
 /**
  * Fill the field 'divb_field_name' with divB
  */
-void CalcDivB(MeshData<Real> *md, std::string divb_field_name="divB");
+void CalcDivB(MeshData<Real>* md, std::string divb_field_name = "divB");
 
 }

--- a/kharma/b_flux_ct/b_flux_ct_functions.hpp
+++ b/kharma/b_flux_ct/b_flux_ct_functions.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: b_flux_ct_functions.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,7 +43,8 @@
 /**
  * Device functions for Flux-CT
  */
-namespace B_FluxCT {
+namespace B_FluxCT
+{
 
 /**
  * ND divergence, averaging to cell corners
@@ -51,27 +52,28 @@ namespace B_FluxCT {
  */
 template<typename Global>
 KOKKOS_FORCEINLINE_FUNCTION double corner_div(const GRCoordinates& G, const Global& B_U,
-                                         const int& k, const int& j, const int& i, const bool& do_3D)
+    const int& k, const int& j, const int& i, const bool& do_3D)
 {
     const double norm = (do_3D) ? 0.25 : 0.5;
     // 2D divergence, averaging to corners
-    double term1 = B_U(V1, k, j, i)   - B_U(V1, k, j, i-1) +
-                   B_U(V1, k, j-1, i) - B_U(V1, k, j-1, i-1);
-    double term2 = B_U(V2, k, j, i)   - B_U(V2, k, j-1, i) +
-                   B_U(V2, k, j, i-1) - B_U(V2, k, j-1, i-1);
+    double term1 = B_U(V1, k, j, i) - B_U(V1, k, j, i - 1) + B_U(V1, k, j - 1, i) -
+                   B_U(V1, k, j - 1, i - 1);
+    double term2 = B_U(V2, k, j, i) - B_U(V2, k, j - 1, i) + B_U(V2, k, j, i - 1) -
+                   B_U(V2, k, j - 1, i - 1);
     double term3 = 0.;
     if (do_3D) {
         // Average to corners in 3D, add 3rd flux
-        term1 +=  B_U(V1, k-1, j, i)   + B_U(V1, k-1, j-1, i)
-                - B_U(V1, k-1, j, i-1) - B_U(V1, k-1, j-1, i-1);
-        term2 +=  B_U(V2, k-1, j, i)   + B_U(V2, k-1, j, i-1)
-                - B_U(V2, k-1, j-1, i) - B_U(V2, k-1, j-1, i-1);
-        term3 =   B_U(V3, k, j, i)     + B_U(V3, k, j-1, i)
-                + B_U(V3, k, j, i-1)   + B_U(V3, k, j-1, i-1)
-                - B_U(V3, k-1, j, i)   - B_U(V3, k-1, j-1, i)
-                - B_U(V3, k-1, j, i-1) - B_U(V3, k-1, j-1, i-1);
+        term1 += B_U(V1, k - 1, j, i) + B_U(V1, k - 1, j - 1, i) -
+                 B_U(V1, k - 1, j, i - 1) - B_U(V1, k - 1, j - 1, i - 1);
+        term2 += B_U(V2, k - 1, j, i) + B_U(V2, k - 1, j, i - 1) -
+                 B_U(V2, k - 1, j - 1, i) - B_U(V2, k - 1, j - 1, i - 1);
+        term3 = B_U(V3, k, j, i) + B_U(V3, k, j - 1, i) + B_U(V3, k, j, i - 1) +
+                B_U(V3, k, j - 1, i - 1) - B_U(V3, k - 1, j, i) -
+                B_U(V3, k - 1, j - 1, i) - B_U(V3, k - 1, j, i - 1) -
+                B_U(V3, k - 1, j - 1, i - 1);
     }
-    return norm*term1/G.Dxc<1>(i) + norm*term2/G.Dxc<2>(j) + norm*term3/G.Dxc<3>(k);
+    return norm * term1 / G.Dxc<1>(i) + norm * term2 / G.Dxc<2>(j) +
+           norm * term3 / G.Dxc<3>(k);
 }
 
 /**
@@ -80,87 +82,98 @@ KOKKOS_FORCEINLINE_FUNCTION double corner_div(const GRCoordinates& G, const Glob
  */
 template<typename Global>
 KOKKOS_FORCEINLINE_FUNCTION void center_grad(const GRCoordinates& G, const Global& P,
-                                          const int& k, const int& j, const int& i, const bool& do_3D,
-                                          double& B1, double& B2, double& B3)
+    const int& k, const int& j, const int& i, const bool& do_3D, double& B1, double& B2,
+    double& B3)
 {
     const double norm = (do_3D) ? 0.25 : 0.5;
     // 2D gradient, averaging to centers
-    double term1 =  P(0, k, j+1, i+1) + P(0, k, j, i+1)
-                  - P(0, k, j+1, i)   - P(0, k, j, i);
-    double term2 =  P(0, k, j+1, i+1) + P(0, k, j+1, i)
-                  - P(0, k, j, i+1)   - P(0, k, j, i);
+    double term1 =
+        P(0, k, j + 1, i + 1) + P(0, k, j, i + 1) - P(0, k, j + 1, i) - P(0, k, j, i);
+    double term2 =
+        P(0, k, j + 1, i + 1) + P(0, k, j + 1, i) - P(0, k, j, i + 1) - P(0, k, j, i);
     double term3 = 0.;
     if (do_3D) {
         // Average to centers in 3D, add 3rd flux
-        term1 += P(0, k+1, j+1, i+1) + P(0, k+1, j, i+1)
-               - P(0, k+1, j+1, i)   - P(0, k+1, j, i);
-        term2 += P(0, k+1, j+1, i+1) + P(0, k+1, j+1, i)
-               - P(0, k+1, j, i+1)   - P(0, k+1, j, i);
-        term3 =  P(0, k+1, j+1, i+1) + P(0, k+1, j, i+1)
-               + P(0, k+1, j+1, i)   + P(0, k+1, j, i)
-               - P(0, k, j+1, i+1)   - P(0, k, j, i+1)
-               - P(0, k, j+1, i)     - P(0, k, j, i);
+        term1 += P(0, k + 1, j + 1, i + 1) + P(0, k + 1, j, i + 1) -
+                 P(0, k + 1, j + 1, i) - P(0, k + 1, j, i);
+        term2 += P(0, k + 1, j + 1, i + 1) + P(0, k + 1, j + 1, i) -
+                 P(0, k + 1, j, i + 1) - P(0, k + 1, j, i);
+        term3 = P(0, k + 1, j + 1, i + 1) + P(0, k + 1, j, i + 1) +
+                P(0, k + 1, j + 1, i) + P(0, k + 1, j, i) - P(0, k, j + 1, i + 1) -
+                P(0, k, j, i + 1) - P(0, k, j + 1, i) - P(0, k, j, i);
     }
-    B1 = norm*term1/G.Dxc<1>(i);
-    B2 = norm*term2/G.Dxc<2>(j);
-    B3 = norm*term3/G.Dxc<3>(k);
+    B1 = norm * term1 / G.Dxc<1>(i);
+    B2 = norm * term2 / G.Dxc<2>(j);
+    B3 = norm * term3 / G.Dxc<3>(k);
 }
 
-KOKKOS_FORCEINLINE_FUNCTION void averaged_curl_3D(const GRCoordinates& G, const GridVector& A, const GridVector& B_U,
-                                             const int& k, const int& j, const int& i)
+KOKKOS_FORCEINLINE_FUNCTION void averaged_curl_3D(const GRCoordinates& G,
+    const GridVector& A, const GridVector& B_U, const int& k, const int& j, const int& i)
 {
     // Take a flux-ct step from the corner potentials.
     // This needs to be 3D because post-tilt A may not point in the phi direction only
 
     // A3,2 derivative
-    const Real A3c2f = (A(V3, k, j + 1, i)     + A(V3, k, j + 1, i + 1) + 
-                        A(V3, k + 1, j + 1, i) + A(V3, k + 1, j + 1, i + 1)) / 4;
-    const Real A3c2b = (A(V3, k, j, i)     + A(V3, k, j, i + 1) +
-                        A(V3, k + 1, j, i) + A(V3, k + 1, j, i + 1)) / 4;
+    const Real A3c2f = (A(V3, k, j + 1, i) + A(V3, k, j + 1, i + 1) +
+                           A(V3, k + 1, j + 1, i) + A(V3, k + 1, j + 1, i + 1)) /
+                       4;
+    const Real A3c2b = (A(V3, k, j, i) + A(V3, k, j, i + 1) + A(V3, k + 1, j, i) +
+                           A(V3, k + 1, j, i + 1)) /
+                       4;
     // A2,3 derivative
-    const Real A2c3f = (A(V2, k + 1, j, i)     + A(V2, k + 1, j, i + 1) +
-                        A(V2, k + 1, j + 1, i) + A(V2, k + 1, j + 1, i + 1)) / 4;
-    const Real A2c3b = (A(V2, k, j, i)     + A(V2, k, j, i + 1) +
-                        A(V2, k, j + 1, i) + A(V2, k, j + 1, i + 1)) / 4;
+    const Real A2c3f = (A(V2, k + 1, j, i) + A(V2, k + 1, j, i + 1) +
+                           A(V2, k + 1, j + 1, i) + A(V2, k + 1, j + 1, i + 1)) /
+                       4;
+    const Real A2c3b = (A(V2, k, j, i) + A(V2, k, j, i + 1) + A(V2, k, j + 1, i) +
+                           A(V2, k, j + 1, i + 1)) /
+                       4;
     B_U(V1, k, j, i) = (A3c2f - A3c2b) / G.Dxc<2>(j) - (A2c3f - A2c3b) / G.Dxc<3>(k);
 
     // A1,3 derivative
-    const Real A1c3f = (A(V1, k + 1, j, i)     + A(V1, k + 1, j, i + 1) + 
-                        A(V1, k + 1, j + 1, i) + A(V1, k + 1, j + 1, i + 1)) / 4;
-    const Real A1c3b = (A(V1, k, j, i)     + A(V1, k, j, i + 1) +
-                        A(V1, k, j + 1, i) + A(V1, k, j + 1, i + 1)) / 4;
+    const Real A1c3f = (A(V1, k + 1, j, i) + A(V1, k + 1, j, i + 1) +
+                           A(V1, k + 1, j + 1, i) + A(V1, k + 1, j + 1, i + 1)) /
+                       4;
+    const Real A1c3b = (A(V1, k, j, i) + A(V1, k, j, i + 1) + A(V1, k, j + 1, i) +
+                           A(V1, k, j + 1, i + 1)) /
+                       4;
     // A3,1 derivative
-    const Real A3c1f = (A(V3, k, j, i + 1)     + A(V3, k + 1, j, i + 1) +
-                        A(V3, k, j + 1, i + 1) + A(V3, k + 1, j + 1, i + 1)) / 4;
-    const Real A3c1b = (A(V3, k, j, i)     + A(V3, k + 1, j, i) +
-                        A(V3, k, j + 1, i) + A(V3, k + 1, j + 1, i)) / 4;
+    const Real A3c1f = (A(V3, k, j, i + 1) + A(V3, k + 1, j, i + 1) +
+                           A(V3, k, j + 1, i + 1) + A(V3, k + 1, j + 1, i + 1)) /
+                       4;
+    const Real A3c1b = (A(V3, k, j, i) + A(V3, k + 1, j, i) + A(V3, k, j + 1, i) +
+                           A(V3, k + 1, j + 1, i)) /
+                       4;
     B_U(V2, k, j, i) = (A1c3f - A1c3b) / G.Dxc<3>(k) - (A3c1f - A3c1b) / G.Dxc<1>(i);
 
     // A2,1 derivative
-    const Real A2c1f = (A(V2, k, j, i + 1)     + A(V2, k, j + 1, i + 1) + 
-                        A(V2, k + 1, j, i + 1) + A(V2, k + 1, j + 1, i + 1)) / 4;
-    const Real A2c1b = (A(V2, k, j, i)     + A(V2, k, j + 1, i) +
-                        A(V2, k + 1, j, i) + A(V2, k + 1, j + 1, i)) / 4;
+    const Real A2c1f = (A(V2, k, j, i + 1) + A(V2, k, j + 1, i + 1) +
+                           A(V2, k + 1, j, i + 1) + A(V2, k + 1, j + 1, i + 1)) /
+                       4;
+    const Real A2c1b = (A(V2, k, j, i) + A(V2, k, j + 1, i) + A(V2, k + 1, j, i) +
+                           A(V2, k + 1, j + 1, i)) /
+                       4;
     // A1,2 derivative
-    const Real A1c2f = (A(V1, k, j + 1, i)     + A(V1, k, j + 1, i + 1) +
-                        A(V1, k + 1, j + 1, i) + A(V1, k + 1, j + 1, i + 1)) / 4;
-    const Real A1c2b = (A(V1, k, j, i)     + A(V1, k, j, i + 1) +
-                        A(V1, k + 1, j, i) + A(V1, k + 1, j, i + 1)) / 4;
+    const Real A1c2f = (A(V1, k, j + 1, i) + A(V1, k, j + 1, i + 1) +
+                           A(V1, k + 1, j + 1, i) + A(V1, k + 1, j + 1, i + 1)) /
+                       4;
+    const Real A1c2b = (A(V1, k, j, i) + A(V1, k, j, i + 1) + A(V1, k + 1, j, i) +
+                           A(V1, k + 1, j, i + 1)) /
+                       4;
     B_U(V3, k, j, i) = (A2c1f - A2c1b) / G.Dxc<1>(i) - (A1c2f - A1c2b) / G.Dxc<2>(j);
 }
 
-KOKKOS_FORCEINLINE_FUNCTION void averaged_curl_2D(const GRCoordinates& G, const GridVector& A, const GridVector& B_U,
-                                             const int& k, const int& j, const int& i)
+KOKKOS_FORCEINLINE_FUNCTION void averaged_curl_2D(const GRCoordinates& G,
+    const GridVector& A, const GridVector& B_U, const int& k, const int& j, const int& i)
 {
     // A3,2 derivative
     const Real A3c2f = (A(V3, k, j + 1, i) + A(V3, k, j + 1, i + 1)) / 2;
-    const Real A3c2b = (A(V3, k, j, i)     + A(V3, k, j, i + 1)) / 2;
+    const Real A3c2b = (A(V3, k, j, i) + A(V3, k, j, i + 1)) / 2;
     B_U(V1, k, j, i) = (A3c2f - A3c2b) / G.Dxc<2>(j);
 
     // A3,1 derivative
     const Real A3c1f = (A(V3, k, j, i + 1) + A(V3, k, j + 1, i + 1)) / 2;
-    const Real A3c1b = (A(V3, k, j, i)     + A(V3, k, j + 1, i)) / 2;
-    B_U(V2, k, j, i) = - (A3c1f - A3c1b) / G.Dxc<1>(i);
+    const Real A3c1b = (A(V3, k, j, i) + A(V3, k, j + 1, i)) / 2;
+    B_U(V2, k, j, i) = -(A3c1f - A3c1b) / G.Dxc<1>(i);
 
     B_U(V3, k, j, i) = 0;
 }

--- a/kharma/boundaries/boundaries.cpp
+++ b/kharma/boundaries/boundaries.cpp
@@ -37,9 +37,9 @@
 #include "boundary_types.hpp"
 #include "decs.hpp"
 #include "domain.hpp"
-#include "kharma.hpp"
 #include "flux_functions.hpp"
 #include "grmhd_functions.hpp"
+#include "kharma.hpp"
 #include "pack.hpp"
 #include "reductions.hpp"
 #include "types.hpp"
@@ -53,63 +53,71 @@
 
 // Very bad definition. Still necessary, though
 // TODO get rid of them eventually
-#define PLOOP for(int ip=0; ip < nvar; ++ip)
+#define PLOOP for (int ip = 0; ip < nvar; ++ip)
 
-std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t> &packages)
+std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Boundaries");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // OPTIONS FOR SPECIFIC BOUNDARIES
     bool spherical = pin->GetBoolean("coordinates", "spherical");
     // Global check inflow sets inner/outer X1 by default
-    bool check_inflow_global = pin->GetOrAddBoolean("boundaries", "check_inflow", spherical);
+    bool check_inflow_global =
+        pin->GetOrAddBoolean("boundaries", "check_inflow", spherical);
 
     // Option to excise a bit at the poles when calculating fluxes
-    bool excise_polar_flux = pin->GetOrAddBoolean("boundaries", "excise_polar_flux", false);
+    bool excise_polar_flux =
+        pin->GetOrAddBoolean("boundaries", "excise_polar_flux", false);
     params.Add("excise_polar_flux", excise_polar_flux);
     // Otherwise, those fluxes should be zero
-    bool zero_polar_flux = pin->GetOrAddBoolean("boundaries", "zero_polar_flux", spherical && !excise_polar_flux);
+    bool zero_polar_flux = pin->GetOrAddBoolean(
+        "boundaries", "zero_polar_flux", spherical && !excise_polar_flux);
     params.Add("zero_polar_flux", zero_polar_flux);
     // Throw an error if both are set
     if (excise_polar_flux && zero_polar_flux) {
-        throw std::runtime_error("Cannot set both boundaries/excise_polar_flux and boundaries/zero_polar_flux!");
+        throw std::runtime_error("Cannot set both boundaries/excise_polar_flux and "
+                                 "boundaries/zero_polar_flux!");
     }
 
     // Apply physical boundaries to conserved GRMHD variables rho u^r, T^mu_nu
     // Probably inadvisable?
-    bool domain_bounds_on_conserved = pin->GetOrAddBoolean("boundaries", "domain_bounds_on_conserved", false);
+    bool domain_bounds_on_conserved =
+        pin->GetOrAddBoolean("boundaries", "domain_bounds_on_conserved", false);
     params.Add("domain_bounds_on_conserved", domain_bounds_on_conserved);
 
     // Fix the X1/X2 corner by replacing the reflecting condition with the inflow
     // Never use this if not in spherical coordinates
-    // Activates by default only with reflecting X2/outflow X1 and interior boundary inside EH
-    // TODO(BSP) may also be specific to Funky MKS coords with zero_point==startx1
+    // Activates by default only with reflecting X2/outflow X1 and interior boundary
+    // inside EH
+    // TODO(CEP) may also be specific to Funky MKS coords with zero_point==startx1
     bool fix_corner = false;
     if (spherical) {
-        bool correct_bounds =
-            (pin->GetString("boundaries", "inner_x2") == "reflecting" &&
-             pin->GetString("boundaries", "outer_x2") == "reflecting" &&
-             pin->GetString("boundaries", "inner_x1") == "outflow");
+        bool correct_bounds = (pin->GetString("boundaries", "inner_x2") == "reflecting" &&
+                               pin->GetString("boundaries", "outer_x2") == "reflecting" &&
+                               pin->GetString("boundaries", "inner_x1") == "outflow");
         bool inside_eh = pin->GetBoolean("coordinates", "domain_intersects_eh");
-        fix_corner = pin->GetOrAddBoolean("boundaries", "fix_corner", correct_bounds && inside_eh);
+        fix_corner =
+            pin->GetOrAddBoolean("boundaries", "fix_corner", correct_bounds && inside_eh);
         // Allow overriding with specific name
         fix_corner = pin->GetOrAddBoolean("boundaries", "fix_corner_inner", fix_corner);
     }
     params.Add("fix_corner_inner", fix_corner);
-    params.Add("fix_corner_outer", pin->GetOrAddBoolean("boundaries", "fix_corner_outer", false));
+    params.Add("fix_corner_outer",
+        pin->GetOrAddBoolean("boundaries", "fix_corner_outer", false));
 
     // We can't use GetVariablesByFlag yet, so ask the packages
     // These flags get anything that needs a physical boundary during the run
     using FC = Metadata::FlagCollection;
-    FC ghost_vars = FC({Metadata::FillGhost, Metadata::Conserved})
-                + FC({Metadata::FillGhost, Metadata::GetUserFlag("Primitive")})
-                - FC({Metadata::GetUserFlag("StartupOnly")});
+    FC ghost_vars = FC({Metadata::FillGhost, Metadata::Conserved}) +
+                    FC({Metadata::FillGhost, Metadata::GetUserFlag("Primitive")}) -
+                    FC({Metadata::GetUserFlag("StartupOnly")});
     auto res_state = StateDescriptor::CreateResolvedStateDescriptor(*packages);
     int nvar = res_state->GetPackDimension(ghost_vars);
     // Face-centered fields: some duplicate stuff, leaving it separate for now
-    FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face})
-                - FC({Metadata::GetUserFlag("StartupOnly")});
+    FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face}) -
+                      FC({Metadata::GetUserFlag("StartupOnly")});
     int nvar_f = 3 * res_state->GetPackDimension(ghost_vars_f);
 
     // TODO encapsulate this
@@ -129,9 +137,15 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
         std::vector<int> s_x2({n1, ng, n3, nvar});
         std::vector<int> s_x3({n1, n2, ng, nvar});
         // Dirichlet conditions must be restored when restarting!
-        m_x1 = Metadata({Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart}, s_x1);
-        m_x2 = Metadata({Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart}, s_x2);
-        m_x3 = Metadata({Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart}, s_x3);
+        m_x1 = Metadata(
+            {Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart},
+            s_x1);
+        m_x2 = Metadata(
+            {Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart},
+            s_x2);
+        m_x3 = Metadata(
+            {Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart},
+            s_x3);
 
         if (nvar_f > 0) {
             // Face mesh sizes
@@ -147,17 +161,24 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
             std::vector<int> s_x1_f({ng_f, n2_f, n3_f, nvar_f});
             std::vector<int> s_x2_f({n1_f, ng_f, n3_f, nvar_f});
             std::vector<int> s_x3_f({n1_f, n2_f, ng_f, nvar_f});
-            // Note these are *NOT* face variables, they cannot be indexed by TopologicalElement.
-            // Instead, we make them a normal vector and use int(TE) % 3
-            m_x1_f = Metadata({Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart}, s_x1_f);
-            m_x2_f = Metadata({Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart}, s_x2_f);
-            m_x3_f = Metadata({Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart}, s_x3_f);
+            // Note these are *NOT* face variables, they cannot be indexed by
+            // TopologicalElement. Instead, we make them a normal vector and use int(TE) %
+            // 3
+            m_x1_f = Metadata(
+                {Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart},
+                s_x1_f);
+            m_x2_f = Metadata(
+                {Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart},
+                s_x2_f);
+            m_x3_f = Metadata(
+                {Metadata::Real, Metadata::Derived, Metadata::OneCopy, Metadata::Restart},
+                s_x3_f);
         }
     }
 
     // Set options for each boundary
     for (int i = 0; i < BOUNDARY_NFACES; i++) {
-        const auto bface = (BoundaryFace) i;
+        const auto bface = (BoundaryFace)i;
         const auto bdomain = BoundaryDomain(bface);
         const auto bname = BoundaryName(bface);
         const auto bdir = BoundaryDirection(bface);
@@ -169,52 +190,65 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
         // OPTIONS FOR ANY BOUNDARY
 
         // Prevent inflow at boundaries.
-        // This is two separate checks, but default to enabling/disabling together for X1 and not elsewhere
-        bool check_inflow = pin->GetOrAddBoolean("boundaries", "check_inflow_" + bname, check_inflow_global && bdir == X1DIR);
+        // This is two separate checks, but default to enabling/disabling together for X1
+        // and not elsewhere
+        bool check_inflow = pin->GetOrAddBoolean(
+            "boundaries", "check_inflow_" + bname, check_inflow_global && bdir == X1DIR);
         params.Add("check_inflow_" + bname, check_inflow);
 
         // Ensure fluxes through the zero-size face at the pole are zero
-        bool zero_flux = pin->GetOrAddBoolean("boundaries", "zero_flux_" + bname, zero_polar_flux && bdir == X2DIR);
+        bool zero_flux = pin->GetOrAddBoolean(
+            "boundaries", "zero_flux_" + bname, zero_polar_flux && bdir == X2DIR);
         params.Add("zero_flux_" + bname, zero_flux);
         // OR allow them via faux-excision
-        bool excise_flux = pin->GetOrAddBoolean("boundaries", "excise_flux_" + bname, excise_polar_flux && bdir == X2DIR);
+        bool excise_flux = pin->GetOrAddBoolean(
+            "boundaries", "excise_flux_" + bname, excise_polar_flux && bdir == X2DIR);
         params.Add("excise_flux_" + bname, excise_flux);
 
         // Allow specifically dP to outflow in otherwise Dirichlet conditions
         // Only used for viscous_bondi problem
-        bool outflow_EMHD = pin->GetOrAddBoolean("boundaries", "outflow_EMHD_" + bname, false);
+        bool outflow_EMHD =
+            pin->GetOrAddBoolean("boundaries", "outflow_EMHD_" + bname, false);
         params.Add("outflow_EMHD_" + bname, outflow_EMHD);
 
-        // Options specific to face-centered B fields, which require a lot of care at boundaries
+        // Options specific to face-centered B fields, which require a lot of care at
+        // boundaries
         if (packages->AllPackages().count("B_CT")) {
             // Invert X2 face values to reflect across polar boundary
-            bool invert_F2 = pin->GetOrAddBoolean("boundaries", "reflect_face_vector_" + bname, (btype == "reflecting"));
-            params.Add("reflect_face_vector_"+bname, invert_F2);
-            // If you'll have field loops exiting the domain, outflow conditions need to be cleaned so as not to
-            // introduce divergence to the first physical zone.
-            bool clean_face_B = pin->GetOrAddBoolean("boundaries", "clean_face_B_" + bname, (btype == "outflow"));
-            params.Add("clean_face_B_"+bname, clean_face_B);
+            bool invert_F2 = pin->GetOrAddBoolean(
+                "boundaries", "reflect_face_vector_" + bname, (btype == "reflecting"));
+            params.Add("reflect_face_vector_" + bname, invert_F2);
+            // If you'll have field loops exiting the domain, outflow conditions need to
+            // be cleaned so as not to introduce divergence to the first physical zone.
+            bool clean_face_B = pin->GetOrAddBoolean(
+                "boundaries", "clean_face_B_" + bname, (btype == "outflow"));
+            params.Add("clean_face_B_" + bname, clean_face_B);
             // Forcibly reconnect field loops that get trapped around the polar boundary
             // Needed to keep excised-flux transmitting boundaries stable
-            bool reconnect_B3 = pin->GetOrAddBoolean("boundaries", "reconnect_B3_" + bname, excise_flux);
-            params.Add("reconnect_B3_"+bname, reconnect_B3);
+            bool reconnect_B3 =
+                pin->GetOrAddBoolean("boundaries", "reconnect_B3_" + bname, excise_flux);
+            params.Add("reconnect_B3_" + bname, reconnect_B3);
 
             // Special EMF averaging.  Allows B3 to "slip" around the pole
-            // Also useful to allow coherent motion even with Dirichlet boundaries, for e.g. multizone
-            bool average_EMF = pin->GetOrAddBoolean("boundaries", "average_EMF_" + bname, (btype == "transmitting"));
-            params.Add("average_EMF_"+bname, average_EMF);
-            // Otherwise, always zero EMFs to prevent B field escaping the domain in polar/dirichlet bounds
-            // Default for dirichlet conditions unless averaging is set manually
-            bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname, (btype == "reflecting" ||
-                                                                                    (btype == "dirichlet" && !average_EMF)));
-            params.Add("zero_EMF_"+bname, zero_EMF);
+            // Also useful to allow coherent motion even with Dirichlet boundaries, for
+            // e.g. multizone
+            bool average_EMF = pin->GetOrAddBoolean(
+                "boundaries", "average_EMF_" + bname, (btype == "transmitting"));
+            params.Add("average_EMF_" + bname, average_EMF);
+            // Otherwise, always zero EMFs to prevent B field escaping the domain in
+            // polar/dirichlet bounds Default for dirichlet conditions unless averaging is
+            // set manually
+            bool zero_EMF = pin->GetOrAddBoolean("boundaries", "zero_EMF_" + bname,
+                (btype == "reflecting" || (btype == "dirichlet" && !average_EMF)));
+            params.Add("zero_EMF_" + bname, zero_EMF);
         }
-        // Advect together/cancel velocity or angular momentum "loops" around the pole, similar to B3 above
-        // Probably not needed anymore, now polar boundary conditions are fixed.  cancel_U3 does not conserve angular momentum.
+        // Advect together/cancel velocity or angular momentum "loops" around the pole,
+        // similar to B3 above Probably not needed anymore, now polar boundary conditions
+        // are fixed.  cancel_U3 does not conserve angular momentum.
         bool cancel_U3 = pin->GetOrAddBoolean("boundaries", "cancel_U3_" + bname, false);
-        params.Add("cancel_U3_"+bname, cancel_U3);
+        params.Add("cancel_U3_" + bname, cancel_U3);
         bool cancel_T3 = pin->GetOrAddBoolean("boundaries", "cancel_T3_" + bname, false);
-        params.Add("cancel_T3_"+bname, cancel_T3);
+        params.Add("cancel_T3_" + bname, cancel_T3);
 
         // String manip to get the Parthenon boundary name, e.g., "ox1_bc"
         auto bname_parthenon = bname.substr(0, 1) + "x" + bname.substr(7, 8) + "_bc";
@@ -229,146 +263,171 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
             // when called via Parthenon's "user" conditions
             if (btype == "dirichlet") {
                 // Dirichlet boundaries: allocate
-                pkg->AddField("Boundaries." + bname, (bdir == X1DIR) ? m_x1 : ((bdir == X2DIR) ? m_x2 : m_x3));
+                pkg->AddField("Boundaries." + bname,
+                    (bdir == X1DIR) ? m_x1 : ((bdir == X2DIR) ? m_x2 : m_x3));
                 if (nvar_f > 0) {
-                    pkg->AddField("Boundaries.f." + bname, (bdir == X1DIR) ? m_x1_f : ((bdir == X2DIR) ? m_x2_f : m_x3_f));
+                    pkg->AddField("Boundaries.f." + bname,
+                        (bdir == X1DIR) ? m_x1_f : ((bdir == X2DIR) ? m_x2_f : m_x3_f));
                 }
                 switch (bface) {
-                case BoundaryFace::inner_x1:
-                    pkg->KBoundaries[bface] = KBoundaries::Dirichlet<BoundaryFace::inner_x1>;
-                    break;
-                case BoundaryFace::outer_x1:
-                    pkg->KBoundaries[bface] = KBoundaries::Dirichlet<BoundaryFace::outer_x1>;
-                    break;
-                case BoundaryFace::inner_x2:
-                    pkg->KBoundaries[bface] = KBoundaries::Dirichlet<BoundaryFace::inner_x2>;
-                    break;
-                case BoundaryFace::outer_x2:
-                    pkg->KBoundaries[bface] = KBoundaries::Dirichlet<BoundaryFace::outer_x2>;
-                    break;
-                case BoundaryFace::inner_x3:
-                    pkg->KBoundaries[bface] = KBoundaries::Dirichlet<BoundaryFace::inner_x3>;
-                    break;
-                case BoundaryFace::outer_x3:
-                    pkg->KBoundaries[bface] = KBoundaries::Dirichlet<BoundaryFace::outer_x3>;
-                    break;
-                default:
-                    break;
+                    case BoundaryFace::inner_x1:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::Dirichlet<BoundaryFace::inner_x1>;
+                        break;
+                    case BoundaryFace::outer_x1:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::Dirichlet<BoundaryFace::outer_x1>;
+                        break;
+                    case BoundaryFace::inner_x2:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::Dirichlet<BoundaryFace::inner_x2>;
+                        break;
+                    case BoundaryFace::outer_x2:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::Dirichlet<BoundaryFace::outer_x2>;
+                        break;
+                    case BoundaryFace::inner_x3:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::Dirichlet<BoundaryFace::inner_x3>;
+                        break;
+                    case BoundaryFace::outer_x3:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::Dirichlet<BoundaryFace::outer_x3>;
+                        break;
+                    default:
+                        break;
                 }
             } else if (btype == "reflecting") {
                 switch (bface) {
-                case BoundaryFace::inner_x1:
-                    pkg->KBoundaries[bface] = BoundaryFunction::ReflectInnerX1;
-                    break;
-                case BoundaryFace::outer_x1:
-                    pkg->KBoundaries[bface] = BoundaryFunction::ReflectOuterX1;
-                    break;
-                case BoundaryFace::inner_x2:
-                    pkg->KBoundaries[bface] = BoundaryFunction::ReflectInnerX2;
-                    break;
-                case BoundaryFace::outer_x2:
-                    pkg->KBoundaries[bface] = BoundaryFunction::ReflectOuterX2;
-                    break;
-                case BoundaryFace::inner_x3:
-                    pkg->KBoundaries[bface] = BoundaryFunction::ReflectInnerX3;
-                    break;
-                case BoundaryFace::outer_x3:
-                    pkg->KBoundaries[bface] = BoundaryFunction::ReflectOuterX3;
-                    break;
-                default:
-                    break;
+                    case BoundaryFace::inner_x1:
+                        pkg->KBoundaries[bface] = BoundaryFunction::ReflectInnerX1;
+                        break;
+                    case BoundaryFace::outer_x1:
+                        pkg->KBoundaries[bface] = BoundaryFunction::ReflectOuterX1;
+                        break;
+                    case BoundaryFace::inner_x2:
+                        pkg->KBoundaries[bface] = BoundaryFunction::ReflectInnerX2;
+                        break;
+                    case BoundaryFace::outer_x2:
+                        pkg->KBoundaries[bface] = BoundaryFunction::ReflectOuterX2;
+                        break;
+                    case BoundaryFace::inner_x3:
+                        pkg->KBoundaries[bface] = BoundaryFunction::ReflectInnerX3;
+                        break;
+                    case BoundaryFace::outer_x3:
+                        pkg->KBoundaries[bface] = BoundaryFunction::ReflectOuterX3;
+                        break;
+                    default:
+                        break;
                 }
             } else if (btype == "transmitting") {
                 switch (bface) {
-                case BoundaryFace::inner_x1:
-                    pkg->KBoundaries[bface] = KBoundaries::OneBlockTransmit<BoundaryFace::inner_x1>;
-                    break;
-                case BoundaryFace::outer_x1:
-                    pkg->KBoundaries[bface] = KBoundaries::OneBlockTransmit<BoundaryFace::outer_x1>;
-                    break;
-                case BoundaryFace::inner_x2:
-                    pkg->KBoundaries[bface] = KBoundaries::OneBlockTransmit<BoundaryFace::inner_x2>;
-                    break;
-                case BoundaryFace::outer_x2:
-                    pkg->KBoundaries[bface] = KBoundaries::OneBlockTransmit<BoundaryFace::outer_x2>;
-                    break;
-                case BoundaryFace::inner_x3:
-                    pkg->KBoundaries[bface] = KBoundaries::OneBlockTransmit<BoundaryFace::inner_x3>;
-                    break;
-                case BoundaryFace::outer_x3:
-                    pkg->KBoundaries[bface] = KBoundaries::OneBlockTransmit<BoundaryFace::outer_x3>;
-                    break;
-                default:
-                    break;
+                    case BoundaryFace::inner_x1:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::OneBlockTransmit<BoundaryFace::inner_x1>;
+                        break;
+                    case BoundaryFace::outer_x1:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::OneBlockTransmit<BoundaryFace::outer_x1>;
+                        break;
+                    case BoundaryFace::inner_x2:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::OneBlockTransmit<BoundaryFace::inner_x2>;
+                        break;
+                    case BoundaryFace::outer_x2:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::OneBlockTransmit<BoundaryFace::outer_x2>;
+                        break;
+                    case BoundaryFace::inner_x3:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::OneBlockTransmit<BoundaryFace::inner_x3>;
+                        break;
+                    case BoundaryFace::outer_x3:
+                        pkg->KBoundaries[bface] =
+                            KBoundaries::OneBlockTransmit<BoundaryFace::outer_x3>;
+                        break;
+                    default:
+                        break;
                 }
-                if (pin->GetString("coordinates", "transform") == "fmks" || pin->GetString("coordinates", "transform") == "funky")
-                    throw std::runtime_error("Transmitting polar boundary conditions require coordinates symmetric about theta=0!");
+                if (pin->GetString("coordinates", "transform") == "fmks" ||
+                    pin->GetString("coordinates", "transform") == "funky")
+                    throw std::runtime_error(
+                        "Transmitting polar boundary conditions require coordinates "
+                        "symmetric about theta=0!");
                 // TODO also check for wedge simulations x3<2pi
             } else if (btype == "outflow") {
                 switch (bface) {
-                case BoundaryFace::inner_x1:
-                    pkg->KBoundaries[bface] = BoundaryFunction::OutflowInnerX1;
-                    break;
-                case BoundaryFace::outer_x1:
-                    pkg->KBoundaries[bface] = BoundaryFunction::OutflowOuterX1;
-                    break;
-                case BoundaryFace::inner_x2:
-                    pkg->KBoundaries[bface] = BoundaryFunction::OutflowInnerX2;
-                    break;
-                case BoundaryFace::outer_x2:
-                    pkg->KBoundaries[bface] = BoundaryFunction::OutflowOuterX2;
-                    break;
-                case BoundaryFace::inner_x3:
-                    pkg->KBoundaries[bface] = BoundaryFunction::OutflowInnerX3;
-                    break;
-                case BoundaryFace::outer_x3:
-                    pkg->KBoundaries[bface] = BoundaryFunction::OutflowOuterX3;
-                    break;
-                default:
-                    break;
+                    case BoundaryFace::inner_x1:
+                        pkg->KBoundaries[bface] = BoundaryFunction::OutflowInnerX1;
+                        break;
+                    case BoundaryFace::outer_x1:
+                        pkg->KBoundaries[bface] = BoundaryFunction::OutflowOuterX1;
+                        break;
+                    case BoundaryFace::inner_x2:
+                        pkg->KBoundaries[bface] = BoundaryFunction::OutflowInnerX2;
+                        break;
+                    case BoundaryFace::outer_x2:
+                        pkg->KBoundaries[bface] = BoundaryFunction::OutflowOuterX2;
+                        break;
+                    case BoundaryFace::inner_x3:
+                        pkg->KBoundaries[bface] = BoundaryFunction::OutflowInnerX3;
+                        break;
+                    case BoundaryFace::outer_x3:
+                        pkg->KBoundaries[bface] = BoundaryFunction::OutflowOuterX3;
+                        break;
+                    default:
+                        break;
                 }
             } else if (btype == "bondi") {
                 // Boundaries will need these to be recorded into a 'Params'
                 AddBondiParameters(pin, *packages);
                 switch (bface) {
-                case BoundaryFace::inner_x1:
-                    pkg->KBoundaries[bface] = SetBondi<IndexDomain::inner_x1>;
-                    break;
-                case BoundaryFace::outer_x1:
-                    pkg->KBoundaries[bface] = SetBondi<IndexDomain::outer_x1>;
-                    break;
-                case BoundaryFace::inner_x2:
-                    pkg->KBoundaries[bface] = SetBondi<IndexDomain::inner_x2>;
-                    break;
-                case BoundaryFace::outer_x2:
-                    pkg->KBoundaries[bface] = SetBondi<IndexDomain::outer_x2>;
-                    break;
-                case BoundaryFace::inner_x3:
-                    pkg->KBoundaries[bface] = SetBondi<IndexDomain::inner_x3>;
-                    break;
-                case BoundaryFace::outer_x3:
-                    pkg->KBoundaries[bface] = SetBondi<IndexDomain::outer_x3>;
-                    break;
-                default:
-                    break;
+                    case BoundaryFace::inner_x1:
+                        pkg->KBoundaries[bface] = SetBondi<IndexDomain::inner_x1>;
+                        break;
+                    case BoundaryFace::outer_x1:
+                        pkg->KBoundaries[bface] = SetBondi<IndexDomain::outer_x1>;
+                        break;
+                    case BoundaryFace::inner_x2:
+                        pkg->KBoundaries[bface] = SetBondi<IndexDomain::inner_x2>;
+                        break;
+                    case BoundaryFace::outer_x2:
+                        pkg->KBoundaries[bface] = SetBondi<IndexDomain::outer_x2>;
+                        break;
+                    case BoundaryFace::inner_x3:
+                        pkg->KBoundaries[bface] = SetBondi<IndexDomain::inner_x3>;
+                        break;
+                    case BoundaryFace::outer_x3:
+                        pkg->KBoundaries[bface] = SetBondi<IndexDomain::outer_x3>;
+                        break;
+                    default:
+                        break;
                 }
             } else {
-                throw std::runtime_error("Unknown boundary type: "+btype);
+                throw std::runtime_error("Unknown boundary type: " + btype);
             }
         }
     }
 
     // If we've split in the phi direction or we're running in 2D
-    if (pin->GetInteger("parthenon/mesh", "nx3") != pin->GetInteger("parthenon/meshblock", "nx3") ||
+    if (pin->GetInteger("parthenon/mesh", "nx3") !=
+            pin->GetInteger("parthenon/meshblock", "nx3") ||
         pin->GetInteger("parthenon/mesh", "nx3") == 1) {
-        if (pin->GetString("boundaries", "inner_x3") == "transmitting" || pin->GetString("boundaries", "outer_x3") == "transmitting")
-            throw std::runtime_error("Transmitting polar boundary conditions require 3D with one block in x3!");
-        if (params.Get<bool>("cancel_U3_inner_x3") || params.Get<bool>("cancel_U3_outer_x3") ||
-            params.Get<bool>("cancel_T3_inner_x3") || params.Get<bool>("cancel_T3_outer_x3"))
-            throw std::runtime_error("Polar cancellations require 3D with one block in x3!");
+        if (pin->GetString("boundaries", "inner_x3") == "transmitting" ||
+            pin->GetString("boundaries", "outer_x3") == "transmitting")
+            throw std::runtime_error("Transmitting polar boundary conditions require 3D "
+                                     "with one block in x3!");
+        if (params.Get<bool>("cancel_U3_inner_x3") ||
+            params.Get<bool>("cancel_U3_outer_x3") ||
+            params.Get<bool>("cancel_T3_inner_x3") ||
+            params.Get<bool>("cancel_T3_outer_x3"))
+            throw std::runtime_error(
+                "Polar cancellations require 3D with one block in x3!");
         if (packages->AllPackages().count("B_CT") &&
-            (params.Get<bool>("reconnect_B3_inner_x3") || params.Get<bool>("reconnect_B3_outer_x3")))
-            throw std::runtime_error("Polar reconnections require 3D with one block in x3!");
+            (params.Get<bool>("reconnect_B3_inner_x3") ||
+                params.Get<bool>("reconnect_B3_outer_x3")))
+            throw std::runtime_error(
+                "Polar reconnections require 3D with one block in x3!");
     }
 
     // Callbacks
@@ -379,7 +438,8 @@ std::shared_ptr<KHARMAPackage> KBoundaries::Initialize(ParameterInput *pin, std:
     return pkg;
 }
 
-void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexDomain domain, bool coarse)
+void KBoundaries::ApplyBoundary(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
 {
     Flag("ApplyBoundary"); // this is not a callback, flag for ourselves
     // KHARMA has to do some extra tasks in addition to just applying the usual
@@ -390,10 +450,10 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     auto pkg = pmb->packages.Get<KHARMAPackage>("Boundaries");
     auto& params = pkg->AllParams();
 
-    // TODO canonize this as a function. Prints all variables in the current MBD/MD object,
-    // which can now be smaller than everything.
-    // std::cout << rc->GetVariableVector().size() << std::endl;
-    // for (auto &var : rc->GetVariableVector()) {
+    // TODO canonize this as a function. Prints all variables in the current MBD/MD
+    // object, which can now be smaller than everything. std::cout <<
+    // rc->GetVariableVector().size() << std::endl; for (auto &var :
+    // rc->GetVariableVector()) {
     //     std::cout << var->label() << " ";
     // }
     // std::cout << std::endl;
@@ -404,20 +464,22 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     const auto bdir = BoundaryDirection(bface);
     const bool binner = BoundaryIsInner(bface);
 
-    // We get called over a lot of different packs depending on doing physical boundaries, EMF boundaries,
-    // boundaries during solves/GMG, and so on.  Check once whether this is a "normal" boundary condition
-    // with the GRMHD variables
+    // We get called over a lot of different packs depending on doing physical boundaries,
+    // EMF boundaries, boundaries during solves/GMG, and so on.  Check once whether this
+    // is a "normal" boundary condition with the GRMHD variables
     // TODO redesign boundary functions as per-package callbacks which take a pack+map
-    // TODO probably retire PackMHDPrims, it's not more useful than just packing on the flag.
+    // TODO probably retire PackMHDPrims, it's not more useful than just packing on the
+    // flag.
     PackIndexMap dummy_map;
     bool full_grmhd_boundary = GRMHD::PackMHDPrims(rc.get(), dummy_map).GetDim(4) > 0;
 
     // Averaging ops on *physical* cells must be done before computing boundaries
     // We should do a PreBoundaries callback...
     if (pmb->packages.AllPackages().count("B_CT")) {
-        auto bfpack = rc->PackVariables({Metadata::Face, Metadata::FillGhost, Metadata::GetUserFlag("B_CT")});
+        auto bfpack = rc->PackVariables(
+            {Metadata::Face, Metadata::FillGhost, Metadata::GetUserFlag("B_CT")});
         if (params.Get<bool>("reconnect_B3_" + bname) && bfpack.GetDim(4) > 0) {
-            Flag("ReconnectFaceB_"+bname);
+            Flag("ReconnectFaceB_" + bname);
             B_CT::ReconnectBoundaryB3(rc.get(), domain, bfpack, coarse);
             EndFlag();
         }
@@ -432,7 +494,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     }
 
     // Always call through to the registered boundary function
-    Flag("Apply "+bname+" boundary: "+btype_name);
+    Flag("Apply " + bname + " boundary: " + btype_name);
     pkg->KBoundaries[bface](rc, coarse);
     EndFlag();
 
@@ -453,48 +515,55 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
         auto& emfpack = rc->PackVariables(std::vector<std::string>{"B_CT.emf"});
         if (emfpack.GetDim(4) > 0) {
             if (params.Get<bool>("zero_EMF_" + bname)) {
-                Flag("ZeroEMF_"+bname);
+                Flag("ZeroEMF_" + bname);
                 B_CT::ZeroBoundaryEMF(rc.get(), domain, emfpack, coarse);
                 EndFlag();
             }
             if (params.Get<bool>("average_EMF_" + bname)) {
-                Flag("AverageEMF_"+bname);
+                Flag("AverageEMF_" + bname);
                 B_CT::AverageBoundaryEMF(rc.get(), domain, emfpack, coarse);
                 EndFlag();
             }
         }
 
         // Correct Parthenon's reflecting conditions on the corresponding face
-        // Note these are REFLECTING SPECIFIC, not suitable for the similar op w/transmitting
-        // TODO move this to Parthenon.  Move out of this case if we gain non-B_CT face variables
-        auto fpack = rc->PackVariables({Metadata::Face, Metadata::FillGhost, Metadata::GetUserFlag("SplitVector")});
+        // Note these are REFLECTING SPECIFIC, not suitable for the similar op
+        // w/transmitting
+        // TODO move this to Parthenon.  Move out of this case if we gain non-B_CT face
+        // variables
+        auto fpack = rc->PackVariables(
+            {Metadata::Face, Metadata::FillGhost, Metadata::GetUserFlag("SplitVector")});
         if (params.Get<bool>("reflect_face_vector_" + bname) && fpack.GetDim(4) > 0) {
-            Flag("ReflectFace_"+bname);
+            Flag("ReflectFace_" + bname);
             const TopologicalElement face = FaceOf(bdir);
             auto b = KDomain::GetBoundaryRange(rc, domain, face, coarse);
             // Zero the last physical face, otherwise invert.
             auto i_f = (binner) ? b.ie : b.is;
             auto j_f = (binner) ? b.je : b.js;
             auto k_f = (binner) ? b.ke : b.ks;
-            pmb->par_for(
-                "reflect_face_vector_" + bname, 0, fpack.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+            pmb->par_for("reflect_face_vector_" + bname, 0, fpack.GetDim(4) - 1, b.ks,
+                b.ke, b.js, b.je, b.is, b.ie,
+                         KOKKOS_LAMBDA(const int& v, const int& k, const int& j,
+                                       const int& i)
+                {
                     const int kk = (bdir == 3) ? k_f - (k - k_f) : k;
                     const int jj = (bdir == 2) ? j_f - (j - j_f) : j;
                     const int ii = (bdir == 1) ? i_f - (i - i_f) : i;
-                    fpack(face, v, k, j, i) = ((bdir == 1 && i == i_f) ||
-                                            (bdir == 2 && j == j_f) ||
-                                            (bdir == 3 && k == k_f)) ? 0. : -fpack(face, v, kk, jj, ii);
-                }
-            );
+                    fpack(face, v, k, j, i) =
+                        ((bdir == 1 && i == i_f) || (bdir == 2 && j == j_f) ||
+                            (bdir == 3 && k == k_f))
+                            ? 0.
+                            : -fpack(face, v, kk, jj, ii);
+                });
             EndFlag();
         }
 
         // Correct orthogonal B field component to eliminate divergence in last rank
         // and ghosts. Used for outflow conditions when field lines will exit domain
-        auto bfpack = rc->PackVariables({Metadata::Face, Metadata::FillGhost, Metadata::GetUserFlag("B_CT")});
+        auto bfpack = rc->PackVariables(
+            {Metadata::Face, Metadata::FillGhost, Metadata::GetUserFlag("B_CT")});
         if (params.Get<bool>("clean_face_B_" + bname) && bfpack.GetDim(4) > 0) {
-            Flag("CleanFaceB_"+bname);
+            Flag("CleanFaceB_" + bname);
             B_CT::DestructiveBoundaryClean(rc.get(), domain, bfpack, coarse);
             EndFlag();
         }
@@ -513,7 +582,7 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     // Prevent inflow of material by changing fluid speeds,
     // anywhere we've specified.
     if (params.Get<bool>("check_inflow_" + bname)) {
-        Flag("CheckInflow_"+bname);
+        Flag("CheckInflow_" + bname);
         CheckInflow(rc, domain, coarse);
         EndFlag();
     }
@@ -521,34 +590,37 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     // Allow specifically dP to outflow in otherwise Dirichlet conditions
     // Only used for viscous_bondi problem, should be moved in there somehow
     if (params.Get<bool>("outflow_EMHD_" + bname)) {
-        Flag("OutflowEMHD_"+bname);
-        auto EMHDg = rc->PackVariables({Metadata::GetUserFlag("EMHDVar"), Metadata::FillGhost});
-        const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
-        const auto &range = (bdir == 1) ? bounds.GetBoundsI(IndexDomain::interior)
+        Flag("OutflowEMHD_" + bname);
+        auto EMHDg =
+            rc->PackVariables({Metadata::GetUserFlag("EMHDVar"), Metadata::FillGhost});
+        const auto& bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
+        const auto& range = (bdir == 1)
+                                ? bounds.GetBoundsI(IndexDomain::interior)
                                 : (bdir == 2 ? bounds.GetBoundsJ(IndexDomain::interior)
-                                    : bounds.GetBoundsK(IndexDomain::interior));
+                                             : bounds.GetBoundsK(IndexDomain::interior));
         const int ref = binner ? range.s : range.e;
-        pmb->par_for_bndry(
-            "outflow_EMHD", IndexRange{0,EMHDg.GetDim(4)-1}, domain, CC, coarse, false,
-            KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
-                EMHDg(v, k, j, i) = EMHDg(v, (bdir == 3) ? ref : k, (bdir == 2) ? ref : j, (bdir == 1) ? ref : i);
-            }
-        );
+        pmb->par_for_bndry("outflow_EMHD", IndexRange{0, EMHDg.GetDim(4) - 1}, domain, CC,
+            coarse, false,
+            KOKKOS_LAMBDA(const int& v, const int& k, const int& j, const int& i)
+            {
+                EMHDg(v, k, j, i) = EMHDg(v, (bdir == 3) ? ref : k, (bdir == 2) ? ref : j,
+                    (bdir == 1) ? ref : i);
+            });
         EndFlag();
     }
 
     /*
-    * KHARMA is very particular about corner boundaries.
-    * In particular, we apply the outflow boundary over ALL X2 & X3.
-    * Then we apply the polar bound only where outflow is not applied,
-    * and periodic bounds only where neither other bound applies.
-    * The latter is accomplished regardless of Parthenon's definitions,
-    * since these functions are run after Parthenon's MPI boundary syncs &
-    * replace whatever they've done.
-    * However, the former must be added after the X2 boundary call,
-    * replacing the reflecting conditions in the X1/X2 corner (or in 3D, edge)
-    * with outflow conditions based on the updated ghost cells.
-    */
+     * KHARMA is very particular about corner boundaries.
+     * In particular, we apply the outflow boundary over ALL X2 & X3.
+     * Then we apply the polar bound only where outflow is not applied,
+     * and periodic bounds only where neither other bound applies.
+     * The latter is accomplished regardless of Parthenon's definitions,
+     * since these functions are run after Parthenon's MPI boundary syncs &
+     * replace whatever they've done.
+     * However, the former must be added after the X2 boundary call,
+     * replacing the reflecting conditions in the X1/X2 corner (or in 3D, edge)
+     * with outflow conditions based on the updated ghost cells.
+     */
     if (bdir == X2DIR) {
         // TODO test more carefully whether this is still needed for face-centered B...
 
@@ -593,7 +665,8 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
             // and UtoP on EVERYTHING ELSE
             Packages::BoundaryPtoUElseUtoP(rc.get(), domain, coarse);
         } else {
-            // If we want to apply boundaries to conserved vars, just run UtoP on EVERYTHING
+            // If we want to apply boundaries to conserved vars, just run UtoP on
+            // EVERYTHING
             Packages::BoundaryUtoP(rc.get(), domain, coarse);
         }
     }
@@ -601,10 +674,11 @@ void KBoundaries::ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexD
     EndFlag();
 }
 
-void KBoundaries::CheckInflow(std::shared_ptr<MeshBlockData<Real>> &rc, IndexDomain domain, bool coarse)
+void KBoundaries::CheckInflow(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
-    const auto &G = pmb->coords;
+    const auto& G = pmb->coords;
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
     PackIndexMap prims_map;
@@ -613,15 +687,15 @@ void KBoundaries::CheckInflow(std::shared_ptr<MeshBlockData<Real>> &rc, IndexDom
 
     // Inflow check
     // Iterate over all boundary domain zones w/p=0
-    pmb->par_for_bndry(
-        "check_inflow", IndexRange{0, 0}, domain, CC, coarse, false,
-        KOKKOS_LAMBDA(const int &p, const int &k, const int &j, const int &i) {
+    pmb->par_for_bndry("check_inflow", IndexRange{0, 0}, domain, CC, coarse, false,
+                       KOKKOS_LAMBDA(const int& p, const int& k, const int& j,
+                                     const int& i)
+        {
             KBoundaries::check_inflow(G, P, domain, m_p.U1, k, j, i);
-        }
-    );
+        });
 }
 
-TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
+TaskStatus KBoundaries::FixFlux(MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -638,8 +712,8 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
     const IndexRange3 bi = KDomain::GetRange(md, IndexDomain::interior);
     const IndexRange3 b1 = KDomain::GetRange(md, IndexDomain::interior, -1, 1);
 
-    for (auto &pmb : pmesh->block_list) {
-        auto &rc = pmb->meshblock_data.Get(md->StageName());
+    for (auto& pmb : pmesh->block_list) {
+        auto& rc = pmb->meshblock_data.Get(md->StageName());
 
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
             BoundaryFace bface = (BoundaryFace)i;
@@ -649,7 +723,8 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
 
             if (bdir > ndim) continue;
 
-            const IndexRange3 bf = KDomain::GetRange(rc, IndexDomain::interior, FaceOf(bdir));
+            const IndexRange3 bf =
+                KDomain::GetRange(rc, IndexDomain::interior, FaceOf(bdir));
 
             // Fluxes are needed in 1-zone halo for FluxCT
             IndexRange3 b = b1;
@@ -663,7 +738,7 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
             }
 
             PackIndexMap cons_map;
-            auto &F = rc->PackVariablesAndFluxes({Metadata::WithFluxes}, cons_map);
+            auto& F = rc->PackVariablesAndFluxes({Metadata::WithFluxes}, cons_map);
 
             // If we should check inflow on this face...
             if (params.Get<bool>("check_inflow_" + bname)) {
@@ -671,19 +746,23 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
                 // ...and if this face of the block corresponds to a global boundary...
                 if (KBoundaries::IsPhysicalBoundary(pmb, bface)) {
                     if (binner) {
-                        pmb->par_for(
-                            "zero_inflow_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                            KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
-                                F.flux(bdir, m_rho, k, j, i) = m::min(F.flux(bdir, m_rho, k, j, i), 0.);
-                            }
-                        );
+                        pmb->par_for("zero_inflow_flux_" + bname, b.ks, b.ke, b.js, b.je,
+                            b.is, b.ie,
+                                     KOKKOS_LAMBDA(const int& k, const int& j,
+                                                   const int& i)
+                            {
+                                F.flux(bdir, m_rho, k, j, i) =
+                                    m::min(F.flux(bdir, m_rho, k, j, i), 0.);
+                            });
                     } else {
-                        pmb->par_for(
-                            "zero_inflow_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                            KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
-                                F.flux(bdir, m_rho, k, j, i) = m::max(F.flux(bdir, m_rho, k, j, i), 0.);
-                            }
-                        );
+                        pmb->par_for("zero_inflow_flux_" + bname, b.ks, b.ke, b.js, b.je,
+                            b.is, b.ie,
+                                     KOKKOS_LAMBDA(const int& k, const int& j,
+                                                   const int& i)
+                            {
+                                F.flux(bdir, m_rho, k, j, i) =
+                                    m::max(F.flux(bdir, m_rho, k, j, i), 0.);
+                            });
                     }
                 }
             }
@@ -692,12 +771,15 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
             if (params.Get<bool>("zero_flux_" + bname)) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (KBoundaries::IsPhysicalBoundary(pmb, bface)) {
-                    pmb->par_for(
-                        "zero_flux_" + bname, 0, F.GetDim(4) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                        KOKKOS_LAMBDA(const int &p, const int &k, const int &j, const int &i) {
+                    pmb->par_for("zero_flux_" + bname, 0, F.GetDim(4) - 1, b.ks, b.ke,
+                        b.js, b.je, b.is, b.ie,
+                        KOKKOS_LAMBDA(const int& p,
+                                      const int& k,
+                                      const int& j,
+                                      const int& i)
+                        {
                             F.flux(bdir, p, k, j, i) = 0.;
-                        }
-                    );
+                        });
                 }
             }
 
@@ -705,181 +787,243 @@ TaskStatus KBoundaries::FixFlux(MeshData<Real> *md)
             if (params.Get<bool>("excise_flux_" + bname)) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (IsPhysicalBoundary(pmb, bface)) {
-                    if (bdir != 2) throw std::runtime_error("Excised polar fluxes only fully implemented in X2!");
+                    if (bdir != 2)
+                        throw std::runtime_error(
+                            "Excised polar fluxes only fully implemented in X2!");
 
                     // Pack w/B to match indices with the `Flux.X` below
                     // We won't *update* B field though
-                    auto &F = rc->PackVariablesAndFluxes({Metadata::WithFluxes}, cons_map);
+                    auto& F =
+                        rc->PackVariablesAndFluxes({Metadata::WithFluxes}, cons_map);
 
                     // Going to need the primitive vars
                     PackIndexMap prims_map;
-                    std::vector<MetadataFlag> prims_flags = {Metadata::GetUserFlag("Primitive"), Metadata::Cell};
+                    std::vector<MetadataFlag> prims_flags = {
+                        Metadata::GetUserFlag("Primitive"), Metadata::Cell};
                     const auto& P_all = rc->PackVariables(prims_flags, prims_map);
                     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
                     // And a ton of other stuff
-                    // But we're modifying the live temporaries, and eventually fluxes, here
-                    const auto& Pl_all = rc->PackVariables(std::vector<std::string>{"Flux.Pl"});
-                    const auto& Pr_all = rc->PackVariables(std::vector<std::string>{"Flux.Pr"});
-                    const auto& Ul_all = rc->PackVariables(std::vector<std::string>{"Flux.Ul"});
-                    const auto& Ur_all = rc->PackVariables(std::vector<std::string>{"Flux.Ur"});
-                    const auto& Fl_all = rc->PackVariables(std::vector<std::string>{"Flux.Fl"});
-                    const auto& Fr_all = rc->PackVariables(std::vector<std::string>{"Flux.Fr"});
-                    // I assume we should update cmax/cmin. Else we should use the old ones, so
-                    const auto& cmax  = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
-                    const auto& cmin  = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
+                    // But we're modifying the live temporaries, and eventually fluxes,
+                    // here
+                    const auto& Pl_all =
+                        rc->PackVariables(std::vector<std::string>{"Flux.Pl"});
+                    const auto& Pr_all =
+                        rc->PackVariables(std::vector<std::string>{"Flux.Pr"});
+                    const auto& Ul_all =
+                        rc->PackVariables(std::vector<std::string>{"Flux.Ul"});
+                    const auto& Ur_all =
+                        rc->PackVariables(std::vector<std::string>{"Flux.Ur"});
+                    const auto& Fl_all =
+                        rc->PackVariables(std::vector<std::string>{"Flux.Fl"});
+                    const auto& Fr_all =
+                        rc->PackVariables(std::vector<std::string>{"Flux.Fr"});
+                    // I assume we should update cmax/cmin. Else we should use the old
+                    // ones, so
+                    const auto& cmax =
+                        rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
+                    const auto& cmin =
+                        rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
-                    const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
+                    const EMHD::EMHD_parameters& emhd_params =
+                        EMHD::GetEMHDParameters(pmb->packages);
                     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
                     const auto& G = pmb->coords;
                     const int nvar = F.GetDim(4);
                     // Loci "outer" and "inner" refer to right and left.
-                    // At right edge, our "outer" toward domain is Loci "inner" as in left half
+                    // At right edge, our "outer" toward domain is Loci "inner" as in left
+                    // half
                     const Loci loc = (binner) ? Loci::outer_half : Loci::inner_half;
 
-                    const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, CC);
+                    const IndexRange3 bi =
+                        KDomain::GetRange(rc, IndexDomain::interior, CC);
                     // Cell center of our two which is actually on grid
                     const int j_cell = (binner) ? b.js : b.js - 1;
 
                     // Replace existing X3 fluxes in last row with true half-cell versions
                     const int dir = X3DIR;
-                    pmb->par_for(
-                        "excise_flux_" + bname, b.ks, b.ke, j_cell, j_cell, b.is, b.ie,
-                        KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+                    pmb->par_for("excise_flux_" + bname, b.ks, b.ke, j_cell, j_cell, b.is,
+                        b.ie,
+                        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                        {
                             // Leftover Pl/Pr from X3DIR flux calculation!
-                            const int jn = (binner) ? j+1 : j-1;
-                            PLOOP Pl_all(ip, k, j, i) = 0.75 * Pl_all(ip, k, j, i) + 0.25 * Pl_all(ip, k, jn, i);
-                            PLOOP Pr_all(ip, k, j, i) = 0.75 * Pr_all(ip, k, j, i) + 0.25 * Pr_all(ip, k, jn, i);
+                            const int jn = (binner) ? j + 1 : j - 1;
+                            PLOOP
+                                Pl_all(ip, k, j, i) = 0.75 * Pl_all(ip, k, j, i) +
+                                                      0.25 * Pl_all(ip, k, jn, i);
+                            PLOOP
+                                Pr_all(ip, k, j, i) = 0.75 * Pr_all(ip, k, j, i) +
+                                                      0.25 * Pr_all(ip, k, jn, i);
 
                             FourVectors Dtmp;
                             // Left
                             GRMHD::calc_4vecs(G, Pl_all, m_p, k, j, i, loc, Dtmp);
-                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ul_all, m_u, loc);
-                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k, j, i, dir, Fl_all, m_u, loc);
+                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, 0, Ul_all, m_u, loc);
+                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, dir, Fl_all, m_u, loc);
                             // Magnetosonic speeds
                             Real cmaxL, cminL;
-                            Flux::vchar_global(G, Pl_all, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxL, cminL);
+                            Flux::vchar_global(G, Pl_all, m_p, Dtmp, gam, emhd_params, k,
+                                j, i, loc, dir, cmaxL, cminL);
                             // Record speeds
-                            cmax(dir-1, k, j, i) = m::max(0., cmaxL);
-                            cmin(dir-1, k, j, i) = m::min(0., cminL);
+                            cmax(dir - 1, k, j, i) = m::max(0., cmaxL);
+                            cmin(dir - 1, k, j, i) = m::min(0., cminL);
 
                             // Right
                             GRMHD::calc_4vecs(G, Pr_all, m_p, k, j, i, loc, Dtmp);
-                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ur_all, m_u, loc);
-                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k, j, i, dir, Fr_all, m_u, loc);
+                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, 0, Ur_all, m_u, loc);
+                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, dir, Fr_all, m_u, loc);
                             // Magnetosonic speeds
                             Real cmaxR, cminR;
-                            Flux::vchar_global(G, Pr_all, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxR, cminR);
+                            Flux::vchar_global(G, Pr_all, m_p, Dtmp, gam, emhd_params, k,
+                                j, i, loc, dir, cmaxR, cminR);
 
                             // Reset cmax/cmin based on our flux
-                            cmax(dir-1, k, j, i) =  m::max(cmax(dir-1, k, j, i), cmaxR);
-                            cmin(dir-1, k, j, i) = -m::min(cmin(dir-1, k, j, i), cminR);
+                            cmax(dir - 1, k, j, i) =
+                                m::max(cmax(dir - 1, k, j, i), cmaxR);
+                            cmin(dir - 1, k, j, i) =
+                                -m::min(cmin(dir - 1, k, j, i), cminR);
 
                             // Use LLF flux
                             PLOOP {
                                 if (ip != m_u.B1 && ip != m_u.B2 && ip != m_u.B3)
-                                    F.flux(dir, ip, k, j, i) = Flux::llf(Fl_all(ip, k, j, i), Fr_all(ip, k, j, i),
-                                                                    cmax(dir-1, k, j, i), cmin(dir-1, k, j, i),
-                                                                    Ul_all(ip, k, j, i), Ur_all(ip, k, j, i)) * 0.5;
+                                    F.flux(dir, ip, k, j, i) =
+                                        Flux::llf(Fl_all(ip, k, j, i),
+                                            Fr_all(ip, k, j, i), cmax(dir - 1, k, j, i),
+                                            cmin(dir - 1, k, j, i), Ul_all(ip, k, j, i),
+                                            Ur_all(ip, k, j, i)) *
+                                        0.5;
                             }
-                        }
-                    );
+                        });
 
                     // Replace fluxes through the pole (would be zero) with fluxes through
-                    // the middle of the cell. Should be general, remember this has 1-zone halo!
-                    pmb->par_for(
-                        "excise_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                        KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
-                            // Face i,j,k borders cell with same index and 1 left with index:
+                    // the middle of the cell. Should be general, remember this has 1-zone
+                    // halo!
+                    pmb->par_for("excise_flux_" + bname, b.ks, b.ke, b.js, b.je, b.is,
+                        b.ie,
+                        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                        {
+                            // Face i,j,k borders cell with same index and 1 left with
+                            // index:
                             int kk = (bdir == 3) ? k - 1 : k;
                             int jj = (bdir == 2) ? j - 1 : j;
                             int ii = (bdir == 1) ? i - 1 : i;
 
                             // "Reconstruct" at cell midplanes: equivalent to donor-cell
-                            PLOOP Pl_all(ip, k, j, i) = P_all(ip, kk, jj, ii);
-                            PLOOP Pr_all(ip, k, j, i) = P_all(ip, k, j, i);
+                            PLOOP
+                                Pl_all(ip, k, j, i) = P_all(ip, kk, jj, ii);
+                            PLOOP
+                                Pr_all(ip, k, j, i) = P_all(ip, k, j, i);
 
                             FourVectors Dtmp;
                             // Left
-                            GRMHD::calc_4vecs(G, Pl_all, m_p, k, j, i, Loci::center, Dtmp);
-                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ul_all, m_u, Loci::center);
-                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k, j, i, bdir, Fl_all, m_u, Loci::center);
+                            GRMHD::calc_4vecs(
+                                G, Pl_all, m_p, k, j, i, Loci::center, Dtmp);
+                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, 0, Ul_all, m_u, Loci::center);
+                            Flux::prim_to_flux(G, Pl_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, bdir, Fl_all, m_u, Loci::center);
                             // Magnetosonic speeds
                             Real cmaxL, cminL;
-                            Flux::vchar_global(G, Pl_all, m_p, Dtmp, gam, emhd_params, k, j, i, Loci::center, bdir, cmaxL, cminL);
+                            Flux::vchar_global(G, Pl_all, m_p, Dtmp, gam, emhd_params, k,
+                                j, i, Loci::center, bdir, cmaxL, cminL);
                             // Record speeds
-                            cmax(bdir-1, k, j, i) = m::max(0., cmaxL);
-                            cmin(bdir-1, k, j, i) = m::min(0., cminL);
+                            cmax(bdir - 1, k, j, i) = m::max(0., cmaxL);
+                            cmin(bdir - 1, k, j, i) = m::min(0., cminL);
 
                             // Right
-                            GRMHD::calc_4vecs(G, Pr_all, m_p, k, j, i, Loci::center, Dtmp);
-                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ur_all, m_u, Loci::center);
-                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k, j, i, bdir, Fr_all, m_u, Loci::center);
+                            GRMHD::calc_4vecs(
+                                G, Pr_all, m_p, k, j, i, Loci::center, Dtmp);
+                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, 0, Ur_all, m_u, Loci::center);
+                            Flux::prim_to_flux(G, Pr_all, m_p, Dtmp, emhd_params, gam, k,
+                                j, i, bdir, Fr_all, m_u, Loci::center);
                             // Magnetosonic speeds
                             Real cmaxR, cminR;
-                            Flux::vchar_global(G, Pr_all, m_p, Dtmp, gam, emhd_params, k, j, i, Loci::center, bdir, cmaxR, cminR);
+                            Flux::vchar_global(G, Pr_all, m_p, Dtmp, gam, emhd_params, k,
+                                j, i, Loci::center, bdir, cmaxR, cminR);
 
                             // Reset cmax/cmin based on our flux
-                            cmax(bdir-1, k, j, i) =  m::max(cmax(bdir-1, k, j, i), cmaxR);
-                            cmin(bdir-1, k, j, i) = -m::min(cmin(bdir-1, k, j, i), cminR);
+                            cmax(bdir - 1, k, j, i) =
+                                m::max(cmax(bdir - 1, k, j, i), cmaxR);
+                            cmin(bdir - 1, k, j, i) =
+                                -m::min(cmin(bdir - 1, k, j, i), cminR);
 
                             // Use LLF flux
                             PLOOP {
                                 if (ip != m_u.B1 && ip != m_u.B2 && ip != m_u.B3) {
-                                    F.flux(bdir, ip, k, j, i) = Flux::llf(Fl_all(ip, k, j, i), Fr_all(ip, k, j, i),
-                                                                        cmax(bdir-1, k, j, i), cmin(bdir-1, k, j, i),
-                                                                        Ul_all(ip, k, j, i), Ur_all(ip, k, j, i));
+                                    F.flux(bdir, ip, k, j, i) = Flux::llf(
+                                        Fl_all(ip, k, j, i), Fr_all(ip, k, j, i),
+                                        cmax(bdir - 1, k, j, i), cmin(bdir - 1, k, j, i),
+                                        Ul_all(ip, k, j, i), Ur_all(ip, k, j, i));
                                     // Reduce the X1 flux in a semi-consistent way
                                     const int jc = (binner) ? j_cell + 1 : j_cell;
-                                    F.flux(X1DIR, ip, k, j_cell, i) *= 0.5
-                                        * (G.gdet(Loci::face1, j_cell, i) + G.gdet(Loci::corner, jc, i)) / 2 / G.gdet(Loci::face1, j_cell, i);
-                                    // This is also a decent guess, but less accurate than recalculating as above
-                                    // F.flux(X3DIR, ip, k, j_cell, i) *= 0.5
-                                    //     * G.gdet(loc, j_cell, i) / G.gdet(Loci::center, j_cell, i);
+                                    F.flux(X1DIR, ip, k, j_cell, i) *=
+                                        0.5 *
+                                        (G.gdet(Loci::face1, j_cell, i) +
+                                            G.gdet(Loci::corner, jc, i)) /
+                                        2 / G.gdet(Loci::face1, j_cell, i);
+                                    // This is also a decent guess, but less accurate than
+                                    // recalculating as above F.flux(X3DIR, ip, k, j_cell,
+                                    // i) *= 0.5
+                                    //     * G.gdet(loc, j_cell, i) / G.gdet(Loci::center,
+                                    //     j_cell, i);
                                 }
                             }
-                        }
-                    );
+                        });
                     // Then average to make absolutely sure fluxes match
                     // TODO only for X2 bound currently!
-                    // Must pay attention that only physical zones are touched: no averaging w/ghosts!
+                    // Must pay attention that only physical zones are touched: no
+                    // averaging w/ghosts!
                     const int Nk3p = (bi.ke - bi.ks + 1);
-                    const int Nk3p2 = Nk3p/2;
+                    const int Nk3p2 = Nk3p / 2;
                     const int ksp = bi.ks;
-                    // Run over X1 *interior* on the X2 face, for half the *interior* X3 range
-                    pmb->par_for(
-                        "average_excised_flux_" + bname, 0, F.GetDim(4)-1, bi.ks, bi.ks + Nk3p2 - 1, b.js, b.je, bi.is, bi.ie,
-                        KOKKOS_LAMBDA(const int &v, const int &k, const int &j, const int &i) {
+                    // Run over X1 *interior* on the X2 face, for half the *interior* X3
+                    // range
+                    pmb->par_for("average_excised_flux_" + bname, 0, F.GetDim(4) - 1,
+                        bi.ks, bi.ks + Nk3p2 - 1, b.js, b.je, bi.is, bi.ie,
+                        KOKKOS_LAMBDA(const int& v,
+                                      const int& k,
+                                      const int& j,
+                                      const int& i)
+                        {
                             const int ki = ((k - ksp + Nk3p2) % Nk3p) + ksp;
                             Real avg = 0.;
-                            if (v == m_u.U2 || v == m_u.B2 || v == m_u.U3 || v == m_u.B3) {
+                            if (v == m_u.U2 || v == m_u.B2 || v == m_u.U3 ||
+                                v == m_u.B3) {
                                 // Flux direction reversed, but *coordinate also reverses*
-                                avg = (F.flux(bdir, v, k, j, i) + F.flux(bdir, v, ki, j, i)) / 2;
+                                avg = (F.flux(bdir, v, k, j, i) +
+                                          F.flux(bdir, v, ki, j, i)) /
+                                      2;
                                 F.flux(bdir, v, ki, j, i) = avg;
                             } else {
                                 // Only the flux direction reverses
-                                avg = (F.flux(bdir, v, k, j, i) - F.flux(bdir, v, ki, j, i)) / 2;
+                                avg = (F.flux(bdir, v, k, j, i) -
+                                          F.flux(bdir, v, ki, j, i)) /
+                                      2;
                                 F.flux(bdir, v, ki, j, i) = -avg;
                             }
-                            F.flux(bdir, v, k, j, i)  = avg;
-                        }
-                    );
+                            F.flux(bdir, v, k, j, i) = avg;
+                        });
                 }
             }
-
         }
     }
 
     return TaskStatus::complete;
 }
 
-void KBoundaries::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+void KBoundaries::AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
-    // Note we're ignoring "domain," we just add the "source" where it's needed next to the pole
+    // Note we're ignoring "domain," we just add the "source" where it's needed next to
+    // the pole
     auto pmesh = mdudt->GetMeshPointer();
     auto& params = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
-    for (int i=0; i < mdudt->NumBlocks(); ++i) {
-        auto &rc = mdudt->GetBlockData(i);
+    for (int i = 0; i < mdudt->NumBlocks(); ++i) {
+        auto& rc = mdudt->GetBlockData(i);
         auto pmb = rc->GetBlockPointer();
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
             BoundaryFace bface = (BoundaryFace)i;
@@ -894,7 +1038,9 @@ void KBoundaries::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDoma
             if (params.Get<bool>("excise_flux_" + bname)) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (IsPhysicalBoundary(pmb, bface)) {
-                    if (bdir != 2) throw std::runtime_error("Excised polar fluxes only fully implemented in X2!");
+                    if (bdir != 2)
+                        throw std::runtime_error(
+                            "Excised polar fluxes only fully implemented in X2!");
 
                     const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior);
 
@@ -909,21 +1055,27 @@ void KBoundaries::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDoma
                         b.ks = b.ke = (binner) ? bi.ks : bi.ke;
                     }
 
-                    // The magnetic field is probably defined at faces; even if it's defined in cells,
-                    // we shouldn't be monkeying with it.  We just do not adjust it here.
-                    auto &dUdt = rc->PackVariables({Metadata::GetUserFlag("HD"), Metadata::WithFluxes});
+                    // The magnetic field is probably defined at faces; even if it's
+                    // defined in cells, we shouldn't be monkeying with it.  We just do
+                    // not adjust it here.
+                    auto& dUdt = rc->PackVariables(
+                        {Metadata::GetUserFlag("HD"), Metadata::WithFluxes});
                     const auto& G = pmb->coords;
                     const Loci loc = (binner) ? Loci::outer_half : Loci::inner_half;
 
-                    pmb->par_for(
-                        "normalize_excised_flux_" + bname, 0, dUdt.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                        KOKKOS_LAMBDA(const int &v, const int &k, const int &j, const int &i) {
+                    pmb->par_for("normalize_excised_flux_" + bname, 0, dUdt.GetDim(4) - 1,
+                        b.ks, b.ke, b.js, b.je, b.is, b.ie,
+                        KOKKOS_LAMBDA(const int& v,
+                                      const int& k,
+                                      const int& j,
+                                      const int& i)
+                        {
                             // Factor of 2 because cell is half-size in fluxdiv
-                            // gdet factors move conserved vars at outer cell to the center
-                            dUdt(v, k, j, i) *= 2 * G.gdet(Loci::center, j, i) / G.gdet(loc, j, i);
-                        }
-                    );
-
+                            // gdet factors move conserved vars at outer cell to the
+                            // center
+                            dUdt(v, k, j, i) *=
+                                2 * G.gdet(Loci::center, j, i) / G.gdet(loc, j, i);
+                        });
                 }
             }
         }

--- a/kharma/boundaries/boundaries.hpp
+++ b/kharma/boundaries/boundaries.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: boundaries.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,32 +41,37 @@
 #include "one_block_transmit.hpp"
 
 /**
- * This package has any functions related to KHARMA's treatment of "domain" boundary conditions:
- * the exterior simulation edges, as opposed to internal meshblock boundaries.
- * 
+ * This package has any functions related to KHARMA's treatment of "domain" boundary
+ * conditions: the exterior simulation edges, as opposed to internal meshblock boundaries.
+ *
  * This package implements Parthenon's "user" boundary conditions in order to add some
- * features related to GRMHD.  
+ * features related to GRMHD.
  */
-namespace KBoundaries {
+namespace KBoundaries
+{
 
 /**
  * Choose which boundary conditions will be used based on inputs,
  * declare any fields needed to store e.g. constant boundary conditions
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Generic KHARMA override function for Parthenon domain boundary conditions.
  * This is registered as the "user" boundary condition with Parthenon, and
  * wraps Parthenon's reflecting or outflow boundary conditions wherever those
  * would be applied.
- * 
+ *
  */
-void ApplyBoundary(std::shared_ptr<MeshBlockData<Real>> &rc, IndexDomain domain, bool coarse);
+void ApplyBoundary(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse);
 // Template version to conform to Parthenon's calling convention. See above.
-template <IndexDomain domain>
-inline void ApplyBoundaryTemplate(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
-{ ApplyBoundary(rc, domain, coarse); }
+template<IndexDomain domain>
+inline void ApplyBoundaryTemplate(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse)
+{
+    ApplyBoundary(rc, domain, coarse);
+}
 
 /**
  * Fix fluxes on physical boundaries.
@@ -75,7 +80,7 @@ inline void ApplyBoundaryTemplate(std::shared_ptr<MeshBlockData<Real>> &rc, bool
  * OR
  * 2. Ensure that fluxes through & around the pole reflect a half-zone excision
  */
-TaskStatus FixFlux(MeshData<Real> *rc);
+TaskStatus FixFlux(MeshData<Real>* rc);
 
 /**
  * When fluxes are allowed across the pole, they are computed by assuming half-size zones
@@ -85,7 +90,7 @@ TaskStatus FixFlux(MeshData<Real> *rc);
  * Since *only* the divergence term should be doubled, this must be run *first* after
  * FluxDivergence, which is ensured by Packages::AddSource.
  */
-void AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+void AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 
 // INTERNAL FUNCTIONS
 
@@ -93,25 +98,28 @@ void AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
  * Check for inflowing material on an outflow boundary, and
  * reset the velocity of such material so it is no longer inflowing.
  */
-void CheckInflow(std::shared_ptr<MeshBlockData<Real>> &rc, IndexDomain domain, bool coarse);
+void CheckInflow(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse);
 
 /**
  * Check for velocity toward the simulation domain in a zone, and eliminate it.
  */
-KOKKOS_INLINE_FUNCTION void check_inflow(const GRCoordinates &G, const VariablePack<Real>& P, const IndexDomain domain,
-                                         const int& index_u1, const int& k, const int& j, const int& i)
+KOKKOS_INLINE_FUNCTION void check_inflow(const GRCoordinates& G,
+    const VariablePack<Real>& P, const IndexDomain domain, const int& index_u1,
+    const int& k, const int& j, const int& i)
 {
     // TODO fewer temporaries?
     Real uvec[NVEC], ucon[GR_DIM];
-    VLOOP uvec[v] = P(index_u1 + v, k, j, i);
+    VLOOP
+        uvec[v] = P(index_u1 + v, k, j, i);
     GRMHD::calc_ucon(G, uvec, k, j, i, Loci::center, ucon);
 
     if (((ucon[1] > 0.) && (domain == IndexDomain::inner_x1)) ||
-        ((ucon[1] < 0.) && (domain == IndexDomain::outer_x1)))
-    {
+        ((ucon[1] < 0.) && (domain == IndexDomain::outer_x1))) {
         // Find gamma and remove it from primitive velocity
         double gamma = GRMHD::lorentz_calc(G, uvec, k, j, i, Loci::center);
-        VLOOP uvec[v] /= gamma;
+        VLOOP
+            uvec[v] /= gamma;
 
         // Reset radial velocity so radial 4-velocity is zero
         Real alpha = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
@@ -122,16 +130,18 @@ KOKKOS_INLINE_FUNCTION void check_inflow(const GRCoordinates &G, const VariableP
         Real vsq = G.gcov(Loci::center, j, i, 1, 1) * uvec[V1] * uvec[V1] +
                    G.gcov(Loci::center, j, i, 2, 2) * uvec[V2] * uvec[V2] +
                    G.gcov(Loci::center, j, i, 3, 3) * uvec[V3] * uvec[V3] +
-        2. * (G.gcov(Loci::center, j, i, 1, 2) * uvec[V1] * uvec[V2] +
-              G.gcov(Loci::center, j, i, 1, 3) * uvec[V1] * uvec[V3] +
-              G.gcov(Loci::center, j, i, 2, 3) * uvec[V2] * uvec[V3]);
+                   2. * (G.gcov(Loci::center, j, i, 1, 2) * uvec[V1] * uvec[V2] +
+                            G.gcov(Loci::center, j, i, 1, 3) * uvec[V1] * uvec[V3] +
+                            G.gcov(Loci::center, j, i, 2, 3) * uvec[V2] * uvec[V3]);
 
-        vsq = clip(vsq, 1.e-13, 1. - 1./(50.*50.));
+        vsq = clip(vsq, 1.e-13, 1. - 1. / (50. * 50.));
 
-        gamma = 1./m::sqrt(1. - vsq);
+        gamma = 1. / m::sqrt(1. - vsq);
 
-        VLOOP uvec[v] *= gamma;
-        VLOOP P(index_u1 + v, k, j, i) = uvec[v];
+        VLOOP
+            uvec[v] *= gamma;
+        VLOOP
+            P(index_u1 + v, k, j, i) = uvec[v];
     }
 }
 

--- a/kharma/boundaries/boundary_types.hpp
+++ b/kharma/boundaries/boundary_types.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: boundary_types.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,19 +39,18 @@
 
 using namespace parthenon;
 
-namespace KBoundaries {
+namespace KBoundaries
+{
 
 inline bool BoundaryIsInner(const IndexDomain domain)
 {
-    return domain == IndexDomain::inner_x1 ||
-           domain == IndexDomain::inner_x2 ||
+    return domain == IndexDomain::inner_x1 || domain == IndexDomain::inner_x2 ||
            domain == IndexDomain::inner_x3;
 }
 
 inline bool BoundaryIsInner(const BoundaryFace bface)
 {
-    return bface == BoundaryFace::inner_x1 ||
-           bface == BoundaryFace::inner_x2 ||
+    return bface == BoundaryFace::inner_x1 || bface == BoundaryFace::inner_x2 ||
            bface == BoundaryFace::inner_x3;
 }
 
@@ -136,43 +135,43 @@ inline std::string DomainName(const IndexDomain domain)
 inline IndexDomain BoundaryDomain(const BoundaryFace face)
 {
     switch (face) {
-    case BoundaryFace::inner_x1:
-        return IndexDomain::inner_x1;
-    case BoundaryFace::outer_x1:
-        return IndexDomain::outer_x1;
-    case BoundaryFace::inner_x2:
-        return IndexDomain::inner_x2;
-    case BoundaryFace::outer_x2:
-        return IndexDomain::outer_x2;
-    case BoundaryFace::inner_x3:
-        return IndexDomain::inner_x3;
-    case BoundaryFace::outer_x3:
-        return IndexDomain::outer_x3;
-    case BoundaryFace::undef:
-    default:
-        throw std::runtime_error("Undefined boundary face has no domain!");
+        case BoundaryFace::inner_x1:
+            return IndexDomain::inner_x1;
+        case BoundaryFace::outer_x1:
+            return IndexDomain::outer_x1;
+        case BoundaryFace::inner_x2:
+            return IndexDomain::inner_x2;
+        case BoundaryFace::outer_x2:
+            return IndexDomain::outer_x2;
+        case BoundaryFace::inner_x3:
+            return IndexDomain::inner_x3;
+        case BoundaryFace::outer_x3:
+            return IndexDomain::outer_x3;
+        case BoundaryFace::undef:
+        default:
+            throw std::runtime_error("Undefined boundary face has no domain!");
     }
 }
 
 inline BoundaryFace BoundaryFaceOf(const IndexDomain domain)
 {
     switch (domain) {
-    case IndexDomain::inner_x1:
-        return BoundaryFace::inner_x1;
-    case IndexDomain::outer_x1:
-        return BoundaryFace::outer_x1;
-    case IndexDomain::inner_x2:
-        return BoundaryFace::inner_x2;
-    case IndexDomain::outer_x2:
-        return BoundaryFace::outer_x2;
-    case IndexDomain::inner_x3:
-        return BoundaryFace::inner_x3;
-    case IndexDomain::outer_x3:
-        return BoundaryFace::outer_x3;
-    case IndexDomain::interior:
-    case IndexDomain::entire:
-    default:
-        return BoundaryFace::undef;
+        case IndexDomain::inner_x1:
+            return BoundaryFace::inner_x1;
+        case IndexDomain::outer_x1:
+            return BoundaryFace::outer_x1;
+        case IndexDomain::inner_x2:
+            return BoundaryFace::inner_x2;
+        case IndexDomain::outer_x2:
+            return BoundaryFace::outer_x2;
+        case IndexDomain::inner_x3:
+            return BoundaryFace::inner_x3;
+        case IndexDomain::outer_x3:
+            return BoundaryFace::outer_x3;
+        case IndexDomain::interior:
+        case IndexDomain::entire:
+        default:
+            return BoundaryFace::undef;
     }
 }
 

--- a/kharma/boundaries/dirichlet.cpp
+++ b/kharma/boundaries/dirichlet.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: dirichlet.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,28 +42,32 @@
 
 using namespace parthenon;
 
-void KBoundaries::DirichletImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse, bool set)
+void KBoundaries::DirichletImpl(
+    MeshBlockData<Real>* rc, BoundaryFace bface, bool coarse, bool set)
 {
     // Get all cell-centered ghosts, minus anything just used at startup
     using FC = Metadata::FlagCollection;
-    FC ghost_vars = FC({Metadata::FillGhost, Metadata::Conserved})
-                  + FC({Metadata::FillGhost, Metadata::GetUserFlag("Primitive")})
-                  - FC({Metadata::GetUserFlag("StartupOnly")});
+    FC ghost_vars = FC({Metadata::FillGhost, Metadata::Conserved}) +
+                    FC({Metadata::FillGhost, Metadata::GetUserFlag("Primitive")}) -
+                    FC({Metadata::GetUserFlag("StartupOnly")});
     auto q = rc->PackVariables(ghost_vars, coarse);
-    auto bound = rc->PackVariables(std::vector<std::string>{"Boundaries." + BoundaryName(bface)});
+    auto bound =
+        rc->PackVariables(std::vector<std::string>{"Boundaries." + BoundaryName(bface)});
     DirichletSetFromField(rc, q, bound, bface, coarse, set, false);
 
-    FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face})
-                  - FC({Metadata::GetUserFlag("StartupOnly")});
+    FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face}) -
+                      FC({Metadata::GetUserFlag("StartupOnly")});
     auto q_f = rc->PackVariables(ghost_vars_f, coarse);
-    auto bound_f = rc->PackVariables(std::vector<std::string>{"Boundaries.f." + BoundaryName(bface)});
+    auto bound_f = rc->PackVariables(
+        std::vector<std::string>{"Boundaries.f." + BoundaryName(bface)});
     DirichletSetFromField(rc, q_f, bound_f, bface, coarse, set, true);
 }
 
-void KBoundaries::DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> &q, VariablePack<Real> &bound,
-                                        BoundaryFace bface, bool coarse, bool set, bool do_face)
+void KBoundaries::DirichletSetFromField(MeshBlockData<Real>* rc, VariablePack<Real>& q,
+    VariablePack<Real>& bound, BoundaryFace bface, bool coarse, bool set, bool do_face)
 {
-    // We're sometimes called without any variables to sync (e.g. syncing flags, EMFs), just return
+    // We're sometimes called without any variables to sync (e.g. syncing flags, EMFs),
+    // just return
     if (q.GetDim(4) == 0) return;
 
     // Determine elements to run over
@@ -77,7 +81,8 @@ void KBoundaries::DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Re
 
     // Warn when the cache doesn't match the variables we've been given
     if ((el_tot * q.GetDim(4)) != bound.GetDim(4)) {
-        std::cerr << "Dirichlet boundary mismatch! Boundary cache: " << bound.GetDim(4) << " for pack: " << el_tot * q.GetDim(4) << std::endl;
+        std::cerr << "Dirichlet boundary mismatch! Boundary cache: " << bound.GetDim(4)
+                  << " for pack: " << el_tot * q.GetDim(4) << std::endl;
     }
 
     // Indices
@@ -91,31 +96,34 @@ void KBoundaries::DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Re
         IndexRange3 b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
 
         // Flatten TopologicalElements when reading/writing to boundaries cache
-        pmb->par_for(
-            "dirichlet_boundary_" + bname, 0, q.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+        pmb->par_for("dirichlet_boundary_" + bname, 0, q.GetDim(4) - 1, b.ks, b.ke, b.js,
+            b.je, b.is, b.ie,
+                     KOKKOS_LAMBDA(const int& v, const int& k, const int& j, const int& i)
+            {
                 if (set) {
-                    bound(el_tot*v + (static_cast<int>(el) % el_tot), k - b.ks, j - b.js, i - b.is) = q(el, v, k, j, i);
+                    bound(el_tot * v + (static_cast<int>(el) % el_tot), k - b.ks,
+                        j - b.js, i - b.is) = q(el, v, k, j, i);
                 } else {
-                    q(el, v, k, j, i) = bound(el_tot*v + (static_cast<int>(el) % el_tot), k - b.ks, j - b.js, i - b.is);
+                    q(el, v, k, j, i) =
+                        bound(el_tot * v + (static_cast<int>(el) % el_tot), k - b.ks,
+                            j - b.js, i - b.is);
                 }
-            }
-        );
+            });
     }
 }
 
-void KBoundaries::FreezeDirichlet(std::shared_ptr<MeshData<Real>> &md)
+void KBoundaries::FreezeDirichlet(std::shared_ptr<MeshData<Real>>& md)
 {
     // For each face...
-    for (int i=0; i < BOUNDARY_NFACES; i++) {
-        BoundaryFace bface = (BoundaryFace) i;
+    for (int i = 0; i < BOUNDARY_NFACES; i++) {
+        BoundaryFace bface = (BoundaryFace)i;
         auto bname = BoundaryName(bface);
         auto pmesh = md->GetMeshPointer();
         // ...if this boundary is dirichlet...
         if (pmesh->packages.Get("Boundaries")->Param<std::string>(bname) == "dirichlet") {
-            //std::cout << "Freezing dirichlet " << bname << " on mesh." << std::endl;
-            // ...on all blocks...
-            for (int i=0; i < md->NumBlocks(); i++) {
+            // std::cout << "Freezing dirichlet " << bname << " on mesh." << std::endl;
+            //  ...on all blocks...
+            for (int i = 0; i < md->NumBlocks(); i++) {
                 auto rc = md->GetBlockData(i).get();
                 auto pmb = rc->GetBlockPointer();
                 // ...if the face is not internal
@@ -128,17 +136,17 @@ void KBoundaries::FreezeDirichlet(std::shared_ptr<MeshData<Real>> &md)
         }
     }
 }
-void KBoundaries::FreezeDirichletBlock(MeshBlockData<Real> *rc)
+void KBoundaries::FreezeDirichletBlock(MeshBlockData<Real>* rc)
 {
     // For each face...
-    for (int i=0; i < BOUNDARY_NFACES; i++) {
-        BoundaryFace bface = (BoundaryFace) i;
+    for (int i = 0; i < BOUNDARY_NFACES; i++) {
+        BoundaryFace bface = (BoundaryFace)i;
         auto bname = BoundaryName(bface);
         auto pmb = rc->GetBlockPointer();
         // ...if this boundary is dirichlet and physical...
         if (pmb->packages.Get("Boundaries")->Param<std::string>(bname) == "dirichlet" &&
             KBoundaries::IsPhysicalBoundary(pmb, bface)) {
-            //std::cout << "Freezing dirichlet " << bname << " on block." << std::endl;
+            // std::cout << "Freezing dirichlet " << bname << " on block." << std::endl;
             auto domain = BoundaryDomain(bface);
             // Set whatever is in that domain as the Dirichlet bound
             SetDomainDirichlet(rc, domain, false);

--- a/kharma/boundaries/dirichlet.hpp
+++ b/kharma/boundaries/dirichlet.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: dirichlet.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,15 +35,16 @@
 
 #include "boundary_types.hpp"
 
-namespace KBoundaries {
+namespace KBoundaries
+{
 
-// TODO(BSP) privatize probably
-void DirichletImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse, bool set);
-void DirichletSetFromField(MeshBlockData<Real> *rc, VariablePack<Real> &q, VariablePack<Real> &bound,
-                                        BoundaryFace bface, bool coarse, bool set, bool do_face);
+// TODO(CEP) privatize probably
+void DirichletImpl(MeshBlockData<Real>* rc, BoundaryFace bface, bool coarse, bool set);
+void DirichletSetFromField(MeshBlockData<Real>* rc, VariablePack<Real>& q,
+    VariablePack<Real>& bound, BoundaryFace bface, bool coarse, bool set, bool do_face);
 
-template <BoundaryFace bface>
-inline void Dirichlet(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
+template<BoundaryFace bface>
+inline void Dirichlet(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse)
 {
     DirichletImpl(rc.get(), bface, coarse, false);
 }
@@ -51,10 +52,10 @@ inline void Dirichlet(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
 /**
  * Freeze any dirichlet boundary conditions in their current forms.
  */
-void FreezeDirichlet(std::shared_ptr<MeshData<Real>> &md);
-void FreezeDirichletBlock(MeshBlockData<Real> *rc);
+void FreezeDirichlet(std::shared_ptr<MeshData<Real>>& md);
+void FreezeDirichletBlock(MeshBlockData<Real>* rc);
 
-inline void SetDomainDirichlet(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+inline void SetDomainDirichlet(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto bface = KBoundaries::BoundaryFaceOf(domain);
     DirichletImpl(rc, bface, coarse, true);

--- a/kharma/boundaries/one_block_transmit.cpp
+++ b/kharma/boundaries/one_block_transmit.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: one_block_transmit.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,26 +41,27 @@
 
 using namespace parthenon;
 
-void KBoundaries::TransmitImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse)
+void KBoundaries::TransmitImpl(MeshBlockData<Real>* rc, BoundaryFace bface, bool coarse)
 {
     // Get all cell-centered ghosts, minus anything just used at startup
     using FC = Metadata::FlagCollection;
-    FC ghost_vars = FC({Metadata::FillGhost, Metadata::Cell})
-                  - FC({Metadata::GetUserFlag("StartupOnly")});
+    FC ghost_vars = FC({Metadata::FillGhost, Metadata::Cell}) -
+                    FC({Metadata::GetUserFlag("StartupOnly")});
     PackIndexMap bounds_map;
     auto q = rc->PackVariables(ghost_vars, bounds_map, coarse);
     TransmitSetTE(rc, q, bface, bounds_map, coarse, false);
 
-    FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face})
-                    - FC({Metadata::GetUserFlag("StartupOnly")});
+    FC ghost_vars_f = FC({Metadata::FillGhost, Metadata::Face}) -
+                      FC({Metadata::GetUserFlag("StartupOnly")});
     auto q_f = rc->PackVariables(ghost_vars_f, bounds_map, coarse);
     TransmitSetTE(rc, q_f, bface, bounds_map, coarse, true);
 }
 
-void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q, BoundaryFace bface,
-                                PackIndexMap &bounds_map, bool coarse, bool do_face)
+void KBoundaries::TransmitSetTE(MeshBlockData<Real>* rc, VariablePack<Real>& q,
+    BoundaryFace bface, PackIndexMap& bounds_map, bool coarse, bool do_face)
 {
-    // We're sometimes called without any variables to sync (e.g. syncing flags, EMFs), just return
+    // We're sometimes called without any variables to sync (e.g. syncing flags, EMFs),
+    // just return
     if (q.GetDim(4) == 0) return;
 
     // Pull boundary properties
@@ -79,7 +80,7 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q, 
     } else {
         el_list = {CC};
     }
-    for (TopologicalElement &el : el_list) {
+    for (TopologicalElement& el : el_list) {
         // This automatically includes zones on domain faces, which we set to 0 below
         const IndexRange3 b = KDomain::GetBoundaryRange(rc, domain, el, coarse);
         const IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, CC, coarse);
@@ -88,10 +89,11 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q, 
         const int reflect_offset = corresponding_face ? 0 : (binner ? 1 : -1);
 
         // TODO SPECIFIC TO X2
-        // Total physical/interior *zones* in dir 3.  Note first/last face will share an opposite,
-        // i.e. both F3(0,x,x) and F3(N3,x,x) -> F3(N3/2,x,x), but in reverse only the former
+        // Total physical/interior *zones* in dir 3.  Note first/last face will share an
+        // opposite, i.e. both F3(0,x,x) and F3(N3,x,x) -> F3(N3/2,x,x), but in reverse
+        // only the former
         const int Nk3p = (bi.ke - bi.ks + 1);
-        const int Nk3p2 = Nk3p/2;
+        const int Nk3p2 = Nk3p / 2;
         const int ksp = bi.ks;
         // Calculate j just like for reflecting conditions
         const int jpivot = (binner) ? b.je : b.js;
@@ -100,42 +102,47 @@ void KBoundaries::TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q, 
         const bool do_face_invert = (el == F3 || el == F2);
         // TODO figure out fixing '.vector_component' in Parthenon
         // Subtracting from 'second' ensures -1 returns remain negative
-        const int x2_index_1 = bounds_map["cons.uvec"].second-1;
-        const int x2_index_2 = bounds_map["prims.uvec"].second-1;
-        const int x2_index_3 = bounds_map["cons.B"].second-1;
-        const int x2_index_4 = bounds_map["prims.B"].second-1;
+        const int x2_index_1 = bounds_map["cons.uvec"].second - 1;
+        const int x2_index_2 = bounds_map["prims.uvec"].second - 1;
+        const int x2_index_3 = bounds_map["cons.B"].second - 1;
+        const int x2_index_4 = bounds_map["prims.B"].second - 1;
         const int x3_index_1 = bounds_map["cons.uvec"].second;
         const int x3_index_2 = bounds_map["prims.uvec"].second;
         const int x3_index_3 = bounds_map["cons.B"].second;
         const int x3_index_4 = bounds_map["prims.B"].second;
 
-        //std::cerr << "Transmitting boundary. el=" << static_cast<int>(el) << " do_invert=" << do_face_invert << " corr_face=" << corresponding_face << std::endl;
-        //std::cerr << "Elements: " << q.GetDim(4) << " vector components: ";
-        //pmb->par_for(
-        //    "print_" + bname, 0, q.GetDim(4)-1,
-        //    KOKKOS_LAMBDA (const int &v) {
-        //        printf("%d ", q(el, v).vector_component);
-        //    }
+        // std::cerr << "Transmitting boundary. el=" << static_cast<int>(el) << "
+        // do_invert=" << do_face_invert << " corr_face=" << corresponding_face <<
+        // std::endl; std::cerr << "Elements: " << q.GetDim(4) << " vector components: ";
+        // pmb->par_for(
+        //     "print_" + bname, 0, q.GetDim(4)-1,
+        //     KOKKOS_LAMBDA (const int &v) {
+        //         printf("%d ", q(el, v).vector_component);
+        //     }
         //);
-        //std::cerr << std::endl;
+        // std::cerr << std::endl;
 
-        pmb->par_for(
-            "transmitting_polar_boundary_" + bname, 0, q.GetDim(4)-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+        pmb->par_for("transmitting_polar_boundary_" + bname, 0, q.GetDim(4) - 1, b.ks,
+            b.ke, b.js, b.je, b.is, b.ie,
+                     KOKKOS_LAMBDA(const int& v, const int& k, const int& j, const int& i)
+            {
                 const int ki = ((k - ksp + Nk3p2) % Nk3p) + ksp;
                 const int ji = jpivot + reflect_offset + (jpivot - j);
                 const int ii = i;
-                const Real invert = (do_face_invert ||
-                                    v == x2_index_1 || v == x2_index_2 ||
-                                    v == x2_index_3 || v == x2_index_4 ||
-                                    v == x3_index_1 || v == x3_index_2 ||
-                                    v == x3_index_3 || v == x3_index_4 ||
-                                    q(el, v).vector_component == X2DIR ||
-                                    q(el, v).vector_component == X3DIR) ? -1. : 1.;
+                const Real invert =
+                    (do_face_invert || v == x2_index_1 || v == x2_index_2 ||
+                        v == x2_index_3 || v == x2_index_4 || v == x3_index_1 ||
+                        v == x3_index_2 || v == x3_index_3 || v == x3_index_4 ||
+                        q(el, v).vector_component == X2DIR ||
+                        q(el, v).vector_component == X3DIR)
+                        ? -1.
+                        : 1.;
                 // if (i == 10 && j == 3 && k == 10)
-                //    printf("Set el %d v %d zone %d %d %d from %d %d %d invert: %f\n", (int) el, v, k, j, i, ki, ji, ii, invert);
-                q(el, v, k, j, i) = (corresponding_face && j == jpivot) ? 0. : invert * q(el, v, ki, ji, ii);
-            }
-        );
+                //    printf("Set el %d v %d zone %d %d %d from %d %d %d invert:
+                //    %f\n", (int) el, v, k, j, i, ki, ji, ii, invert);
+                q(el, v, k, j, i) = (corresponding_face && j == jpivot)
+                                        ? 0.
+                                        : invert * q(el, v, ki, ji, ii);
+            });
     }
 }

--- a/kharma/boundaries/one_block_transmit.hpp
+++ b/kharma/boundaries/one_block_transmit.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: one_block_transmit.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,15 +35,16 @@
 
 #include "boundary_types.hpp"
 
-namespace KBoundaries {
+namespace KBoundaries
+{
 
-// TODO(BSP) privatize probably
-void TransmitImpl(MeshBlockData<Real> *rc, BoundaryFace bface, bool coarse);
-void TransmitSetTE(MeshBlockData<Real> *rc, VariablePack<Real> &q, BoundaryFace bface,
-                    PackIndexMap &bounds_map, bool coarse, bool do_face);
+// TODO(CEP) privatize probably
+void TransmitImpl(MeshBlockData<Real>* rc, BoundaryFace bface, bool coarse);
+void TransmitSetTE(MeshBlockData<Real>* rc, VariablePack<Real>& q, BoundaryFace bface,
+    PackIndexMap& bounds_map, bool coarse, bool do_face);
 
-template <BoundaryFace bface>
-inline void OneBlockTransmit(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse)
+template<BoundaryFace bface>
+inline void OneBlockTransmit(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse)
 {
     TransmitImpl(rc.get(), bface, coarse);
 }

--- a/kharma/coord_output/coord_output.cpp
+++ b/kharma/coord_output/coord_output.cpp
@@ -35,10 +35,11 @@
 
 #include "domain.hpp"
 
-std::shared_ptr<KHARMAPackage> CoordinateOutput::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> CoordinateOutput::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("CoordinateOutput");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Any options? Which fields to output is determined in outputs
 
@@ -48,8 +49,8 @@ std::shared_ptr<KHARMAPackage> CoordinateOutput::Initialize(ParameterInput *pin,
     std::vector<int> s_4vector({GR_DIM});
     std::vector<int> s_4tensor({GR_DIM, GR_DIM});
     std::vector<int> s_4conn({GR_DIM, GR_DIM, GR_DIM});
-    std::vector<MetadataFlag> flags_geom = {Metadata::Real, Metadata::Cell, Metadata::Derived,
-                                            Metadata::OneCopy};
+    std::vector<MetadataFlag> flags_geom = {
+        Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
     auto m0 = Metadata(flags_geom);
     auto m1 = Metadata(flags_geom, s_4vector);
     auto m2 = Metadata(flags_geom, s_4tensor);
@@ -83,27 +84,30 @@ std::shared_ptr<KHARMAPackage> CoordinateOutput::Initialize(ParameterInput *pin,
     pkg->AddField("coords.gcov_embed", m2);
     pkg->AddField("coords.gdet_embed", m0);
     // TODO?
-    //pkg->AddField("coords.lapse_embed", m0);
-    //pkg->AddField("coords.conn_embed", m3);
+    // pkg->AddField("coords.lapse_embed", m0);
+    // pkg->AddField("coords.conn_embed", m3);
 
     // Register our output.  This will be called before *any* output,
     // but we will only fill the fields before the first.
     // This is all that's needed unless:
     // 1. Someone wants geometry in an AMR sim with remeshing
-    // 2. Parthenon decides to include a way to delete fields, which we would want to do here
+    // 2. Parthenon decides to include a way to delete fields, which we would want to do
+    // here
     pkg->BlockUserWorkBeforeOutput = CoordinateOutput::BlockUserWorkBeforeOutput;
 
     return pkg;
 }
 
-TaskStatus CoordinateOutput::BlockUserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin)
+TaskStatus CoordinateOutput::BlockUserWorkBeforeOutput(
+    MeshBlock* pmb, ParameterInput* pin)
 {
     auto& globals = pmb->packages.Get("Globals")->AllParams();
     if (!globals.Get<bool>("in_loop")) {
         auto rc = pmb->meshblock_data.Get("base");
 
         PackIndexMap geom_map;
-        auto Geom = rc->PackVariables({Metadata::GetUserFlag("CoordinateOutput")}, geom_map);
+        auto Geom =
+            rc->PackVariables({Metadata::GetUserFlag("CoordinateOutput")}, geom_map);
 
         const auto& G = pmb->coords;
 
@@ -134,41 +138,51 @@ TaskStatus CoordinateOutput::BlockUserWorkBeforeOutput(MeshBlock *pmb, Parameter
 
         IndexRange3 b = KDomain::GetRange(rc, IndexDomain::entire);
         pmb->par_for("set_geometry", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 // Native
                 GReal Xnative[GR_DIM];
                 G.coord(k, j, i, Loci::center, Xnative);
-                Geom(mXnative+1, k, j, i) = Geom(mX1, k, j, i) = Xnative[1];
-                Geom(mXnative+2, k, j, i) = Geom(mX2, k, j, i) = Xnative[2];
-                Geom(mXnative+3, k, j, i) = Geom(mX3, k, j, i) = Xnative[3];
+                Geom(mXnative + 1, k, j, i) = Geom(mX1, k, j, i) = Xnative[1];
+                Geom(mXnative + 2, k, j, i) = Geom(mX2, k, j, i) = Xnative[2];
+                Geom(mXnative + 3, k, j, i) = Geom(mX3, k, j, i) = Xnative[3];
                 // Cartesian
-                Geom(mXcart+1, k, j, i) = Geom(mx, k, j, i) = G.x(k, j, i);
-                Geom(mXcart+2, k, j, i) = Geom(my, k, j, i) = G.y(k, j, i);
-                Geom(mXcart+3, k, j, i) = Geom(mz, k, j, i) = G.z(k, j, i);
+                Geom(mXcart + 1, k, j, i) = Geom(mx, k, j, i) = G.x(k, j, i);
+                Geom(mXcart + 2, k, j, i) = Geom(my, k, j, i) = G.y(k, j, i);
+                Geom(mXcart + 3, k, j, i) = Geom(mz, k, j, i) = G.z(k, j, i);
                 // Spherical
-                Geom(mXsph+1, k, j, i) = Geom(mr, k, j, i) = G.r(k, j, i);
-                Geom(mXsph+2, k, j, i) = Geom(mth, k, j, i) = G.th(k, j, i);
-                Geom(mXsph+3, k, j, i) = Geom(mphi, k, j, i) = G.phi(k, j, i);
+                Geom(mXsph + 1, k, j, i) = Geom(mr, k, j, i) = G.r(k, j, i);
+                Geom(mXsph + 2, k, j, i) = Geom(mth, k, j, i) = G.th(k, j, i);
+                Geom(mXsph + 3, k, j, i) = Geom(mphi, k, j, i) = G.phi(k, j, i);
 
                 // Metric, native
-                DLOOP2 Geom(mgcov+GR_DIM*mu+nu, k, j, i) = G.gcov(Loci::center, j, i, mu, nu);
-                DLOOP2 Geom(mgcon+GR_DIM*mu+nu, k, j, i) = G.gcon(Loci::center, j, i, mu, nu);
+                DLOOP2
+                    Geom(mgcov + GR_DIM * mu + nu, k, j, i) =
+                        G.gcov(Loci::center, j, i, mu, nu);
+                DLOOP2
+                    Geom(mgcon + GR_DIM * mu + nu, k, j, i) =
+                        G.gcon(Loci::center, j, i, mu, nu);
                 Geom(mgdet, k, j, i) = G.gdet(Loci::center, j, i);
                 Geom(mlapse, k, j, i) = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
                 // shift? = G.gcon(Loci::center, j, i, 0, 1) * alpha * alpha;
                 // Connection
-                DLOOP3 Geom(mconn+GR_DIM*GR_DIM*mu+GR_DIM*nu+lam, k, j, i) = G.conn(j, i, mu, nu, lam);
+                DLOOP3
+                    Geom(mconn + GR_DIM * GR_DIM * mu + GR_DIM * nu + lam, k, j, i) =
+                        G.conn(j, i, mu, nu, lam);
 
                 // Metric, embedding
-                GReal Xembed[GR_DIM], gcov_embed[GR_DIM][GR_DIM], gcon_embed[GR_DIM][GR_DIM];
+                GReal Xembed[GR_DIM], gcov_embed[GR_DIM][GR_DIM],
+                    gcon_embed[GR_DIM][GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, Xembed);
                 G.coords.gcov_embed(Xembed, gcov_embed);
-                GReal gdet = G.coords.gcon_embed(Xembed, gcon_embed); // Save a tiny bit of time
-                DLOOP2 Geom(mgcov_embed+GR_DIM*mu+nu, k, j, i) = gcov_embed[mu][nu];
-                DLOOP2 Geom(mgcon_embed+GR_DIM*mu+nu, k, j, i) = gcon_embed[mu][nu];
+                GReal gdet =
+                    G.coords.gcon_embed(Xembed, gcon_embed); // Save a tiny bit of time
+                DLOOP2
+                    Geom(mgcov_embed + GR_DIM * mu + nu, k, j, i) = gcov_embed[mu][nu];
+                DLOOP2
+                    Geom(mgcon_embed + GR_DIM * mu + nu, k, j, i) = gcon_embed[mu][nu];
                 Geom(mgdet_embed, k, j, i) = gdet;
-            }
-        );
+            });
     }
 
     return TaskStatus::complete;

--- a/kharma/coord_output/coord_output.hpp
+++ b/kharma/coord_output/coord_output.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: coord_output.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,16 +37,19 @@
 
 #include <parthenon/parthenon.hpp>
 
-namespace CoordinateOutput {
+namespace CoordinateOutput
+{
 
 /**
  * Initialize the wind package with several options from the input deck
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
- * Fill the geometry output variables with quantities from the GRCoordinates object over a block
+ * Fill the geometry output variables with quantities from the GRCoordinates object over a
+ * block
  */
-TaskStatus BlockUserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin);
+TaskStatus BlockUserWorkBeforeOutput(MeshBlock* pmb, ParameterInput* pin);
 
 }

--- a/kharma/coordinates/coordinate_embedding.hpp
+++ b/kharma/coordinates/coordinate_embedding.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: coordinate_embedding.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,27 +44,29 @@
 // Instead we use mpark's reimplementation,
 // patched to never throw exceptions.
 // Because who needs those?
-// TODO(BSP) try to switch to std:: unless using SYCL
+// TODO(CEP) try to switch to std:: unless using SYCL
 #include <mpark/variant.hpp>
-//#include <variant>
-//namespace mpark = std;
+// #include <variant>
+// namespace mpark = std;
 
 /**
- * Coordinates in HARM are logically Cartesian -- that is, in some coordinate system, here dubbed "native"
- * coordinates, each cell is a rectangular prism of exactly the same shape as all the others.
- * However, working in GR allows us to define that "native" coordinate system arbitrarily
- * in relation to the "base" or "embedding" coordinates, which are usually Spherical Kerr-Schild coordinates.
+ * Coordinates in HARM are logically Cartesian -- that is, in some coordinate system, here
+ * dubbed "native" coordinates, each cell is a rectangular prism of exactly the same shape
+ * as all the others. However, working in GR allows us to define that "native" coordinate
+ * system arbitrarily in relation to the "base" or "embedding" coordinates, which are
+ * usually Spherical Kerr-Schild coordinates.
  *
- * That is, as long as we have a bijective map of base<->transformed coordinates, we can define the latter
- * arbitrarily, which is great for putting resolution where we need and not where we don't.
+ * That is, as long as we have a bijective map of base<->transformed coordinates, we can
+ * define the latter arbitrarily, which is great for putting resolution where we need and
+ * not where we don't.
  *
- * This class keeps track of the base coordinates and the map, defining generic functions guaranteed to return
- * something in the native or embedding coordinate system, given something else -- e.g. covariant metric "gcov"
- * at a native coordinate location Xnative.
- * 
+ * This class keeps track of the base coordinates and the map, defining generic functions
+ * guaranteed to return something in the native or embedding coordinate system, given
+ * something else -- e.g. covariant metric "gcov" at a native coordinate location Xnative.
+ *
  * Each system or transform must be a class defining a basic interface:
  * see coordinate_systems.hpp for the current examples.
- * 
+ *
  * Specifically, the BaseCoords class must implement:
  * * gcov_embed
  * And the Transform class must implement:
@@ -72,540 +74,661 @@
  * * coord_to_native
  * * dxdX_to_embed
  * * dxdX_to_native
- * 
- * Each possible class is added to a couple of mpark::variant containers, and then to the chains of if statements below.
  *
- * TODO convenience functions.  Intelligent r/th/phi, x/y/z, KS and BL, a, etc by auto-translating contents
+ * Each possible class is added to a couple of mpark::variant containers, and then to the
+ * chains of if statements below.
+ *
+ * TODO convenience functions.  Intelligent r/th/phi, x/y/z, KS and BL, a, etc by
+ * auto-translating contents
  */
-class CoordinateEmbedding {
-    public:
-        SomeBaseCoords base;
-        SomeTransform transform;
+class CoordinateEmbedding
+{
+  public:
+    SomeBaseCoords base;
+    SomeTransform transform;
 
-        // Common code for constructors
+    // Common code for constructors
 #pragma hd_warning_disable
-        KOKKOS_FUNCTION void EmplaceSystems(const SomeBaseCoords& base_in, const SomeTransform& transform_in) {
-            // Isn't there some more elegant way to say "yeah the types are fine just copy da bits"?
-            if (mpark::holds_alternative<SphMinkowskiCoords>(base_in)) {
-                base.emplace<SphMinkowskiCoords>(mpark::get<SphMinkowskiCoords>(base_in));
-            } else if (mpark::holds_alternative<CartMinkowskiCoords>(base_in)) {
-                base.emplace<CartMinkowskiCoords>(mpark::get<CartMinkowskiCoords>(base_in));
-            } else if (mpark::holds_alternative<SphBLCoords>(base_in)) {
-                base.emplace<SphBLCoords>(mpark::get<SphBLCoords>(base_in));
-            } else if (mpark::holds_alternative<SphKSCoords>(base_in)) {
-                base.emplace<SphKSCoords>(mpark::get<SphKSCoords>(base_in));
-            } else if (mpark::holds_alternative<SphKSExtG>(base_in)) {
-                base.emplace<SphKSExtG>(mpark::get<SphKSExtG>(base_in));
-            } else if (mpark::holds_alternative<SphBLExtG>(base_in)) {
-                base.emplace<SphBLExtG>(mpark::get<SphBLExtG>(base_in));
-            }
-
-            if (mpark::holds_alternative<NullTransform>(transform_in)) {
-                transform.emplace<NullTransform>(mpark::get<NullTransform>(transform_in));
-            } else if (mpark::holds_alternative<ExponentialTransform>(transform_in)) {
-                transform.emplace<ExponentialTransform>(mpark::get<ExponentialTransform>(transform_in));
-            } else if (mpark::holds_alternative<SuperExponentialTransform>(transform_in)) {
-                transform.emplace<SuperExponentialTransform>(mpark::get<SuperExponentialTransform>(transform_in));
-            } else if (mpark::holds_alternative<ModifyTransform>(transform_in)) {
-                transform.emplace<ModifyTransform>(mpark::get<ModifyTransform>(transform_in));
-            } else if (mpark::holds_alternative<FunkyTransform>(transform_in)) {
-                transform.emplace<FunkyTransform>(mpark::get<FunkyTransform>(transform_in));
-            } else if (mpark::holds_alternative<WidepoleTransform>(transform_in)) {
-                transform.emplace<WidepoleTransform>(mpark::get<WidepoleTransform>(transform_in));
-            }
+    KOKKOS_FUNCTION void EmplaceSystems(
+        const SomeBaseCoords& base_in, const SomeTransform& transform_in)
+    {
+        // Isn't there some more elegant way to say "yeah the types are fine just copy da
+        // bits"?
+        if (mpark::holds_alternative<SphMinkowskiCoords>(base_in)) {
+            base.emplace<SphMinkowskiCoords>(mpark::get<SphMinkowskiCoords>(base_in));
+        } else if (mpark::holds_alternative<CartMinkowskiCoords>(base_in)) {
+            base.emplace<CartMinkowskiCoords>(mpark::get<CartMinkowskiCoords>(base_in));
+        } else if (mpark::holds_alternative<SphBLCoords>(base_in)) {
+            base.emplace<SphBLCoords>(mpark::get<SphBLCoords>(base_in));
+        } else if (mpark::holds_alternative<SphKSCoords>(base_in)) {
+            base.emplace<SphKSCoords>(mpark::get<SphKSCoords>(base_in));
+        } else if (mpark::holds_alternative<SphKSExtG>(base_in)) {
+            base.emplace<SphKSExtG>(mpark::get<SphKSExtG>(base_in));
+        } else if (mpark::holds_alternative<SphBLExtG>(base_in)) {
+            base.emplace<SphBLExtG>(mpark::get<SphBLExtG>(base_in));
         }
 
-        // Constructors
-#pragma hd_warning_disable
-        CoordinateEmbedding() = default;
-#pragma hd_warning_disable
-        CoordinateEmbedding(parthenon::ParameterInput* pin) {
-            const std::string base_str = pin->GetString("coordinates", "base");
-            const std::string transform_str = pin->GetOrAddString("coordinates", "transform", "null");
+        if (mpark::holds_alternative<NullTransform>(transform_in)) {
+            transform.emplace<NullTransform>(mpark::get<NullTransform>(transform_in));
+        } else if (mpark::holds_alternative<ExponentialTransform>(transform_in)) {
+            transform.emplace<ExponentialTransform>(
+                mpark::get<ExponentialTransform>(transform_in));
+        } else if (mpark::holds_alternative<SuperExponentialTransform>(transform_in)) {
+            transform.emplace<SuperExponentialTransform>(
+                mpark::get<SuperExponentialTransform>(transform_in));
+        } else if (mpark::holds_alternative<ModifyTransform>(transform_in)) {
+            transform.emplace<ModifyTransform>(mpark::get<ModifyTransform>(transform_in));
+        } else if (mpark::holds_alternative<FunkyTransform>(transform_in)) {
+            transform.emplace<FunkyTransform>(mpark::get<FunkyTransform>(transform_in));
+        } else if (mpark::holds_alternative<WidepoleTransform>(transform_in)) {
+            transform.emplace<WidepoleTransform>(
+                mpark::get<WidepoleTransform>(transform_in));
+        }
+    }
 
-            // Parse names.  See coordinate_systems.hpp for details
-            if (base_str == "spherical_minkowski") {
-                base.emplace<SphMinkowskiCoords>(SphMinkowskiCoords());
-            } else if (base_str == "cartesian_minkowski" || base_str == "minkowski") {
-                base.emplace<CartMinkowskiCoords>(CartMinkowskiCoords());
-            } else if (base_str == "spherical_ks" || base_str == "ks" ||
-                        base_str == "spherical_ks_extg" || base_str == "ks_extg") {
-                GReal a = pin->GetReal("coordinates", "a");
-                bool ext_g = pin->GetOrAddBoolean("coordinates", "ext_g", false);
-                if (ext_g || base_str == "spherical_ks_extg" || base_str == "ks_extg") {
-                    if (a > 0) throw std::invalid_argument("Transform is for spherical coordinates!");
-                    base.emplace<SphKSExtG>(SphKSExtG(a));
-                } else {
-                    base.emplace<SphKSCoords>(SphKSCoords(a));
-                }
-            } else if (base_str == "spherical_bl" || base_str == "bl" ||
-                        base_str == "spherical_bl_extg" || base_str == "bl_extg") {
-                GReal a = pin->GetReal("coordinates", "a");
-                bool ext_g = pin->GetOrAddBoolean("coordinates", "ext_g", false);
-                if (ext_g || base_str == "spherical_bl_extg" || base_str == "bl_extg") {
-                    if (a > 0) throw std::invalid_argument("Transform is for spherical coordinates!");
-                    base.emplace<SphBLExtG>(SphBLExtG(a));
-                } else {
-                    base.emplace<SphBLCoords>(SphBLCoords(a));
-                }
+    // Constructors
+#pragma hd_warning_disable
+    CoordinateEmbedding() = default;
+#pragma hd_warning_disable
+    CoordinateEmbedding(parthenon::ParameterInput* pin)
+    {
+        const std::string base_str = pin->GetString("coordinates", "base");
+        const std::string transform_str =
+            pin->GetOrAddString("coordinates", "transform", "null");
+
+        // Parse names.  See coordinate_systems.hpp for details
+        if (base_str == "spherical_minkowski") {
+            base.emplace<SphMinkowskiCoords>(SphMinkowskiCoords());
+        } else if (base_str == "cartesian_minkowski" || base_str == "minkowski") {
+            base.emplace<CartMinkowskiCoords>(CartMinkowskiCoords());
+        } else if (base_str == "spherical_ks" || base_str == "ks" ||
+                   base_str == "spherical_ks_extg" || base_str == "ks_extg") {
+            GReal a = pin->GetReal("coordinates", "a");
+            bool ext_g = pin->GetOrAddBoolean("coordinates", "ext_g", false);
+            if (ext_g || base_str == "spherical_ks_extg" || base_str == "ks_extg") {
+                if (a > 0)
+                    throw std::invalid_argument(
+                        "Transform is for spherical coordinates!");
+                base.emplace<SphKSExtG>(SphKSExtG(a));
             } else {
-                throw std::invalid_argument("Unsupported base coordinates!");
+                base.emplace<SphKSCoords>(SphKSCoords(a));
             }
-
-            bool spherical = is_spherical();
-
-            if (transform_str == "null" || transform_str == "none") {
-                if (spherical) {
-                    transform.emplace<SphNullTransform>(SphNullTransform());
-                } else {
-                    transform.emplace<NullTransform>(NullTransform());
-                }
-            } else if (transform_str == "exponential" || transform_str == "exp" || transform_str == "eks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
-                transform.emplace<ExponentialTransform>(ExponentialTransform());
-            } else if (transform_str == "superexponential" || transform_str == "superexp") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
-                GReal r_br = pin->GetOrAddReal("coordinates", "r_br", 1000.);
-                GReal npow = pin->GetOrAddReal("coordinates", "npow", 1.0);
-                GReal cpow = pin->GetOrAddReal("coordinates", "cpow", 4.0);
-                transform.emplace<SuperExponentialTransform>(SuperExponentialTransform(r_br, npow, cpow));
-            } else if (transform_str == "modified" || transform_str == "mks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
-                GReal hslope = pin->GetOrAddReal("coordinates", "hslope", 0.3);
-                transform.emplace<ModifyTransform>(ModifyTransform(hslope));
-            } else if (transform_str == "funky" || transform_str == "fmks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
-                GReal hslope = pin->GetOrAddReal("coordinates", "hslope", 0.3);
-                GReal mks_smooth = pin->GetOrAddReal("coordinates", "mks_smooth", 0.5);
-                GReal poly_xt = pin->GetOrAddReal("coordinates", "poly_xt", 0.82);
-                GReal poly_alpha = pin->GetOrAddReal("coordinates", "poly_alpha", 14.0);
-                // Set fmks to use x1min from our system for compatibility. Note THIS WILL CHANGE
-                GReal startx1 = 0.; // Default for temporary coordinate construction before mesh, future general default
-                if (pin->DoesParameterExist("coordinates", "fmks_zero_point")) {
-                    startx1 = pin->GetReal("coordinates", "fmks_zero_point");
-                } else if (pin->DoesParameterExist("parthenon/mesh", "x1min")) {
-                    std::cout << "KHARMA WARNING: Constructing FMKS coordinates using mesh x1min is deprecated." << std::endl
-                              << "Set coordinates/fmks_zero_point for consistent behavior." << std::endl;
-                    startx1 = pin->GetReal("parthenon/mesh", "x1min");
-                }
-                transform.emplace<FunkyTransform>(FunkyTransform(startx1, hslope, mks_smooth, poly_xt, poly_alpha));
-            } else if (transform_str == "widepole" || transform_str == "wks") {
-                if (!spherical) throw std::invalid_argument("Transform is for spherical coordinates!");
-                GReal lin_frac = pin->GetOrAddReal("coordinates", "lin_frac", 0.6);
-                GReal smoothness = pin->GetOrAddReal("coordinates", "smoothness", -1.0);
-                GReal nx2 = pin->GetReal("parthenon/mesh", "nx2");
-                GReal nx3 = pin->GetReal("parthenon/mesh", "nx3");
-                transform.emplace<WidepoleTransform>(WidepoleTransform(lin_frac, smoothness, nx2, nx3));
+        } else if (base_str == "spherical_bl" || base_str == "bl" ||
+                   base_str == "spherical_bl_extg" || base_str == "bl_extg") {
+            GReal a = pin->GetReal("coordinates", "a");
+            bool ext_g = pin->GetOrAddBoolean("coordinates", "ext_g", false);
+            if (ext_g || base_str == "spherical_bl_extg" || base_str == "bl_extg") {
+                if (a > 0)
+                    throw std::invalid_argument(
+                        "Transform is for spherical coordinates!");
+                base.emplace<SphBLExtG>(SphBLExtG(a));
             } else {
-                throw std::invalid_argument("Unsupported coordinate transform!");
+                base.emplace<SphBLCoords>(SphBLCoords(a));
             }
-        }
-#pragma hd_warning_disable
-        KOKKOS_FUNCTION CoordinateEmbedding(SomeBaseCoords& base_in, SomeTransform& transform_in): base(base_in), transform(transform_in) {}
-#pragma hd_warning_disable
-        KOKKOS_FUNCTION CoordinateEmbedding(const CoordinateEmbedding& src): base(src.base), transform(src.transform) {}
-#pragma hd_warning_disable
-        KOKKOS_FUNCTION const CoordinateEmbedding& operator=(const CoordinateEmbedding& src)
-        {
-            //CoordinateEmbedding copy(src);
-            //base.swap(copy.base);
-            //transform.swap(copy.transform);
-            EmplaceSystems(src.base, src.transform);
-            return *this;
-        }
-        // Convenience functions to get common things:
-        // Names (host only)
-#pragma hd_warning_disable
-        KOKKOS_INLINE_FUNCTION std::string variant_names() const
-        {
-            std::string basename(
-                mpark::visit( [&](const auto& self) {
-                    return self.name;
-                }, base)
-            );
-
-            std::string transformname(
-                mpark::visit( [&](const auto& self) {
-                    return self.name;
-                }, transform)
-            );
-
-            return basename + " " + transformname;
+        } else {
+            throw std::invalid_argument("Unsupported base coordinates!");
         }
 
-        // Properties (host or device)
-        KOKKOS_INLINE_FUNCTION bool is_spherical() const
-        {
-            return mpark::visit( [&](const auto& self) {
+        bool spherical = is_spherical();
+
+        if (transform_str == "null" || transform_str == "none") {
+            if (spherical) {
+                transform.emplace<SphNullTransform>(SphNullTransform());
+            } else {
+                transform.emplace<NullTransform>(NullTransform());
+            }
+        } else if (transform_str == "exponential" || transform_str == "exp" ||
+                   transform_str == "eks") {
+            if (!spherical)
+                throw std::invalid_argument("Transform is for spherical coordinates!");
+            transform.emplace<ExponentialTransform>(ExponentialTransform());
+        } else if (transform_str == "superexponential" || transform_str == "superexp") {
+            if (!spherical)
+                throw std::invalid_argument("Transform is for spherical coordinates!");
+            GReal r_br = pin->GetOrAddReal("coordinates", "r_br", 1000.);
+            GReal npow = pin->GetOrAddReal("coordinates", "npow", 1.0);
+            GReal cpow = pin->GetOrAddReal("coordinates", "cpow", 4.0);
+            transform.emplace<SuperExponentialTransform>(
+                SuperExponentialTransform(r_br, npow, cpow));
+        } else if (transform_str == "modified" || transform_str == "mks") {
+            if (!spherical)
+                throw std::invalid_argument("Transform is for spherical coordinates!");
+            GReal hslope = pin->GetOrAddReal("coordinates", "hslope", 0.3);
+            transform.emplace<ModifyTransform>(ModifyTransform(hslope));
+        } else if (transform_str == "funky" || transform_str == "fmks") {
+            if (!spherical)
+                throw std::invalid_argument("Transform is for spherical coordinates!");
+            GReal hslope = pin->GetOrAddReal("coordinates", "hslope", 0.3);
+            GReal mks_smooth = pin->GetOrAddReal("coordinates", "mks_smooth", 0.5);
+            GReal poly_xt = pin->GetOrAddReal("coordinates", "poly_xt", 0.82);
+            GReal poly_alpha = pin->GetOrAddReal("coordinates", "poly_alpha", 14.0);
+            // Set fmks to use x1min from our system for compatibility. Note THIS WILL
+            // CHANGE
+            GReal startx1 = 0.; // Default for temporary coordinate construction before
+                                // mesh, future general default
+            if (pin->DoesParameterExist("coordinates", "fmks_zero_point")) {
+                startx1 = pin->GetReal("coordinates", "fmks_zero_point");
+            } else if (pin->DoesParameterExist("parthenon/mesh", "x1min")) {
+                std::cout << "KHARMA WARNING: Constructing FMKS coordinates using mesh "
+                             "x1min is deprecated."
+                          << std::endl
+                          << "Set coordinates/fmks_zero_point for consistent behavior."
+                          << std::endl;
+                startx1 = pin->GetReal("parthenon/mesh", "x1min");
+            }
+            transform.emplace<FunkyTransform>(
+                FunkyTransform(startx1, hslope, mks_smooth, poly_xt, poly_alpha));
+        } else if (transform_str == "widepole" || transform_str == "wks") {
+            if (!spherical)
+                throw std::invalid_argument("Transform is for spherical coordinates!");
+            GReal lin_frac = pin->GetOrAddReal("coordinates", "lin_frac", 0.6);
+            GReal smoothness = pin->GetOrAddReal("coordinates", "smoothness", -1.0);
+            GReal nx2 = pin->GetReal("parthenon/mesh", "nx2");
+            GReal nx3 = pin->GetReal("parthenon/mesh", "nx3");
+            transform.emplace<WidepoleTransform>(
+                WidepoleTransform(lin_frac, smoothness, nx2, nx3));
+        } else {
+            throw std::invalid_argument("Unsupported coordinate transform!");
+        }
+    }
+#pragma hd_warning_disable
+    KOKKOS_FUNCTION CoordinateEmbedding(
+        SomeBaseCoords& base_in, SomeTransform& transform_in)
+        : base(base_in)
+        , transform(transform_in)
+    {}
+#pragma hd_warning_disable
+    KOKKOS_FUNCTION CoordinateEmbedding(const CoordinateEmbedding& src)
+        : base(src.base)
+        , transform(src.transform)
+    {}
+#pragma hd_warning_disable
+    KOKKOS_FUNCTION const CoordinateEmbedding& operator=(const CoordinateEmbedding& src)
+    {
+        // CoordinateEmbedding copy(src);
+        // base.swap(copy.base);
+        // transform.swap(copy.transform);
+        EmplaceSystems(src.base, src.transform);
+        return *this;
+    }
+    // Convenience functions to get common things:
+    // Names (host only)
+#pragma hd_warning_disable
+    KOKKOS_INLINE_FUNCTION std::string variant_names() const
+    {
+        std::string basename(mpark::visit(
+            [&](const auto& self)
+            {
+                return self.name;
+            },
+            base));
+
+        std::string transformname(mpark::visit(
+            [&](const auto& self)
+            {
+                return self.name;
+            },
+            transform));
+
+        return basename + " " + transformname;
+    }
+
+    // Properties (host or device)
+    KOKKOS_INLINE_FUNCTION bool is_spherical() const
+    {
+        return mpark::visit(
+            [&](const auto& self)
+            {
                 return self.spherical;
-            }, base);
+            },
+            base);
+    }
+    KOKKOS_INLINE_FUNCTION bool is_transformed() const
+    {
+        return !mpark::holds_alternative<NullTransform>(transform);
+    }
+    KOKKOS_INLINE_FUNCTION GReal get_horizon() const
+    {
+        if (mpark::holds_alternative<SphKSCoords>(base) ||
+            mpark::holds_alternative<SphBLCoords>(base) ||
+            mpark::holds_alternative<SphKSExtG>(base) ||
+            mpark::holds_alternative<SphBLExtG>(base)) {
+            const GReal a = get_a();
+            return 1 + m::sqrt(1 - a * a);
+        } else {
+            return 0.0;
         }
-        KOKKOS_INLINE_FUNCTION bool is_transformed() const
-        {
-            return !mpark::holds_alternative<NullTransform>(transform);
-        }
-        KOKKOS_INLINE_FUNCTION GReal get_horizon() const
-        {
-            if (mpark::holds_alternative<SphKSCoords>(base) ||
-                mpark::holds_alternative<SphBLCoords>(base) ||
-                mpark::holds_alternative<SphKSExtG>(base) ||
-                mpark::holds_alternative<SphBLExtG>(base)) {
-                const GReal a = get_a();
-                return 1 + m::sqrt(1 - a * a);
-            } else {
-                return 0.0;
-            }
-        }
-        KOKKOS_INLINE_FUNCTION GReal get_a() const
-        {
-            return mpark::visit( [&](const auto& self) {
+    }
+    KOKKOS_INLINE_FUNCTION GReal get_a() const
+    {
+        return mpark::visit(
+            [&](const auto& self)
+            {
                 return self.a;
-            }, base);
-        }
-        GReal startx(int dir) const
-        {
-            return mpark::visit( [&](const auto& self) {
+            },
+            base);
+    }
+    GReal startx(int dir) const
+    {
+        return mpark::visit(
+            [&](const auto& self)
+            {
                 return self.startx[dir - 1];
-            }, transform);
-        }
-        GReal stopx(int dir) const
-        {
-            return mpark::visit( [&](const auto& self) {
+            },
+            transform);
+    }
+    GReal stopx(int dir) const
+    {
+        return mpark::visit(
+            [&](const auto& self)
+            {
                 return self.stopx[dir - 1];
-            }, transform);
-        }
+            },
+            transform);
+    }
 
-        KOKKOS_INLINE_FUNCTION bool is_ks() const
-        {
-            return mpark::holds_alternative<SphKSCoords>(base);
-        }
-        KOKKOS_INLINE_FUNCTION bool is_cart_minkowski() const
-        {
-            return mpark::holds_alternative<CartMinkowskiCoords>(base) && mpark::holds_alternative<NullTransform>(transform);
-        }
+    KOKKOS_INLINE_FUNCTION bool is_ks() const
+    {
+        return mpark::holds_alternative<SphKSCoords>(base);
+    }
+    KOKKOS_INLINE_FUNCTION bool is_cart_minkowski() const
+    {
+        return mpark::holds_alternative<CartMinkowskiCoords>(base) &&
+               mpark::holds_alternative<NullTransform>(transform);
+    }
 
-        // Note this is the one thing we need from BaseCoords
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            mpark::visit( [&Xembed, &gcov](const auto& self) {
+    // Note this is the one thing we need from BaseCoords
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        mpark::visit(
+            [&Xembed, &gcov](const auto& self)
+            {
                 self.gcov_embed(Xembed, gcov);
-            }, base);
-        }
-        // All the quantities we can derive from that
-        KOKKOS_INLINE_FUNCTION Real gcon_from_gcov(const Real gcov[GR_DIM][GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
-        {
-            Real gdet = invert(&gcov[0][0], &gcon[0][0]);
-            return m::sqrt(m::abs(gdet));
-        }
-        KOKKOS_INLINE_FUNCTION Real gcon_embed(const GReal Xembed[GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
-        {
-            GReal gcov[GR_DIM][GR_DIM];
-            gcov_embed(Xembed, gcov);
-            return gcon_from_gcov(gcov, gcon);
-        }
-        KOKKOS_INLINE_FUNCTION Real gdet_embed(const GReal Xembed[GR_DIM]) const
-        {
-            GReal gcon[GR_DIM][GR_DIM];
-            return gcon_embed(Xembed, gcon);
-        }
+            },
+            base);
+    }
+    // All the quantities we can derive from that
+    KOKKOS_INLINE_FUNCTION Real gcon_from_gcov(
+        const Real gcov[GR_DIM][GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
+    {
+        Real gdet = invert(&gcov[0][0], &gcon[0][0]);
+        return m::sqrt(m::abs(gdet));
+    }
+    KOKKOS_INLINE_FUNCTION Real gcon_embed(
+        const GReal Xembed[GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
+    {
+        GReal gcov[GR_DIM][GR_DIM];
+        gcov_embed(Xembed, gcov);
+        return gcon_from_gcov(gcov, gcon);
+    }
+    KOKKOS_INLINE_FUNCTION Real gdet_embed(const GReal Xembed[GR_DIM]) const
+    {
+        GReal gcon[GR_DIM][GR_DIM];
+        return gcon_embed(Xembed, gcon);
+    }
 
-        // Now, everything we take from CoordinateTransform
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
+    // Now, everything we take from CoordinateTransform
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
                 self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
+            },
+            transform);
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
                 self.coord_to_native(Xembed, Xnative);
-            }, transform);
-        }
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            mpark::visit( [&Xnative, &dxdX](const auto& self) {
+            },
+            transform);
+    }
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        mpark::visit(
+            [&Xnative, &dxdX](const auto& self)
+            {
                 self.dxdX(Xnative, dxdX);
-            }, transform);
-        }
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            mpark::visit( [&Xnative, &dXdx](const auto& self) {
+            },
+            transform);
+    }
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        mpark::visit(
+            [&Xnative, &dXdx](const auto& self)
+            {
                 self.dXdx(Xnative, dXdx);
-            }, transform);
-        }
+            },
+            transform);
+    }
 
-        // Coordinate convenience functions:
-        // transform the radial coordinate alone without len-4 arrays
-        // ...at least not for the user.  These are not fast
-        KOKKOS_INLINE_FUNCTION GReal r_to_native(const GReal r) const
-        {
-            const GReal Xembed[GR_DIM] = {0., r, 0., 0.};
-            GReal Xnative[GR_DIM];
-            mpark::visit( [&Xembed, &Xnative](const auto& self) {
+    // Coordinate convenience functions:
+    // transform the radial coordinate alone without len-4 arrays
+    // ...at least not for the user.  These are not fast
+    KOKKOS_INLINE_FUNCTION GReal r_to_native(const GReal r) const
+    {
+        const GReal Xembed[GR_DIM] = {0., r, 0., 0.};
+        GReal Xnative[GR_DIM];
+        mpark::visit(
+            [&Xembed, &Xnative](const auto& self)
+            {
                 self.coord_to_native(Xembed, Xnative);
-            }, transform);
-            return Xnative[1];
-        }
-        KOKKOS_INLINE_FUNCTION GReal X1_to_embed(const GReal X1) const
-        {
-            const GReal Xnative[GR_DIM] = {0., X1, 0., 0.};
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
+            },
+            transform);
+        return Xnative[1];
+    }
+    KOKKOS_INLINE_FUNCTION GReal X1_to_embed(const GReal X1) const
+    {
+        const GReal Xnative[GR_DIM] = {0., X1, 0., 0.};
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
                 self.coord_to_embed(Xnative, Xembed);
-            }, transform);
+            },
+            transform);
+        return Xembed[1];
+    }
+
+    // Get a particular coordinate from an array
+    // note these *aren't faster* or less memory, just convenient
+    KOKKOS_INLINE_FUNCTION GReal r_of(const GReal Xnative[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
+                self.coord_to_embed(Xnative, Xembed);
+            },
+            transform);
+        if (is_spherical()) {
             return Xembed[1];
+        } else {
+            return m::sqrt(SQR(Xembed[1]) + SQR(Xembed[2]) + SQR(Xembed[3]));
         }
+    }
+    KOKKOS_INLINE_FUNCTION GReal th_of(const GReal Xnative[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
+                self.coord_to_embed(Xnative, Xembed);
+            },
+            transform);
+        if (is_spherical()) {
+            return Xembed[2];
+        } else {
+            return m::atan2(m::sqrt(SQR(Xembed[1]) + SQR(Xembed[2])), Xembed[3]);
+        }
+    }
+    KOKKOS_INLINE_FUNCTION GReal phi_of(const GReal Xnative[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
+                self.coord_to_embed(Xnative, Xembed);
+            },
+            transform);
+        if (is_spherical()) {
+            return Xembed[3];
+        } else {
+            return m::atan2(Xembed[2], Xembed[1]);
+        }
+    }
+    KOKKOS_INLINE_FUNCTION GReal x_of(const GReal Xnative[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
+                self.coord_to_embed(Xnative, Xembed);
+            },
+            transform);
+        if (!is_spherical()) {
+            return Xembed[1];
+        } else {
+            return Xembed[1] * m::sin(Xembed[2]) * m::cos(Xembed[3]);
+        }
+    }
+    KOKKOS_INLINE_FUNCTION GReal y_of(const GReal Xnative[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
+                self.coord_to_embed(Xnative, Xembed);
+            },
+            transform);
+        if (!is_spherical()) {
+            return Xembed[2];
+        } else {
+            return Xembed[1] * m::sin(Xembed[2]) * m::sin(Xembed[3]);
+        }
+    }
+    KOKKOS_INLINE_FUNCTION GReal z_of(const GReal Xnative[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        mpark::visit(
+            [&Xnative, &Xembed](const auto& self)
+            {
+                self.coord_to_embed(Xnative, Xembed);
+            },
+            transform);
+        if (!is_spherical()) {
+            return Xembed[3];
+        } else {
+            return Xembed[1] * m::cos(Xembed[2]);
+        }
+    }
 
-        // Get a particular coordinate from an array
-        // note these *aren't faster* or less memory, just convenient
-        KOKKOS_INLINE_FUNCTION GReal r_of(const GReal Xnative[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
-                self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-            if (is_spherical()) {
-                return Xembed[1];
-            } else {
-                return m::sqrt(SQR(Xembed[1]) + SQR(Xembed[2]) + SQR(Xembed[3]));
-            }
+    // VECTOR TRANSFORMS
+    // Contravariant vectors:
+    KOKKOS_INLINE_FUNCTION void con_vec_to_embed(const GReal Xnative[GR_DIM],
+        const GReal vcon_native[GR_DIM], GReal vcon_embed[GR_DIM]) const
+    {
+        Real dxdX_temp[GR_DIM][GR_DIM];
+        dxdX(Xnative, dxdX_temp);
+        DLOOP1 {
+            vcon_embed[mu] = 0;
+            for (int nu = 0; nu < GR_DIM; ++nu)
+                vcon_embed[mu] += dxdX_temp[mu][nu] * vcon_native[nu];
         }
-        KOKKOS_INLINE_FUNCTION GReal th_of(const GReal Xnative[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
-                self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-            if (is_spherical()) {
-                return Xembed[2];
-            } else {
-                return m::atan2(m::sqrt(SQR(Xembed[1]) + SQR(Xembed[2])), Xembed[3]);
-            }
+    }
+    KOKKOS_INLINE_FUNCTION void con_vec_to_native(const GReal Xnative[GR_DIM],
+        const GReal vcon_embed[GR_DIM], GReal vcon_native[GR_DIM]) const
+    {
+        Real dXdx_temp[GR_DIM][GR_DIM];
+        dXdx(Xnative, dXdx_temp);
+        DLOOP1 { // TODO is this faster, or DLOOP1/2?
+            vcon_native[mu] = 0;
+            for (int nu = 0; nu < GR_DIM; ++nu)
+                vcon_native[mu] += dXdx_temp[mu][nu] * vcon_embed[nu];
         }
-        KOKKOS_INLINE_FUNCTION GReal phi_of(const GReal Xnative[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
-                self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-            if (is_spherical()) {
-                return Xembed[3];
-            } else {
-                return m::atan2(Xembed[2], Xembed[1]);
-            }
-        }
-        KOKKOS_INLINE_FUNCTION GReal x_of(const GReal Xnative[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
-                self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-            if (!is_spherical()) {
-                return Xembed[1];
-            } else {
-                return Xembed[1] * m::sin(Xembed[2]) * m::cos(Xembed[3]);
-            }
-        }
-        KOKKOS_INLINE_FUNCTION GReal y_of(const GReal Xnative[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
-                self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-            if (!is_spherical()) {
-                return Xembed[2];
-            } else {
-                return Xembed[1] * m::sin(Xembed[2]) * m::sin(Xembed[3]);
-            }
-        }
-        KOKKOS_INLINE_FUNCTION GReal z_of(const GReal Xnative[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            mpark::visit( [&Xnative, &Xembed](const auto& self) {
-                self.coord_to_embed(Xnative, Xembed);
-            }, transform);
-            if (!is_spherical()) {
-                return Xembed[3];
-            } else {
-                return Xembed[1] * m::cos(Xembed[2]);
-            }
-        }
+    }
+    // Covariant are opposite
+    KOKKOS_INLINE_FUNCTION void cov_vec_to_native(const GReal Xnative[GR_DIM],
+        const GReal vcov_embed[GR_DIM], GReal vcov_native[GR_DIM]) const
+    {
+        con_vec_to_embed(Xnative, vcov_embed, vcov_native);
+    }
+    KOKKOS_INLINE_FUNCTION void cov_vec_to_embed(const GReal Xnative[GR_DIM],
+        const GReal vcov_native[GR_DIM], GReal vcov_embed[GR_DIM]) const
+    {
+        con_vec_to_native(Xnative, vcov_native, vcov_embed);
+    }
 
-        // VECTOR TRANSFORMS
-        // Contravariant vectors:
-        KOKKOS_INLINE_FUNCTION void con_vec_to_embed(const GReal Xnative[GR_DIM], const GReal vcon_native[GR_DIM], GReal vcon_embed[GR_DIM]) const
-        {
-            Real dxdX_temp[GR_DIM][GR_DIM];
-            dxdX(Xnative, dxdX_temp);
-            DLOOP1 {
-                vcon_embed[mu] = 0;
-                for(int nu=0; nu < GR_DIM; ++nu)
-                    vcon_embed[mu] += dxdX_temp[mu][nu] * vcon_native[nu];
-            }
-        }
-        KOKKOS_INLINE_FUNCTION void con_vec_to_native(const GReal Xnative[GR_DIM], const GReal vcon_embed[GR_DIM], GReal vcon_native[GR_DIM]) const
-        {
-            Real dXdx_temp[GR_DIM][GR_DIM];
-            dXdx(Xnative, dXdx_temp);
-            DLOOP1 { // TODO is this faster, or DLOOP1/2?
-                vcon_native[mu] = 0;
-                for(int nu=0; nu < GR_DIM; ++nu)
-                    vcon_native[mu] += dXdx_temp[mu][nu] * vcon_embed[nu];
-            }
-        }
-        // Covariant are opposite
-        KOKKOS_INLINE_FUNCTION void cov_vec_to_native(const GReal Xnative[GR_DIM], const GReal vcov_embed[GR_DIM], GReal vcov_native[GR_DIM]) const
-            {con_vec_to_embed(Xnative, vcov_embed, vcov_native);}
-        KOKKOS_INLINE_FUNCTION void cov_vec_to_embed(const GReal Xnative[GR_DIM], const GReal vcov_native[GR_DIM], GReal vcov_embed[GR_DIM]) const
-            {con_vec_to_native(Xnative, vcov_native, vcov_embed);}
+    // TENSOR TRANSFORMS
+    // Covariant first
+    KOKKOS_INLINE_FUNCTION void cov_tensor_to_embed(const GReal Xnative[GR_DIM],
+        const GReal tcov_native[GR_DIM][GR_DIM], GReal tcov_embed[GR_DIM][GR_DIM]) const
+    {
+        Real dXdx_temp[GR_DIM][GR_DIM];
+        dXdx(Xnative, dXdx_temp);
 
-        // TENSOR TRANSFORMS
-        // Covariant first
-        KOKKOS_INLINE_FUNCTION void cov_tensor_to_embed(const GReal Xnative[GR_DIM], const GReal tcov_native[GR_DIM][GR_DIM], GReal tcov_embed[GR_DIM][GR_DIM]) const
-        {
-            Real dXdx_temp[GR_DIM][GR_DIM];
-            dXdx(Xnative, dXdx_temp);
-
-            DLOOP2 {
-                tcov_embed[mu][nu] = 0;
-                for (int lam = 0; lam < GR_DIM; ++lam) {
-                    for (int kap = 0; kap < GR_DIM; ++kap) {
-                        tcov_embed[mu][nu] += tcov_native[lam][kap]*dXdx_temp[lam][mu]*dXdx_temp[kap][nu];
-                    }
+        DLOOP2 {
+            tcov_embed[mu][nu] = 0;
+            for (int lam = 0; lam < GR_DIM; ++lam) {
+                for (int kap = 0; kap < GR_DIM; ++kap) {
+                    tcov_embed[mu][nu] +=
+                        tcov_native[lam][kap] * dXdx_temp[lam][mu] * dXdx_temp[kap][nu];
                 }
             }
         }
-        KOKKOS_INLINE_FUNCTION void cov_tensor_to_native(const GReal Xnative[GR_DIM], const GReal tcov_embed[GR_DIM][GR_DIM], GReal tcov_native[GR_DIM][GR_DIM]) const
-        {
-            Real dxdX_temp[GR_DIM][GR_DIM];
-            dxdX(Xnative, dxdX_temp);
+    }
+    KOKKOS_INLINE_FUNCTION void cov_tensor_to_native(const GReal Xnative[GR_DIM],
+        const GReal tcov_embed[GR_DIM][GR_DIM], GReal tcov_native[GR_DIM][GR_DIM]) const
+    {
+        Real dxdX_temp[GR_DIM][GR_DIM];
+        dxdX(Xnative, dxdX_temp);
 
-            DLOOP2 {
-                tcov_native[mu][nu] = 0;
-                for (int lam = 0; lam < GR_DIM; lam++) {
-                    for (int kap = 0; kap < GR_DIM; kap++) {
-                        tcov_native[mu][nu] += tcov_embed[lam][kap]*dxdX_temp[lam][mu]*dxdX_temp[kap][nu];
-                    }
+        DLOOP2 {
+            tcov_native[mu][nu] = 0;
+            for (int lam = 0; lam < GR_DIM; lam++) {
+                for (int kap = 0; kap < GR_DIM; kap++) {
+                    tcov_native[mu][nu] +=
+                        tcov_embed[lam][kap] * dxdX_temp[lam][mu] * dxdX_temp[kap][nu];
                 }
             }
         }
-        // Con are opposite
-        KOKKOS_INLINE_FUNCTION void con_tensor_to_embed(const GReal Xnative[GR_DIM], const GReal tcon_native[GR_DIM][GR_DIM], GReal tcon_embed[GR_DIM][GR_DIM]) const
-            {cov_tensor_to_native(Xnative, tcon_native, tcon_embed);}
-        KOKKOS_INLINE_FUNCTION void con_tensor_to_native(const GReal Xnative[GR_DIM], const GReal tcon_embed[GR_DIM][GR_DIM], GReal tcon_native[GR_DIM][GR_DIM]) const
-            {cov_tensor_to_embed(Xnative, tcon_embed, tcon_native);}
+    }
+    // Con are opposite
+    KOKKOS_INLINE_FUNCTION void con_tensor_to_embed(const GReal Xnative[GR_DIM],
+        const GReal tcon_native[GR_DIM][GR_DIM], GReal tcon_embed[GR_DIM][GR_DIM]) const
+    {
+        cov_tensor_to_native(Xnative, tcon_native, tcon_embed);
+    }
+    KOKKOS_INLINE_FUNCTION void con_tensor_to_native(const GReal Xnative[GR_DIM],
+        const GReal tcon_embed[GR_DIM][GR_DIM], GReal tcon_native[GR_DIM][GR_DIM]) const
+    {
+        cov_tensor_to_embed(Xnative, tcon_embed, tcon_native);
+    }
 
-        // And then derived metric properties
-        KOKKOS_INLINE_FUNCTION void gcov_native(const GReal Xnative[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            Real gcov_em[GR_DIM][GR_DIM];
-            GReal Xembed[GR_DIM];
-            // Get coordinates in embedding system
-            coord_to_embed(Xnative, Xembed);
+    // And then derived metric properties
+    KOKKOS_INLINE_FUNCTION void gcov_native(
+        const GReal Xnative[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        Real gcov_em[GR_DIM][GR_DIM];
+        GReal Xembed[GR_DIM];
+        // Get coordinates in embedding system
+        coord_to_embed(Xnative, Xembed);
 
-            // Get metric in embedding coordinates
-            gcov_embed(Xembed, gcov_em);
+        // Get metric in embedding coordinates
+        gcov_embed(Xembed, gcov_em);
 
-            // Transform to native coordinates
-            cov_tensor_to_native(Xnative, gcov_em, gcov);
+        // Transform to native coordinates
+        cov_tensor_to_native(Xnative, gcov_em, gcov);
+    }
+    KOKKOS_INLINE_FUNCTION Real gcon_native(
+        const GReal X[GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
+    {
+        Real gcov[GR_DIM][GR_DIM];
+        gcov_native(X, gcov);
+        return gcon_from_gcov(gcov, gcon);
+    }
+    KOKKOS_INLINE_FUNCTION Real gdet_native(const GReal X[GR_DIM]) const
+    {
+        Real gcon[GR_DIM][GR_DIM];
+        return gcon_native(X, gcon);
+    }
+
+    KOKKOS_INLINE_FUNCTION void conn_native(
+        const GReal X[GR_DIM], const GReal delta, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
+    {
+        GReal tmp[GR_DIM][GR_DIM][GR_DIM];
+        GReal gcon[GR_DIM][GR_DIM];
+        GReal Xh[GR_DIM], Xl[GR_DIM];
+        GReal gh[GR_DIM][GR_DIM];
+        GReal gl[GR_DIM][GR_DIM];
+
+        for (int nu = 0; nu < GR_DIM; nu++) {
+            DLOOP1
+                Xl[mu] = X[mu] - delta * (mu == nu);
+            DLOOP1
+                Xh[mu] = X[mu] + delta * (mu == nu);
+            gcov_native(Xh, gh);
+            gcov_native(Xl, gl);
+
+            for (int lam = 0; lam < GR_DIM; lam++) {
+                for (int kap = 0; kap < GR_DIM; kap++) {
+                    conn[lam][kap][nu] =
+                        (gh[lam][kap] - gl[lam][kap]) / (Xh[nu] - Xl[nu]);
+                }
+            }
         }
-        KOKKOS_INLINE_FUNCTION Real gcon_native(const GReal X[GR_DIM], Real gcon[GR_DIM][GR_DIM]) const
-        {
-            Real gcov[GR_DIM][GR_DIM];
-            gcov_native(X, gcov);
-            return gcon_from_gcov(gcov, gcon);
-        }
-        KOKKOS_INLINE_FUNCTION Real gdet_native(const GReal X[GR_DIM]) const
-        {
-            Real gcon[GR_DIM][GR_DIM];
-            return gcon_native(X, gcon);
-        }
 
-        KOKKOS_INLINE_FUNCTION void conn_native(const GReal X[GR_DIM], const GReal delta, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
-        {
-            GReal tmp[GR_DIM][GR_DIM][GR_DIM];
-            GReal gcon[GR_DIM][GR_DIM];
-            GReal Xh[GR_DIM], Xl[GR_DIM];
-            GReal gh[GR_DIM][GR_DIM];
-            GReal gl[GR_DIM][GR_DIM];
-
+        // Rearrange to find \Gamma_{lam nu mu}
+        for (int lam = 0; lam < GR_DIM; lam++) {
             for (int nu = 0; nu < GR_DIM; nu++) {
-                DLOOP1 Xl[mu] = X[mu] - delta*(mu == nu);
-                DLOOP1 Xh[mu] = X[mu] + delta*(mu == nu);
-                gcov_native(Xh, gh);
-                gcov_native(Xl, gl);
-
-                for (int lam = 0; lam < GR_DIM; lam++) {
-                    for (int kap = 0; kap < GR_DIM; kap++) {
-                        conn[lam][kap][nu] = (gh[lam][kap] - gl[lam][kap])/
-                                                        (Xh[nu] - Xl[nu]);
-                    }
-                }
-            }
-
-            // Rearrange to find \Gamma_{lam nu mu}
-            for (int lam = 0; lam < GR_DIM; lam++) {
-                for (int nu = 0; nu < GR_DIM; nu++) {
-                    for (int mu = 0; mu < GR_DIM; mu++) {
-                        tmp[lam][nu][mu] = 0.5 * (conn[nu][lam][mu] +
-                                                  conn[mu][lam][nu] -
-                                                  conn[mu][nu][lam]);
-                    }
-                }
-            }
-
-            // Need gcon for raising index
-            gcon_native(X, gcon);
-
-            // Raise index to get \Gamma^lam_{nu mu}
-            for (int lam = 0; lam < GR_DIM; lam++) {
-                for (int nu = 0; nu < GR_DIM; nu++) {
-                    for (int mu = 0; mu < GR_DIM; mu++) {
-                        conn[lam][nu][mu] = 0.;
-
-                        for (int kap = 0; kap < GR_DIM; kap++)
-                            conn[lam][nu][mu] += gcon[lam][kap] * tmp[kap][nu][mu];
-                    }
+                for (int mu = 0; mu < GR_DIM; mu++) {
+                    tmp[lam][nu][mu] =
+                        0.5 * (conn[nu][lam][mu] + conn[mu][lam][nu] - conn[mu][nu][lam]);
                 }
             }
         }
 
-        /**
-         * Takes a velocity in Boyer-Lindquist coordinates (optionally without time component) and converts it
-         * to KS, and then to native coordinates.
-         * Not guaranteed to be fast.
-         */
-        KOKKOS_INLINE_FUNCTION void bl_fourvel_to_native(const Real Xnative[GR_DIM], const Real ucon_bl[GR_DIM], Real ucon_native[GR_DIM]) const
-        {
-            GReal Xembed[GR_DIM];
-            coord_to_embed(Xnative, Xembed);
+        // Need gcon for raising index
+        gcon_native(X, gcon);
 
-            // Set u^t to make u a velocity 4-vector in BL
-            GReal gcov_bl[GR_DIM][GR_DIM];
-            if (mpark::holds_alternative<SphKSCoords>(base) ||
-                mpark::holds_alternative<SphBLCoords>(base)) {
-                SphBLCoords(get_a()).gcov_embed(Xembed, gcov_bl);
-            } else if (mpark::holds_alternative<SphKSExtG>(base) ||
-                       mpark::holds_alternative<SphBLExtG>(base)) {
-                SphBLExtG(get_a()).gcov_embed(Xembed, gcov_bl);
+        // Raise index to get \Gamma^lam_{nu mu}
+        for (int lam = 0; lam < GR_DIM; lam++) {
+            for (int nu = 0; nu < GR_DIM; nu++) {
+                for (int mu = 0; mu < GR_DIM; mu++) {
+                    conn[lam][nu][mu] = 0.;
+
+                    for (int kap = 0; kap < GR_DIM; kap++)
+                        conn[lam][nu][mu] += gcon[lam][kap] * tmp[kap][nu][mu];
+                }
             }
-
-            Real ucon_bl_fourv[GR_DIM];
-            DLOOP1 ucon_bl_fourv[mu] = ucon_bl[mu];
-            set_ut(gcov_bl, ucon_bl_fourv);
-
-            // Then transform that 4-vector to KS (or not, if we're using BL base coords)
-            Real ucon_base[GR_DIM];
-            if (mpark::holds_alternative<SphKSCoords>(base)) {
-                mpark::get<SphKSCoords>(base).vec_from_bl(Xembed, ucon_bl_fourv, ucon_base);
-            } else if (mpark::holds_alternative<SphKSExtG>(base)) {
-                mpark::get<SphKSExtG>(base).vec_from_bl(Xembed, ucon_bl_fourv, ucon_base);
-            } else if (mpark::holds_alternative<SphBLCoords>(base) ||
-                       mpark::holds_alternative<SphBLExtG>(base)) {
-                DLOOP1 ucon_base[mu] = ucon_bl_fourv[mu];
-            }
-            // Finally, apply any transform to native coordinates
-            con_vec_to_native(Xnative, ucon_base, ucon_native);
         }
+    }
+
+    /**
+     * Takes a velocity in Boyer-Lindquist coordinates (optionally without time component)
+     * and converts it to KS, and then to native coordinates. Not guaranteed to be fast.
+     */
+    KOKKOS_INLINE_FUNCTION void bl_fourvel_to_native(const Real Xnative[GR_DIM],
+        const Real ucon_bl[GR_DIM], Real ucon_native[GR_DIM]) const
+    {
+        GReal Xembed[GR_DIM];
+        coord_to_embed(Xnative, Xembed);
+
+        // Set u^t to make u a velocity 4-vector in BL
+        GReal gcov_bl[GR_DIM][GR_DIM];
+        if (mpark::holds_alternative<SphKSCoords>(base) ||
+            mpark::holds_alternative<SphBLCoords>(base)) {
+            SphBLCoords(get_a()).gcov_embed(Xembed, gcov_bl);
+        } else if (mpark::holds_alternative<SphKSExtG>(base) ||
+                   mpark::holds_alternative<SphBLExtG>(base)) {
+            SphBLExtG(get_a()).gcov_embed(Xembed, gcov_bl);
+        }
+
+        Real ucon_bl_fourv[GR_DIM];
+        DLOOP1
+            ucon_bl_fourv[mu] = ucon_bl[mu];
+        set_ut(gcov_bl, ucon_bl_fourv);
+
+        // Then transform that 4-vector to KS (or not, if we're using BL base coords)
+        Real ucon_base[GR_DIM];
+        if (mpark::holds_alternative<SphKSCoords>(base)) {
+            mpark::get<SphKSCoords>(base).vec_from_bl(Xembed, ucon_bl_fourv, ucon_base);
+        } else if (mpark::holds_alternative<SphKSExtG>(base)) {
+            mpark::get<SphKSExtG>(base).vec_from_bl(Xembed, ucon_bl_fourv, ucon_base);
+        } else if (mpark::holds_alternative<SphBLCoords>(base) ||
+                   mpark::holds_alternative<SphBLExtG>(base)) {
+            DLOOP1
+                ucon_base[mu] = ucon_bl_fourv[mu];
+        }
+        // Finally, apply any transform to native coordinates
+        con_vec_to_native(Xnative, ucon_base, ucon_native);
+    }
 };

--- a/kharma/coordinates/coordinate_systems.hpp
+++ b/kharma/coordinates/coordinate_systems.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: coordinate_systems.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,13 +35,13 @@
 
 // See note in coordintate_embedding
 #include <mpark/variant.hpp>
-//#include <variant>
-//namespace mpark = std;
+// #include <variant>
+// namespace mpark = std;
 
 #include "decs.hpp"
 
-#include "matrix.hpp"
 #include "kharma_utils.hpp"
+#include "matrix.hpp"
 #include "root_find.hpp"
 
 #define LEGACY_TH 1
@@ -50,15 +50,16 @@
  * Embedding/Base systems implemented:
  * Minkowski space: Cartesian and Spherical coordinates
  * Kerr Space: Spherical KS and BL coordinates
- * 
+ *
  * Transformations:
  * Nulls in Cartesian and Spherical coordinates
  * "Modified": r=exp(x1), th=pi*x2 + (1-hslope)*etc
  * "Funky" modified: additional non-invertible cylindrization of th
- * 
+ *
  * TODO Cartesian KS base
  * TODO snake coordinate transform for Cartesian Minkowski
- * TODO CMKS, MKS3 transforms, proper Cartesian<->Spherical functions stolen from e.g. coordinate_utils.hpp
+ * TODO CMKS, MKS3 transforms, proper Cartesian<->Spherical functions stolen from e.g.
+ * coordinate_utils.hpp
  * TODO overhaul the LEGACY_TH stuff
  * TODO currently avoids returning gcov which might be singular,
  *      is this the correct play vs handling in inversions?
@@ -67,681 +68,817 @@
 /**
  * EMBEDDING SYSTEMS:
  * These are the usual systems of coordinates for different spacetimes.
- * Each system/class must define at least gcov_embed, returning the metric in terms of their own coordinates Xembed
- * Some extra convenience classes have been defined for some systems.
+ * Each system/class must define at least gcov_embed, returning the metric in terms of
+ * their own coordinates Xembed Some extra convenience classes have been defined for some
+ * systems.
  */
 
 /**
  * Cartesian Coordinates over flat space.
  */
-class CartMinkowskiCoords {
-    public:
-        static constexpr char name[] = "CartMinkowskiCoords";
-        static constexpr bool spherical = false;
-        static constexpr GReal a = 0.0;
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            DLOOP2 gcov[mu][nu] = (mu == nu) - 2*(mu == 0 && nu == 0);
-        }
+class CartMinkowskiCoords
+{
+  public:
+    static constexpr char name[] = "CartMinkowskiCoords";
+    static constexpr bool spherical = false;
+    static constexpr GReal a = 0.0;
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        DLOOP2
+            gcov[mu][nu] = (mu == nu) - 2 * (mu == 0 && nu == 0);
+    }
 };
 
 /**
  * Spherical coordinates for flat space
  */
-class SphMinkowskiCoords {
-    public:
-        static constexpr char name[] = "SphMinkowskiCoords";
-        static constexpr bool spherical = true;
-        static constexpr GReal a = 0.0;
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            const GReal r = m::max(Xembed[1], SMALL_NUM);
-            const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
-            const GReal sth = m::sin(th);
+class SphMinkowskiCoords
+{
+  public:
+    static constexpr char name[] = "SphMinkowskiCoords";
+    static constexpr bool spherical = true;
+    static constexpr GReal a = 0.0;
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        const GReal r = m::max(Xembed[1], SMALL_NUM);
+        const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        const GReal sth = m::sin(th);
 
-            gzero2(gcov);
-            gcov[0][0] = 1.;
-            gcov[1][1] = 1.;
-            gcov[2][2] = r*r;
-            gcov[3][3] = sth*sth*r*r;
-        }
+        gzero2(gcov);
+        gcov[0][0] = 1.;
+        gcov[1][1] = 1.;
+        gcov[2][2] = r * r;
+        gcov[3][3] = sth * sth * r * r;
+    }
 };
 
 /**
  * Spherical Kerr-Schild coordinates
  */
-class SphKSCoords {
-    public:
-        static constexpr char name[] = "SphKSCoords";
-        // BH Spin is a property of KS
-        const GReal a;
-        static constexpr bool spherical = true;
+class SphKSCoords
+{
+  public:
+    static constexpr char name[] = "SphKSCoords";
+    // BH Spin is a property of KS
+    const GReal a;
+    static constexpr bool spherical = true;
 
-        KOKKOS_FUNCTION SphKSCoords(GReal spin): a(spin) {};
+    KOKKOS_FUNCTION SphKSCoords(GReal spin)
+        : a(spin) {};
 
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            const GReal r = Xembed[1];
-            const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        const GReal r = Xembed[1];
+        const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
 
-            const GReal cth = m::cos(th);
-            const GReal sth = m::sin(th);
-            const GReal sin2 = sth*sth;
-            const GReal rho2 = r*r + a*a*cth*cth;
+        const GReal cth = m::cos(th);
+        const GReal sth = m::sin(th);
+        const GReal sin2 = sth * sth;
+        const GReal rho2 = r * r + a * a * cth * cth;
 
-            gcov[0][0] = -1. + 2.*r/rho2;
-            gcov[0][1] = 2.*r/rho2;
-            gcov[0][2] = 0.;
-            gcov[0][3] = -2.*a*r*sin2/rho2;
+        gcov[0][0] = -1. + 2. * r / rho2;
+        gcov[0][1] = 2. * r / rho2;
+        gcov[0][2] = 0.;
+        gcov[0][3] = -2. * a * r * sin2 / rho2;
 
-            gcov[1][0] = 2.*r/rho2;
-            gcov[1][1] = 1. + 2.*r/rho2;
-            gcov[1][2] = 0.;
-            gcov[1][3] = -a*sin2*(1. + 2.*r/rho2);
+        gcov[1][0] = 2. * r / rho2;
+        gcov[1][1] = 1. + 2. * r / rho2;
+        gcov[1][2] = 0.;
+        gcov[1][3] = -a * sin2 * (1. + 2. * r / rho2);
 
-            gcov[2][0] = 0.;
-            gcov[2][1] = 0.;
-            gcov[2][2] = rho2;
-            gcov[2][3] = 0.;
+        gcov[2][0] = 0.;
+        gcov[2][1] = 0.;
+        gcov[2][2] = rho2;
+        gcov[2][3] = 0.;
 
-            gcov[3][0] = -2.*a*r*sin2/rho2;
-            gcov[3][1] = -a*sin2*(1. + 2.*r/rho2);
-            gcov[3][2] = 0.;
-            gcov[3][3] = sin2*(rho2 + a*a*sin2*(1. + 2.*r/rho2));
-        }
+        gcov[3][0] = -2. * a * r * sin2 / rho2;
+        gcov[3][1] = -a * sin2 * (1. + 2. * r / rho2);
+        gcov[3][2] = 0.;
+        gcov[3][3] = sin2 * (rho2 + a * a * sin2 * (1. + 2. * r / rho2));
+    }
 
-        // For converting from BL
-        KOKKOS_INLINE_FUNCTION void vec_from_bl(const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
-        {
-            GReal r = Xembed[1];
-            Real trans[GR_DIM][GR_DIM];
-            DLOOP2 trans[mu][nu] = (mu == nu);
-            trans[0][1] = 2.*r/(r*r - 2.*r + a*a);
-            trans[3][1] = a/(r*r - 2.*r + a*a);
+    // For converting from BL
+    KOKKOS_INLINE_FUNCTION void vec_from_bl(
+        const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
+    {
+        GReal r = Xembed[1];
+        Real trans[GR_DIM][GR_DIM];
+        DLOOP2
+            trans[mu][nu] = (mu == nu);
+        trans[0][1] = 2. * r / (r * r - 2. * r + a * a);
+        trans[3][1] = a / (r * r - 2. * r + a * a);
 
-            gzero(vcon);
-            DLOOP2 vcon[mu] += trans[mu][nu]*vcon_bl[nu];
-        }
+        gzero(vcon);
+        DLOOP2
+            vcon[mu] += trans[mu][nu] * vcon_bl[nu];
+    }
 
-        KOKKOS_INLINE_FUNCTION void vec_to_bl(const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
-        {
-            GReal r = Xembed[1];
-            GReal rtrans[GR_DIM][GR_DIM], trans[GR_DIM][GR_DIM];
-            DLOOP2 rtrans[mu][nu] = (mu == nu);
-            rtrans[0][1] = 2.*r/(r*r - 2.*r + a*a);
-            rtrans[3][1] = a/(r*r - 2.*r + a*a);
+    KOKKOS_INLINE_FUNCTION void vec_to_bl(
+        const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
+    {
+        GReal r = Xembed[1];
+        GReal rtrans[GR_DIM][GR_DIM], trans[GR_DIM][GR_DIM];
+        DLOOP2
+            rtrans[mu][nu] = (mu == nu);
+        rtrans[0][1] = 2. * r / (r * r - 2. * r + a * a);
+        rtrans[3][1] = a / (r * r - 2. * r + a * a);
 
-            invert(&rtrans[0][0], &trans[0][0]);
+        invert(&rtrans[0][0], &trans[0][0]);
 
-            gzero(vcon);
-            DLOOP2 vcon[mu] += trans[mu][nu]*vcon_bl[nu];
-        }
+        gzero(vcon);
+        DLOOP2
+            vcon[mu] += trans[mu][nu] * vcon_bl[nu];
+    }
 };
 
 /**
  * Spherical Kerr-Schild coordinates w/ external gravity term
  */
-class SphKSExtG {
-    public:
-        static constexpr char name[] = "SphKSExtG";
-        // BH Spin is a property of KS
-        const GReal a;
-        static constexpr bool spherical = true;
+class SphKSExtG
+{
+  public:
+    static constexpr char name[] = "SphKSExtG";
+    // BH Spin is a property of KS
+    const GReal a;
+    static constexpr bool spherical = true;
 
-        static constexpr GReal A = 4.24621057e-9; //1.46797639e-8;
-        static constexpr GReal B = 1.35721335; //1.29411117;
+    static constexpr GReal A = 4.24621057e-9; // 1.46797639e-8;
+    static constexpr GReal B = 1.35721335;    // 1.29411117;
 
-        KOKKOS_FUNCTION SphKSExtG(GReal spin): a(spin) {};
+    KOKKOS_FUNCTION SphKSExtG(GReal spin)
+        : a(spin) {};
 
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            const GReal r = Xembed[1];
-            const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        const GReal r = Xembed[1];
+        const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
 
-            const GReal cth = m::cos(th);
-            const GReal sth = m::sin(th);
-            const GReal sin2 = sth*sth;
-            const GReal rho2 = r*r + a*a*cth*cth;
+        const GReal cth = m::cos(th);
+        const GReal sth = m::sin(th);
+        const GReal sin2 = sth * sth;
+        const GReal rho2 = r * r + a * a * cth * cth;
 
-            const GReal Phi_g = (A / (B - 1.)) * (m::pow(r, B-1.) - m::pow(2, B-1.));
+        const GReal Phi_g = (A / (B - 1.)) * (m::pow(r, B - 1.) - m::pow(2, B - 1.));
 
-            gcov[0][0] = -1. + 2.*r/rho2 - 2. * Phi_g;
-            gcov[0][1] = 2.*r/rho2 - 2. * Phi_g;
-            gcov[0][2] = 0.;
-            gcov[0][3] = -2.*a*r*sin2/rho2;
+        gcov[0][0] = -1. + 2. * r / rho2 - 2. * Phi_g;
+        gcov[0][1] = 2. * r / rho2 - 2. * Phi_g;
+        gcov[0][2] = 0.;
+        gcov[0][3] = -2. * a * r * sin2 / rho2;
 
-            gcov[1][0] = 2.*r/rho2 - 2. * Phi_g;
-            gcov[1][1] = 1. + 2.*r/rho2 - 2. * Phi_g;
-            gcov[1][2] = 0.;
-            gcov[1][3] = -a*sin2*(1. + 2.*r/rho2);
+        gcov[1][0] = 2. * r / rho2 - 2. * Phi_g;
+        gcov[1][1] = 1. + 2. * r / rho2 - 2. * Phi_g;
+        gcov[1][2] = 0.;
+        gcov[1][3] = -a * sin2 * (1. + 2. * r / rho2);
 
-            gcov[2][0] = 0.;
-            gcov[2][1] = 0.;
-            gcov[2][2] = rho2;
-            gcov[2][3] = 0.;
+        gcov[2][0] = 0.;
+        gcov[2][1] = 0.;
+        gcov[2][2] = rho2;
+        gcov[2][3] = 0.;
 
-            gcov[3][0] = -2.*a*r*sin2/rho2;
-            gcov[3][1] = -a*sin2*(1. + 2.*r/rho2);
-            gcov[3][2] = 0.;
-            gcov[3][3] = sin2*(rho2 + a*a*sin2*(1. + 2.*r/rho2));
-        }
+        gcov[3][0] = -2. * a * r * sin2 / rho2;
+        gcov[3][1] = -a * sin2 * (1. + 2. * r / rho2);
+        gcov[3][2] = 0.;
+        gcov[3][3] = sin2 * (rho2 + a * a * sin2 * (1. + 2. * r / rho2));
+    }
 
-        // For converting from BL
-        // TODO will we ever need a from_ks?
-        KOKKOS_INLINE_FUNCTION void vec_from_bl(const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
-        {
-            GReal r = Xembed[1];
-            Real trans[GR_DIM][GR_DIM];
-            DLOOP2 trans[mu][nu] = (mu == nu);
+    // For converting from BL
+    // TODO will we ever need a from_ks?
+    KOKKOS_INLINE_FUNCTION void vec_from_bl(
+        const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
+    {
+        GReal r = Xembed[1];
+        Real trans[GR_DIM][GR_DIM];
+        DLOOP2
+            trans[mu][nu] = (mu == nu);
 
-            // external gravity from GIZMO
-            const GReal Phi_g = (A/(B-1.)) * (m::pow(r,B-1.)-m::pow(2,B-1.));
+        // external gravity from GIZMO
+        const GReal Phi_g = (A / (B - 1.)) * (m::pow(r, B - 1.) - m::pow(2, B - 1.));
 
-            trans[0][1] = (2./r - 2.*Phi_g)/(1. - 2./r + 2.*Phi_g);
-            trans[3][1] = a/(r*r - 2.*r + a*a);
+        trans[0][1] = (2. / r - 2. * Phi_g) / (1. - 2. / r + 2. * Phi_g);
+        trans[3][1] = a / (r * r - 2. * r + a * a);
 
-            gzero(vcon);
-            DLOOP2 vcon[mu] += trans[mu][nu]*vcon_bl[nu];
-        }
+        gzero(vcon);
+        DLOOP2
+            vcon[mu] += trans[mu][nu] * vcon_bl[nu];
+    }
 
-        KOKKOS_INLINE_FUNCTION void vec_to_bl(const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
-        {
-            GReal r = Xembed[1];
-            GReal rtrans[GR_DIM][GR_DIM], trans[GR_DIM][GR_DIM];
-            DLOOP2 rtrans[mu][nu] = (mu == nu);
+    KOKKOS_INLINE_FUNCTION void vec_to_bl(
+        const GReal Xembed[GR_DIM], const Real vcon_bl[GR_DIM], Real vcon[GR_DIM]) const
+    {
+        GReal r = Xembed[1];
+        GReal rtrans[GR_DIM][GR_DIM], trans[GR_DIM][GR_DIM];
+        DLOOP2
+            rtrans[mu][nu] = (mu == nu);
 
-            const GReal Phi_g = (A / (B-1.)) * (m::pow(r, B-1.) - m::pow(2, B-1.));
+        const GReal Phi_g = (A / (B - 1.)) * (m::pow(r, B - 1.) - m::pow(2, B - 1.));
 
-            rtrans[0][1] = (2./r - 2.*Phi_g)/(1. - 2./r + 2.*Phi_g);
-            rtrans[3][1] = a/(r*r - 2.*r + a*a);
+        rtrans[0][1] = (2. / r - 2. * Phi_g) / (1. - 2. / r + 2. * Phi_g);
+        rtrans[3][1] = a / (r * r - 2. * r + a * a);
 
-            invert(&rtrans[0][0], &trans[0][0]);
+        invert(&rtrans[0][0], &trans[0][0]);
 
-            gzero(vcon);
-            DLOOP2 vcon[mu] += trans[mu][nu]*vcon_bl[nu];
-        }
+        gzero(vcon);
+        DLOOP2
+            vcon[mu] += trans[mu][nu] * vcon_bl[nu];
+    }
 };
 
 /**
  * Boyer-Lindquist coordinates as an embedding system
  */
-class SphBLCoords {
-    public:
-        static constexpr char name[] = "SphBLCoords";
-        // BH Spin is a property of BL
-        const GReal a;
-        static constexpr bool spherical = true;
+class SphBLCoords
+{
+  public:
+    static constexpr char name[] = "SphBLCoords";
+    // BH Spin is a property of BL
+    const GReal a;
+    static constexpr bool spherical = true;
 
-        KOKKOS_FUNCTION SphBLCoords(GReal spin): a(spin) {}
+    KOKKOS_FUNCTION SphBLCoords(GReal spin)
+        : a(spin)
+    {}
 
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            const GReal r = Xembed[1];
-            const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
-            const GReal cth = m::cos(th), sth = m::sin(th);
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        const GReal r = Xembed[1];
+        const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        const GReal cth = m::cos(th), sth = m::sin(th);
 
-            const GReal sin2 = sth*sth;
-            const GReal a2 = a*a;
-            const GReal r2 = r*r;
-            // TODO(BSP) this and gcov_embed for KS should look more similar...
-            const GReal mmu = 1. + a2*cth*cth/r2; // mu is taken as an index
+        const GReal sin2 = sth * sth;
+        const GReal a2 = a * a;
+        const GReal r2 = r * r;
+        // TODO(CEP) this and gcov_embed for KS should look more similar...
+        const GReal mmu = 1. + a2 * cth * cth / r2; // mu is taken as an index
 
-            gzero2(gcov);
-            gcov[0][0]  = -(1. - 2./(r*mmu));
-            gcov[0][3]  = -2.*a*sin2/(r*mmu);
-            gcov[1][1]   = mmu/(1. - 2./r + a2/r2);
-            gcov[2][2]   = r2*mmu;
-            gcov[3][0]  = -2.*a*sin2/(r*mmu);
-            gcov[3][3]   = sin2*(r2 + a2 + 2.*a2*sin2/(r*mmu));
-        }
+        gzero2(gcov);
+        gcov[0][0] = -(1. - 2. / (r * mmu));
+        gcov[0][3] = -2. * a * sin2 / (r * mmu);
+        gcov[1][1] = mmu / (1. - 2. / r + a2 / r2);
+        gcov[2][2] = r2 * mmu;
+        gcov[3][0] = -2. * a * sin2 / (r * mmu);
+        gcov[3][3] = sin2 * (r2 + a2 + 2. * a2 * sin2 / (r * mmu));
+    }
 
-        // TODO(BSP) vec to/from ks, put guaranteed ks/bl fns into embedding
-
+    // TODO(CEP) vec to/from ks, put guaranteed ks/bl fns into embedding
 };
 
 /**
  * Boyer-Lindquist coordinates as an embedding system
  */
-class SphBLExtG {
-    public:
-        static constexpr char name[] = "SphBLExtG";
-        // BH Spin is a property of BL
-        const GReal a;
-        static constexpr bool spherical = true;
+class SphBLExtG
+{
+  public:
+    static constexpr char name[] = "SphBLExtG";
+    // BH Spin is a property of BL
+    const GReal a;
+    static constexpr bool spherical = true;
 
-        static constexpr GReal A = 4.24621057e-9; //1.46797639e-8;
-        static constexpr GReal B = 1.35721335; //1.29411117;
+    static constexpr GReal A = 4.24621057e-9; // 1.46797639e-8;
+    static constexpr GReal B = 1.35721335;    // 1.29411117;
 
-        KOKKOS_FUNCTION SphBLExtG(GReal spin): a(spin) {}
+    KOKKOS_FUNCTION SphBLExtG(GReal spin)
+        : a(spin)
+    {}
 
-        KOKKOS_INLINE_FUNCTION void gcov_embed(const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
-        {
-            const GReal r = Xembed[1];
-            const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
-            const GReal cth = m::cos(th), sth = m::sin(th);
+    KOKKOS_INLINE_FUNCTION void gcov_embed(
+        const GReal Xembed[GR_DIM], Real gcov[GR_DIM][GR_DIM]) const
+    {
+        const GReal r = Xembed[1];
+        const GReal th = excise(excise(Xembed[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        const GReal cth = m::cos(th), sth = m::sin(th);
 
-            const GReal sin2 = sth*sth;
-            const GReal a2 = a*a;
-            const GReal r2 = r*r;
-            const GReal mmu = 1. + a2*cth*cth/r2; // mu is taken as an index
+        const GReal sin2 = sth * sth;
+        const GReal a2 = a * a;
+        const GReal r2 = r * r;
+        const GReal mmu = 1. + a2 * cth * cth / r2; // mu is taken as an index
 
-            const GReal Phi_g = (A / (B-1.)) * (m::pow(r, B-1.) - m::pow(2, B-1.));
+        const GReal Phi_g = (A / (B - 1.)) * (m::pow(r, B - 1.) - m::pow(2, B - 1.));
 
-            gzero2(gcov);
-            gcov[0][0]  = -(1. - 2./(r*mmu)) - 2. * Phi_g;;
-            gcov[0][3]  = -2.*a*sin2/(r*mmu);
-            gcov[1][1]   = mmu / (1. - 2./r + 2.*Phi_g);
-            gcov[2][2]   = r2*mmu;
-            gcov[3][0]  = -2.*a*sin2/(r*mmu);
-            gcov[3][3]   = sin2*(r2 + a2 + 2.*a2*sin2/(r*mmu));
-        }
+        gzero2(gcov);
+        gcov[0][0] = -(1. - 2. / (r * mmu)) - 2. * Phi_g;
+        ;
+        gcov[0][3] = -2. * a * sin2 / (r * mmu);
+        gcov[1][1] = mmu / (1. - 2. / r + 2. * Phi_g);
+        gcov[2][2] = r2 * mmu;
+        gcov[3][0] = -2. * a * sin2 / (r * mmu);
+        gcov[3][3] = sin2 * (r2 + a2 + 2. * a2 * sin2 / (r * mmu));
+    }
 };
 
 /**
  * COORDINATE TRANSFORMS:
  * These are transformations which can be applied to base coordinates
- * Each class must define enough functions to apply the transform to coordinates and vectors,
- * both forward and in reverse.
- * That comes out to 4 functions: coord_to_embed, coord_to_native, dXdx, dxdX
+ * Each class must define enough functions to apply the transform to coordinates and
+ * vectors, both forward and in reverse. That comes out to 4 functions: coord_to_embed,
+ * coord_to_native, dXdx, dxdX
  */
 
 /**
- * This class represents a null transformation from the embedding cooridnates, i.e. just using them directly
+ * This class represents a null transformation from the embedding cooridnates, i.e. just
+ * using them directly
  */
-class NullTransform {
-    public:
-        static constexpr char name[] = "NullTransform";
-        static constexpr GReal startx[3] = {-1, -1, -1};
-        static constexpr GReal stopx[3] = {-1, -1, -1};
-        // Coordinate transformations
-        // Any coordinate value protections (th < 0, th > pi, phi > 2pi) should be in the base system
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            DLOOP1 Xembed[mu] = Xnative[mu];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            DLOOP1 Xnative[mu] = Xembed[mu];
-        }
-        // Tangent space transformation matrices
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal X[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            DLOOP2 dxdX[mu][nu] = (mu == nu);
-        }
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal X[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            DLOOP2 dXdx[mu][nu] = (mu == nu);
-        }
+class NullTransform
+{
+  public:
+    static constexpr char name[] = "NullTransform";
+    static constexpr GReal startx[3] = {-1, -1, -1};
+    static constexpr GReal stopx[3] = {-1, -1, -1};
+    // Coordinate transformations
+    // Any coordinate value protections (th < 0, th > pi, phi > 2pi) should be in the base
+    // system
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        DLOOP1
+            Xembed[mu] = Xnative[mu];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        DLOOP1
+            Xnative[mu] = Xembed[mu];
+    }
+    // Tangent space transformation matrices
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal X[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        DLOOP2
+            dxdX[mu][nu] = (mu == nu);
+    }
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal X[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        DLOOP2
+            dXdx[mu][nu] = (mu == nu);
+    }
 };
-// This only exists separately to define startx & stopx. Could fall back on base coords for these?
-class SphNullTransform {
-    public:
-        static constexpr char name[] = "SphNullTransform";
-        static constexpr GReal startx[3] = {-1, 0., 0.};
-        static constexpr GReal stopx[3] = {-1, M_PI, 2*M_PI};
-        // Coordinate transformations
-        // Any coordinate value protections (th < 0, th > pi, phi > 2pi) should be in the base system
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            DLOOP1 Xembed[mu] = Xnative[mu];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            DLOOP1 Xnative[mu] = Xembed[mu];
-        }
-        // Tangent space transformation matrices
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal X[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            DLOOP2 dxdX[mu][nu] = (mu == nu);
-        }
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal X[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            DLOOP2 dXdx[mu][nu] = (mu == nu);
-        }
+// This only exists separately to define startx & stopx. Could fall back on base coords
+// for these?
+class SphNullTransform
+{
+  public:
+    static constexpr char name[] = "SphNullTransform";
+    static constexpr GReal startx[3] = {-1, 0., 0.};
+    static constexpr GReal stopx[3] = {-1, M_PI, 2 * M_PI};
+    // Coordinate transformations
+    // Any coordinate value protections (th < 0, th > pi, phi > 2pi) should be in the base
+    // system
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        DLOOP1
+            Xembed[mu] = Xnative[mu];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        DLOOP1
+            Xnative[mu] = Xembed[mu];
+    }
+    // Tangent space transformation matrices
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal X[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        DLOOP2
+            dxdX[mu][nu] = (mu == nu);
+    }
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal X[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        DLOOP2
+            dXdx[mu][nu] = (mu == nu);
+    }
 };
 
 /**
  * Just exponentiate the radial coordinate
  * Makes sense only for spherical base systems!
  */
-class ExponentialTransform {
-    public:
-        static constexpr char name[] = "ExponentialTransform";
-        static constexpr GReal startx[3] = {-1, 0., 0.};
-        static constexpr GReal stopx[3] = {-1, M_PI, 2*M_PI};
+class ExponentialTransform
+{
+  public:
+    static constexpr char name[] = "ExponentialTransform";
+    static constexpr GReal startx[3] = {-1, 0., 0.};
+    static constexpr GReal stopx[3] = {-1, M_PI, 2 * M_PI};
 
-        // Coordinate transformations
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            Xembed[0] = Xnative[0];
-            Xembed[1] = m::exp(Xnative[1]);
+    // Coordinate transformations
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        Xembed[0] = Xnative[0];
+        Xembed[1] = m::exp(Xnative[1]);
 #if LEGACY_TH
-            Xembed[2] = excise(excise(Xnative[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        Xembed[2] = excise(excise(Xnative[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
 #else
-            Xembed[2] = Xnative[2];
+        Xembed[2] = Xnative[2];
 #endif
-            Xembed[3] = Xnative[3];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            Xnative[0] = Xembed[0];
-            Xnative[1] = m::log(Xembed[1]);
-            Xnative[2] = Xembed[2];
-            Xnative[3] = Xembed[3];
-        }
-        /**
-         * Transformation matrix for contravariant vectors to embedding, or covariant vectors to native
-         */
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dxdX);
-            dxdX[0][0] = 1.;
-            dxdX[1][1] = m::exp(Xnative[1]);
-            dxdX[2][2] = 1.;
-            dxdX[3][3] = 1.;
-        }
-        /**
-         * Transformation matrix for contravariant vectors to native, or covariant vectors to embedding
-         */
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dXdx);
-            dXdx[0][0] = 1.;
-            dXdx[1][1] = 1 / m::exp(Xnative[1]);
-            dXdx[2][2] = 1.;
-            dXdx[3][3] = 1.;
-        }
+        Xembed[3] = Xnative[3];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        Xnative[0] = Xembed[0];
+        Xnative[1] = m::log(Xembed[1]);
+        Xnative[2] = Xembed[2];
+        Xnative[3] = Xembed[3];
+    }
+    /**
+     * Transformation matrix for contravariant vectors to embedding, or covariant vectors
+     * to native
+     */
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dxdX);
+        dxdX[0][0] = 1.;
+        dxdX[1][1] = m::exp(Xnative[1]);
+        dxdX[2][2] = 1.;
+        dxdX[3][3] = 1.;
+    }
+    /**
+     * Transformation matrix for contravariant vectors to native, or covariant vectors to
+     * embedding
+     */
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dXdx);
+        dXdx[0][0] = 1.;
+        dXdx[1][1] = 1 / m::exp(Xnative[1]);
+        dXdx[2][2] = 1.;
+        dXdx[3][3] = 1.;
+    }
 };
 
 /**
  * SuperExponential coordinates, for super simulations
  * Implementation follows HARMPI described in Tchekhovskoy+
  */
-class SuperExponentialTransform {
-    public:
-        static constexpr char name[] = "SuperExponentialTransform";
-        static constexpr GReal startx[3] = {-1, 0., 0.};
-        static constexpr GReal stopx[3] = {-1, M_PI, 2*M_PI};
+class SuperExponentialTransform
+{
+  public:
+    static constexpr char name[] = "SuperExponentialTransform";
+    static constexpr GReal startx[3] = {-1, 0., 0.};
+    static constexpr GReal stopx[3] = {-1, M_PI, 2 * M_PI};
 
-        const GReal xe1br, xn1br;
-        const double npow2, cpow2;
+    const GReal xe1br, xn1br;
+    const double npow2, cpow2;
 
-        // Constructor
-        KOKKOS_FUNCTION SuperExponentialTransform(GReal xe1br_in, double npow2_in, double cpow2_in):
-            xe1br(xe1br_in), npow2(npow2_in), cpow2(cpow2_in), xn1br(m::log(xe1br_in)) {}
+    // Constructor
+    KOKKOS_FUNCTION SuperExponentialTransform(
+        GReal xe1br_in, double npow2_in, double cpow2_in)
+        : xe1br(xe1br_in)
+        , npow2(npow2_in)
+        , cpow2(cpow2_in)
+        , xn1br(m::log(xe1br_in))
+    {}
 
-        // Coordinate transformations
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            Xembed[0] = Xnative[0];
-            const GReal super_dist = Xnative[1] - xn1br;
-            Xembed[1] = m::exp(Xnative[1] + (super_dist > 0) * cpow2 * m::pow(super_dist, npow2));
+    // Coordinate transformations
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        Xembed[0] = Xnative[0];
+        const GReal super_dist = Xnative[1] - xn1br;
+        Xembed[1] =
+            m::exp(Xnative[1] + (super_dist > 0) * cpow2 * m::pow(super_dist, npow2));
 #if LEGACY_TH
-            Xembed[2] = excise(excise(Xnative[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        Xembed[2] = excise(excise(Xnative[2], 0.0, SMALL_NUM), M_PI, SMALL_NUM);
 #else
-            Xembed[2] = Xnative[2];
+        Xembed[2] = Xnative[2];
 #endif
-            Xembed[3] = Xnative[3];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            Xnative[0] = Xembed[0];
-            Xnative[2] = Xembed[2];
-            Xnative[3] = Xembed[3];
-            // TODO can just take log for x1 < xe1br
-            ROOT_FIND_1
-        }
-        /**
-         * Transformation matrix for contravariant vectors to embedding, or covariant vectors to native
-         */
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dxdX);
-            dxdX[0][0] = 1.;
-            const GReal super_dist = Xnative[1] - xn1br;
-            dxdX[1][1] = m::exp(Xnative[1] + (super_dist > 0) * cpow2 * m::pow(super_dist, npow2))
-                            * (1 + (super_dist > 0) * cpow2 * npow2 * m::pow(super_dist, npow2-1));
-            dxdX[2][2] = 1.;
-            dxdX[3][3] = 1.;
-        }
-        /**
-         * Transformation matrix for contravariant vectors to native, or covariant vectors to embedding
-         */
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dXdx);
-            dXdx[0][0] = 1.;
-            const GReal super_dist = Xnative[1] - xn1br;
-            dXdx[1][1] = 1 / (m::exp(Xnative[1] + (super_dist > 0) * cpow2 * m::pow(super_dist, npow2))
-                              * (1 + (super_dist > 0) * cpow2 * npow2 * m::pow(super_dist, npow2-1)));
-            dXdx[2][2] = 1.;
-            dXdx[3][3] = 1.;
-        }
+        Xembed[3] = Xnative[3];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        Xnative[0] = Xembed[0];
+        Xnative[2] = Xembed[2];
+        Xnative[3] = Xembed[3];
+        // TODO can just take log for x1 < xe1br
+        ROOT_FIND_1
+    }
+    /**
+     * Transformation matrix for contravariant vectors to embedding, or covariant vectors
+     * to native
+     */
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dxdX);
+        dxdX[0][0] = 1.;
+        const GReal super_dist = Xnative[1] - xn1br;
+        dxdX[1][1] =
+            m::exp(Xnative[1] + (super_dist > 0) * cpow2 * m::pow(super_dist, npow2)) *
+            (1 + (super_dist > 0) * cpow2 * npow2 * m::pow(super_dist, npow2 - 1));
+        dxdX[2][2] = 1.;
+        dxdX[3][3] = 1.;
+    }
+    /**
+     * Transformation matrix for contravariant vectors to native, or covariant vectors to
+     * embedding
+     */
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dXdx);
+        dXdx[0][0] = 1.;
+        const GReal super_dist = Xnative[1] - xn1br;
+        dXdx[1][1] =
+            1 /
+            (m::exp(Xnative[1] + (super_dist > 0) * cpow2 * m::pow(super_dist, npow2)) *
+                (1 + (super_dist > 0) * cpow2 * npow2 * m::pow(super_dist, npow2 - 1)));
+        dXdx[2][2] = 1.;
+        dXdx[3][3] = 1.;
+    }
 };
 
 /**
  * Modified Kerr-Schild coordinates "MKS"
  * Makes sense only for spherical base systems!
  */
-class ModifyTransform {
-    public:
-        static constexpr char name[] = "ModifyTransform";
-        static constexpr GReal startx[3] = {-1, 0., 0.};
-        static constexpr GReal stopx[3] = {-1, 1., 2*M_PI};
+class ModifyTransform
+{
+  public:
+    static constexpr char name[] = "ModifyTransform";
+    static constexpr GReal startx[3] = {-1, 0., 0.};
+    static constexpr GReal stopx[3] = {-1, 1., 2 * M_PI};
 
-        const GReal hslope;
+    const GReal hslope;
 
-        // Constructor
-        KOKKOS_FUNCTION ModifyTransform(GReal hslope_in): hslope(hslope_in) {}
+    // Constructor
+    KOKKOS_FUNCTION ModifyTransform(GReal hslope_in)
+        : hslope(hslope_in)
+    {}
 
-        // Coordinate transformations
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            Xembed[0] = Xnative[0];
-            Xembed[1] = m::exp(Xnative[1]);
+    // Coordinate transformations
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        Xembed[0] = Xnative[0];
+        Xembed[1] = m::exp(Xnative[1]);
 #if LEGACY_TH
-            const GReal th = M_PI*Xnative[2] + ((1. - hslope)/2.)*m::sin(2.*M_PI*Xnative[2]);
-            Xembed[2] = excise(excise(th, 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        const GReal th =
+            M_PI * Xnative[2] + ((1. - hslope) / 2.) * m::sin(2. * M_PI * Xnative[2]);
+        Xembed[2] = excise(excise(th, 0.0, SMALL_NUM), M_PI, SMALL_NUM);
 #else
-            Xembed[2] = M_PI*Xnative[2] + ((1. - hslope)/2.)*m::sin(2.*M_PI*Xnative[2]);
+        Xembed[2] =
+            M_PI * Xnative[2] + ((1. - hslope) / 2.) * m::sin(2. * M_PI * Xnative[2]);
 #endif
-            Xembed[3] = Xnative[3];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            Xnative[0] = Xembed[0];
-            Xnative[1] = m::log(Xembed[1]);
-            Xnative[3] = Xembed[3];
-            // Treat the special case with a large macro
-            ROOT_FIND
-        }
-        /**
-         * Transformation matrix for contravariant vectors to embedding, or covariant vectors to native
-         */
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dxdX);
-            dxdX[0][0] = 1.;
-            dxdX[1][1] = m::exp(Xnative[1]);
-            dxdX[2][2] = M_PI - (hslope - 1.)*M_PI*m::cos(2.*M_PI*Xnative[2]);
-            dxdX[3][3] = 1.;
-        }
-        /**
-         * Transformation matrix for contravariant vectors to native, or covariant vectors to embedding
-         */
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dXdx);
-            dXdx[0][0] = 1.;
-            dXdx[1][1] = 1 / m::exp(Xnative[1]);
-            dXdx[2][2] = 1 / (M_PI - (hslope - 1.)*M_PI*m::cos(2.*M_PI*Xnative[2]));
-            dXdx[3][3] = 1.;
-        }
+        Xembed[3] = Xnative[3];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        Xnative[0] = Xembed[0];
+        Xnative[1] = m::log(Xembed[1]);
+        Xnative[3] = Xembed[3];
+        // Treat the special case with a large macro
+        ROOT_FIND
+    }
+    /**
+     * Transformation matrix for contravariant vectors to embedding, or covariant vectors
+     * to native
+     */
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dxdX);
+        dxdX[0][0] = 1.;
+        dxdX[1][1] = m::exp(Xnative[1]);
+        dxdX[2][2] = M_PI - (hslope - 1.) * M_PI * m::cos(2. * M_PI * Xnative[2]);
+        dxdX[3][3] = 1.;
+    }
+    /**
+     * Transformation matrix for contravariant vectors to native, or covariant vectors to
+     * embedding
+     */
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dXdx);
+        dXdx[0][0] = 1.;
+        dXdx[1][1] = 1 / m::exp(Xnative[1]);
+        dXdx[2][2] = 1 / (M_PI - (hslope - 1.) * M_PI * m::cos(2. * M_PI * Xnative[2]));
+        dXdx[3][3] = 1.;
+    }
 };
 
 /**
  * "Funky" Modified Kerr-Schild coordinates
  * Make sense only for spherical base systems!
  */
-class FunkyTransform {
-    public:
-        static constexpr char name[] = "FunkyTransform";
-        static constexpr GReal startx[3] = {-1, 0., 0.};
-        static constexpr GReal stopx[3] = {-1, 1., 2*M_PI};
+class FunkyTransform
+{
+  public:
+    static constexpr char name[] = "FunkyTransform";
+    static constexpr GReal startx[3] = {-1, 0., 0.};
+    static constexpr GReal stopx[3] = {-1, 1., 2 * M_PI};
 
-        const GReal startx1;
-        const GReal hslope, poly_xt, poly_alpha, mks_smooth;
-        // Must be *defined* afterward to use constructor below
-        const GReal poly_norm;
+    const GReal startx1;
+    const GReal hslope, poly_xt, poly_alpha, mks_smooth;
+    // Must be *defined* afterward to use constructor below
+    const GReal poly_norm;
 
-        // Constructor
-        KOKKOS_FUNCTION FunkyTransform(GReal startx1_in, GReal hslope_in, GReal mks_smooth_in, GReal poly_xt_in, GReal poly_alpha_in):
-            startx1(startx1_in), hslope(hslope_in), mks_smooth(mks_smooth_in), poly_xt(poly_xt_in), poly_alpha(poly_alpha_in),
-            poly_norm(0.5 * M_PI * 1./(1. + 1./(poly_alpha + 1.) * 1./m::pow(poly_xt, poly_alpha))) {}
+    // Constructor
+    KOKKOS_FUNCTION FunkyTransform(GReal startx1_in, GReal hslope_in, GReal mks_smooth_in,
+        GReal poly_xt_in, GReal poly_alpha_in)
+        : startx1(startx1_in)
+        , hslope(hslope_in)
+        , mks_smooth(mks_smooth_in)
+        , poly_xt(poly_xt_in)
+        , poly_alpha(poly_alpha_in)
+        , poly_norm(0.5 * M_PI * 1. /
+                    (1. + 1. / (poly_alpha + 1.) * 1. / m::pow(poly_xt, poly_alpha)))
+    {}
 
-        // Coordinate transformations
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            Xembed[0] = Xnative[0];
-            Xembed[1] = m::exp(Xnative[1]);
+    // Coordinate transformations
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        Xembed[0] = Xnative[0];
+        Xembed[1] = m::exp(Xnative[1]);
 
-            const GReal thG = M_PI*Xnative[2] + ((1. - hslope)/2.)*m::sin(2.*M_PI*Xnative[2]);
-            const GReal y = 2*Xnative[2] - 1.;
-            const GReal thJ = poly_norm * y * (1. + m::pow(y/poly_xt,poly_alpha) / (poly_alpha + 1.)) + 0.5 * M_PI;
+        const GReal thG =
+            M_PI * Xnative[2] + ((1. - hslope) / 2.) * m::sin(2. * M_PI * Xnative[2]);
+        const GReal y = 2 * Xnative[2] - 1.;
+        const GReal thJ =
+            poly_norm * y * (1. + m::pow(y / poly_xt, poly_alpha) / (poly_alpha + 1.)) +
+            0.5 * M_PI;
 #if LEGACY_TH
-            const GReal th = thG + m::exp(mks_smooth * (startx1 - Xnative[1])) * (thJ - thG);
-            Xembed[2] = excise(excise(th, 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        const GReal th = thG + m::exp(mks_smooth * (startx1 - Xnative[1])) * (thJ - thG);
+        Xembed[2] = excise(excise(th, 0.0, SMALL_NUM), M_PI, SMALL_NUM);
 #else
-            Xembed[2] = thG + m::exp(mks_smooth * (startx1 - Xnative[1])) * (thJ - thG);
+        Xembed[2] = thG + m::exp(mks_smooth * (startx1 - Xnative[1])) * (thJ - thG);
 #endif
-            Xembed[3] = Xnative[3];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            Xnative[0] = Xembed[0];
-            Xnative[1] = m::log(Xembed[1]);
-            Xnative[3] = Xembed[3];
-            // Treat the special case with a macro
-            ROOT_FIND
-        }
-        /**
-         * Transformation matrix for contravariant vectors to embedding, or covariant vectors to native
-         */
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dxdX);
-            dxdX[0][0] = 1.;
-            dxdX[1][1] = m::exp(Xnative[1]);
-            dxdX[2][1] = -exp(mks_smooth * (startx1 - Xnative[1])) * mks_smooth
-                * (
-                M_PI / 2. -
-                M_PI * Xnative[2]
-                    + poly_norm * (2. * Xnative[2] - 1.)
-                        * (1
-                            + (m::pow((-1. + 2 * Xnative[2]) / poly_xt, poly_alpha))
-                                / (1 + poly_alpha))
-                    - 1. / 2. * (1. - hslope) * m::sin(2. * M_PI * Xnative[2]));
-            dxdX[2][2] = M_PI + (1. - hslope) * M_PI * m::cos(2. * M_PI * Xnative[2])
-                + m::exp(mks_smooth * (startx1 - Xnative[1]))
-                    * (-M_PI
-                        + 2. * poly_norm
-                            * (1.
-                                + m::pow((2. * Xnative[2] - 1.) / poly_xt, poly_alpha)
-                                    / (poly_alpha + 1.))
-                        + (2. * poly_alpha * poly_norm * (2. * Xnative[2] - 1.)
-                            * m::pow((2. * Xnative[2] - 1.) / poly_xt, poly_alpha - 1.))
-                            / ((1. + poly_alpha) * poly_xt)
-                        - (1. - hslope) * M_PI * m::cos(2. * M_PI * Xnative[2]));
-            dxdX[3][3] = 1.;
-        }
-        /**
-         * Transformation matrix for contravariant vectors to native, or covariant vectors to embedding
-         */
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            // Okay this one should probably stay numerical
-            Real dxdX_tmp[GR_DIM][GR_DIM];
-            dxdX(Xnative, dxdX_tmp);
-            invert(&dxdX_tmp[0][0],&dXdx[0][0]);
-        }
+        Xembed[3] = Xnative[3];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        Xnative[0] = Xembed[0];
+        Xnative[1] = m::log(Xembed[1]);
+        Xnative[3] = Xembed[3];
+        // Treat the special case with a macro
+        ROOT_FIND
+    }
+    /**
+     * Transformation matrix for contravariant vectors to embedding, or covariant vectors
+     * to native
+     */
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dxdX);
+        dxdX[0][0] = 1.;
+        dxdX[1][1] = m::exp(Xnative[1]);
+        dxdX[2][1] = -exp(mks_smooth * (startx1 - Xnative[1])) * mks_smooth *
+                     (M_PI / 2. - M_PI * Xnative[2] +
+                         poly_norm * (2. * Xnative[2] - 1.) *
+                             (1 + (m::pow((-1. + 2 * Xnative[2]) / poly_xt, poly_alpha)) /
+                                      (1 + poly_alpha)) -
+                         1. / 2. * (1. - hslope) * m::sin(2. * M_PI * Xnative[2]));
+        dxdX[2][2] =
+            M_PI + (1. - hslope) * M_PI * m::cos(2. * M_PI * Xnative[2]) +
+            m::exp(mks_smooth * (startx1 - Xnative[1])) *
+                (-M_PI +
+                    2. * poly_norm *
+                        (1. + m::pow((2. * Xnative[2] - 1.) / poly_xt, poly_alpha) /
+                                  (poly_alpha + 1.)) +
+                    (2. * poly_alpha * poly_norm * (2. * Xnative[2] - 1.) *
+                        m::pow((2. * Xnative[2] - 1.) / poly_xt, poly_alpha - 1.)) /
+                        ((1. + poly_alpha) * poly_xt) -
+                    (1. - hslope) * M_PI * m::cos(2. * M_PI * Xnative[2]));
+        dxdX[3][3] = 1.;
+    }
+    /**
+     * Transformation matrix for contravariant vectors to native, or covariant vectors to
+     * embedding
+     */
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        // Okay this one should probably stay numerical
+        Real dxdX_tmp[GR_DIM][GR_DIM];
+        dxdX(Xnative, dxdX_tmp);
+        invert(&dxdX_tmp[0][0], &dXdx[0][0]);
+    }
 };
 
 /**
  * Wide-pole Kerr-Schild coordinates
  * Make sense only for spherical base systems!
  */
-class WidepoleTransform {
-    public:
-        static constexpr char name[] = "WidepoleTransform";
-        static constexpr GReal startx[3] = {-1, 0., 0.};
-        static constexpr GReal stopx[3] = {-1, 1., 2*M_PI};
+class WidepoleTransform
+{
+  public:
+    static constexpr char name[] = "WidepoleTransform";
+    static constexpr GReal startx[3] = {-1, 0., 0.};
+    static constexpr GReal stopx[3] = {-1, 1., 2 * M_PI};
 
-        const GReal lin_frac, n2, n3;
-        GReal smoothness;
+    const GReal lin_frac, n2, n3;
+    GReal smoothness;
 
-        // Constructor
-        KOKKOS_FUNCTION WidepoleTransform(GReal lin_frac_in, GReal smoothness_in, GReal n2_in, GReal n3_in): lin_frac(lin_frac_in), smoothness(smoothness_in), n2(n2_in), n3(n3_in) 
-        {
-            GReal n3_temp = n3;
-            if (n3 < M_PI) n3_temp = n2;
-            GReal temp;
-            if (smoothness <= 0) {
-                if (lin_frac == 1) temp = 1.;
-                else temp = lin_frac / (1. - lin_frac) * (1. / M_PI - 1. / n3_temp) * n3_temp / n2;
-                if (abs(temp) < 1) smoothness = 1. / (n2 * log((1. + temp) / (1. - temp)));
-                else {
-                    printf("WARNING: It is harder to have del phi ~ del th. Try using lin_frac < %g \n",  1./ ((1. / M_PI - 1./ n3_temp) * n3_temp / n2 + 1.));
-                    smoothness = 0.8 / n2;
-                }
-                smoothness = 0.02; //m::max(0.01, smoothness); // fix it for now for test
+    // Constructor
+    KOKKOS_FUNCTION WidepoleTransform(
+        GReal lin_frac_in, GReal smoothness_in, GReal n2_in, GReal n3_in)
+        : lin_frac(lin_frac_in)
+        , smoothness(smoothness_in)
+        , n2(n2_in)
+        , n3(n3_in)
+    {
+        GReal n3_temp = n3;
+        if (n3 < M_PI) n3_temp = n2;
+        GReal temp;
+        if (smoothness <= 0) {
+            if (lin_frac == 1)
+                temp = 1.;
+            else
+                temp = lin_frac / (1. - lin_frac) * (1. / M_PI - 1. / n3_temp) * n3_temp /
+                       n2;
+            if (abs(temp) < 1)
+                smoothness = 1. / (n2 * log((1. + temp) / (1. - temp)));
+            else {
+                printf("WARNING: It is harder to have del phi ~ del th. Try using "
+                       "lin_frac < %g \n",
+                    1. / ((1. / M_PI - 1. / n3_temp) * n3_temp / n2 + 1.));
+                smoothness = 0.8 / n2;
             }
+            smoothness = 0.02; // m::max(0.01, smoothness); // fix it for now for test
         }
+    }
 
-        // Coordinate transformations
-        KOKKOS_INLINE_FUNCTION void coord_to_embed(const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
-        {
-            Xembed[0] = Xnative[0];
-            Xembed[1] = exp(Xnative[1]);
-            GReal th;
-            //th = M_PI / 2. * (1. + 2. * lin_frac * (Xnative[2] - 0.5) + (1. - lin_frac) * exp((Xnative[2] - 1.) / smoothness) - (1. - lin_frac) * exp(-Xnative[2] / smoothness));
-            th = M_PI / 2. * (1. + 2. * lin_frac * (Xnative[2] - 0.5) + (1. - lin_frac) * (tanh((Xnative[2] - 1.) / smoothness) + 1.) - (1. - lin_frac) * (tanh(-Xnative[2] / smoothness) + 1.));
-            Xembed[2] = excise(excise(th, 0.0, SMALL_NUM), M_PI, SMALL_NUM);
-            Xembed[3] = Xnative[3];
-        }
-        KOKKOS_INLINE_FUNCTION void coord_to_native(const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
-        {
-            Xnative[0] = Xembed[0];
-            Xnative[1] = log(Xembed[1]);
-            Xnative[3] = Xembed[3];
-            // Treat the special case with a macro
-            ROOT_FIND
-        }
-        /**
-         * Transformation matrix for contravariant vectors to embedding, or covariant vectors to native
-         */
-        KOKKOS_INLINE_FUNCTION void dxdX(const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
-        {
-            gzero2(dxdX);
-            dxdX[0][0] = 1.;
-            dxdX[1][1] = exp(Xnative[1]);
-            //dxdX[2][2] = M_PI / 2. * (2. * lin_frac + (1. - lin_frac) / smoothness * exp((Xnative[2] - 1.) / smoothness) + (1. - lin_frac) / smoothness * exp(-Xnative[2] / smoothness));
-            dxdX[2][2] = M_PI / 2. * (2. * lin_frac + (1. - lin_frac) / (smoothness * m::pow(cosh((Xnative[2] - 1.) / smoothness), 2.)) + (1. - lin_frac) / (smoothness * m::pow(cosh(Xnative[2] / smoothness),2.)));
-            dxdX[3][3] = 1.;
-        }
-        /**
-         * Transformation matrix for contravariant vectors to native, or covariant vectors to embedding
-         */
-        KOKKOS_INLINE_FUNCTION void dXdx(const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
-        {
-            // Okay this one should probably stay numerical
-            Real dxdX_tmp[GR_DIM][GR_DIM];
-            dxdX(Xnative, dxdX_tmp);
-            invert(&dxdX_tmp[0][0],&dXdx[0][0]);
-        }
+    // Coordinate transformations
+    KOKKOS_INLINE_FUNCTION void coord_to_embed(
+        const GReal Xnative[GR_DIM], GReal Xembed[GR_DIM]) const
+    {
+        Xembed[0] = Xnative[0];
+        Xembed[1] = exp(Xnative[1]);
+        GReal th;
+        // th = M_PI / 2. * (1. + 2. * lin_frac * (Xnative[2] - 0.5) + (1. - lin_frac) *
+        // exp((Xnative[2] - 1.) / smoothness) - (1. - lin_frac) * exp(-Xnative[2] /
+        // smoothness));
+        th = M_PI / 2. *
+             (1. + 2. * lin_frac * (Xnative[2] - 0.5) +
+                 (1. - lin_frac) * (tanh((Xnative[2] - 1.) / smoothness) + 1.) -
+                 (1. - lin_frac) * (tanh(-Xnative[2] / smoothness) + 1.));
+        Xembed[2] = excise(excise(th, 0.0, SMALL_NUM), M_PI, SMALL_NUM);
+        Xembed[3] = Xnative[3];
+    }
+    KOKKOS_INLINE_FUNCTION void coord_to_native(
+        const GReal Xembed[GR_DIM], GReal Xnative[GR_DIM]) const
+    {
+        Xnative[0] = Xembed[0];
+        Xnative[1] = log(Xembed[1]);
+        Xnative[3] = Xembed[3];
+        // Treat the special case with a macro
+        ROOT_FIND
+    }
+    /**
+     * Transformation matrix for contravariant vectors to embedding, or covariant vectors
+     * to native
+     */
+    KOKKOS_INLINE_FUNCTION void dxdX(
+        const GReal Xnative[GR_DIM], Real dxdX[GR_DIM][GR_DIM]) const
+    {
+        gzero2(dxdX);
+        dxdX[0][0] = 1.;
+        dxdX[1][1] = exp(Xnative[1]);
+        // dxdX[2][2] = M_PI / 2. * (2. * lin_frac + (1. - lin_frac) / smoothness *
+        // exp((Xnative[2] - 1.) / smoothness) + (1. - lin_frac) / smoothness *
+        // exp(-Xnative[2] / smoothness));
+        dxdX[2][2] =
+            M_PI / 2. *
+            (2. * lin_frac +
+                (1. - lin_frac) /
+                    (smoothness * m::pow(cosh((Xnative[2] - 1.) / smoothness), 2.)) +
+                (1. - lin_frac) /
+                    (smoothness * m::pow(cosh(Xnative[2] / smoothness), 2.)));
+        dxdX[3][3] = 1.;
+    }
+    /**
+     * Transformation matrix for contravariant vectors to native, or covariant vectors to
+     * embedding
+     */
+    KOKKOS_INLINE_FUNCTION void dXdx(
+        const GReal Xnative[GR_DIM], Real dXdx[GR_DIM][GR_DIM]) const
+    {
+        // Okay this one should probably stay numerical
+        Real dxdX_tmp[GR_DIM][GR_DIM];
+        dxdX(Xnative, dxdX_tmp);
+        invert(&dxdX_tmp[0][0], &dXdx[0][0]);
+    }
 };
 
 // Bundle coordinates and transforms into umbrella variant types
-// These act as a wannabe "interface" or "parent class" with the exception that access requires "mpark::visit"
-// See coordinate_embedding.hpp
-using SomeBaseCoords = mpark::variant<SphMinkowskiCoords, CartMinkowskiCoords, SphBLCoords, SphKSCoords, SphBLExtG, SphKSExtG>;
-using SomeTransform = mpark::variant<NullTransform, SphNullTransform, ExponentialTransform, SuperExponentialTransform, ModifyTransform, FunkyTransform, WidepoleTransform>;
+// These act as a wannabe "interface" or "parent class" with the exception that access
+// requires "mpark::visit" See coordinate_embedding.hpp
+using SomeBaseCoords = mpark::variant<SphMinkowskiCoords, CartMinkowskiCoords,
+    SphBLCoords, SphKSCoords, SphBLExtG, SphKSExtG>;
+using SomeTransform =
+    mpark::variant<NullTransform, SphNullTransform, ExponentialTransform,
+        SuperExponentialTransform, ModifyTransform, FunkyTransform, WidepoleTransform>;

--- a/kharma/coordinates/coordinate_utils.hpp
+++ b/kharma/coordinates/coordinate_utils.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: coordinate_utils.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,11 +40,13 @@
  * Rotate a set of coordinates 'Xin' by 'angle' about the *y-axis*
  * (chosen so the slice at phi=0 in output will show the desired tilt)
  */
-KOKKOS_INLINE_FUNCTION void rotate_polar(const GReal Xin[GR_DIM], const GReal angle, GReal Xout[GR_DIM], const bool spherical=true)
+KOKKOS_INLINE_FUNCTION void rotate_polar(const GReal Xin[GR_DIM], const GReal angle,
+    GReal Xout[GR_DIM], const bool spherical = true)
 {
     // Make sure we don't break the trivial case
     if (m::abs(angle) < 1e-20) {
-        DLOOP1 Xout[mu] = Xin[mu];
+        DLOOP1
+            Xout[mu] = Xin[mu];
         return;
     }
 
@@ -54,76 +56,82 @@ KOKKOS_INLINE_FUNCTION void rotate_polar(const GReal Xin[GR_DIM], const GReal an
     // Convert to cartesian
     GReal Xin_cart[GR_DIM] = {0};
     if (spherical) {
-        Xin_cart[1] = Xin[1]*sin(Xin[2])*cos(Xin[3]);
-        Xin_cart[2] = Xin[1]*sin(Xin[2])*sin(Xin[3]);
-        Xin_cart[3] = Xin[1]*cos(Xin[2]);
+        Xin_cart[1] = Xin[1] * sin(Xin[2]) * cos(Xin[3]);
+        Xin_cart[2] = Xin[1] * sin(Xin[2]) * sin(Xin[3]);
+        Xin_cart[3] = Xin[1] * cos(Xin[2]);
     } else {
-        DLOOP1 Xin_cart[mu] = Xin[mu];
+        DLOOP1
+            Xin_cart[mu] = Xin[mu];
     }
 
     // Rotate about the y axis
     GReal R[GR_DIM][GR_DIM] = {0};
     R[0][0] = 1;
-    R[1][1] =  cos(angle);
-    R[1][3] =  sin(angle);
-    R[2][2] =  1;
+    R[1][1] = cos(angle);
+    R[1][3] = sin(angle);
+    R[2][2] = 1;
     R[3][1] = -sin(angle);
-    R[3][3] =  cos(angle);
+    R[3][3] = cos(angle);
 
     GReal Xout_cart[GR_DIM] = {0};
-    DLOOP2 Xout_cart[mu] += R[mu][nu] * Xin_cart[nu];
+    DLOOP2
+        Xout_cart[mu] += R[mu][nu] * Xin_cart[nu];
 
     // Convert back
     if (spherical) {
         Xout[0] = Xin[0];
         // This transformation preserves r, we keep the accurate version
-        Xout[1] = Xin[1]; //m::sqrt(Xout_cart[1]*Xout_cart[1] + Xout_cart[2]*Xout_cart[2] + Xout_cart[3]*Xout_cart[3]);
-        Xout[2] = acos(Xout_cart[3]/Xout[1]);
+        Xout[1] = Xin[1]; // m::sqrt(Xout_cart[1]*Xout_cart[1] + Xout_cart[2]*Xout_cart[2]
+                          // + Xout_cart[3]*Xout_cart[3]);
+        Xout[2] = acos(Xout_cart[3] / Xout[1]);
         if (m::isnan(Xout[2])) { // GCC has some trouble with ~acos(-1)
-            if (Xout_cart[3]/Xout[1] < 0)
+            if (Xout_cart[3] / Xout[1] < 0)
                 Xout[2] = M_PI;
             else
                 Xout[2] = 0.0;
         }
         Xout[3] = atan2(Xout_cart[2], Xout_cart[1]);
     } else {
-        DLOOP1 Xout[mu] = Xout_cart[mu];
+        DLOOP1
+            Xout[mu] = Xout_cart[mu];
     }
 }
 
 /**
- * Set the transformation matrix dXdx for converting vectors from spherical to Cartesian coordinates,
- * including rotation *and* normalization!
- * There exists an analytic inverse, of course, but we just take numerical inverses because they are easy
+ * Set the transformation matrix dXdx for converting vectors from spherical to Cartesian
+ * coordinates, including rotation *and* normalization! There exists an analytic inverse,
+ * of course, but we just take numerical inverses because they are easy
  */
-KOKKOS_INLINE_FUNCTION void set_dXdx_sph2cart(const GReal X[GR_DIM], GReal dXdx[GR_DIM][GR_DIM])
+KOKKOS_INLINE_FUNCTION void set_dXdx_sph2cart(
+    const GReal X[GR_DIM], GReal dXdx[GR_DIM][GR_DIM])
 {
     const GReal &r = X[1], &th = X[2], &phi = X[3];
     dXdx[0][0] = 1;
-    dXdx[1][1] = sin(th)*cos(phi);
-    dXdx[1][2] = r*cos(th)*cos(phi);
-    dXdx[1][3] = -r*sin(th)*sin(phi);
-    dXdx[2][1] = sin(th)*sin(phi);
-    dXdx[2][2] = r*cos(th)*sin(phi);
-    dXdx[2][3] = r*sin(th)*cos(phi);
+    dXdx[1][1] = sin(th) * cos(phi);
+    dXdx[1][2] = r * cos(th) * cos(phi);
+    dXdx[1][3] = -r * sin(th) * sin(phi);
+    dXdx[2][1] = sin(th) * sin(phi);
+    dXdx[2][2] = r * cos(th) * sin(phi);
+    dXdx[2][3] = r * sin(th) * cos(phi);
     dXdx[3][1] = cos(th);
-    dXdx[3][2] = -r*sin(th);
+    dXdx[3][2] = -r * sin(th);
     dXdx[3][3] = 0;
 }
 
 /**
  * Same as rotate_polar but for vectors: rotate about the y-axis
  */
-KOKKOS_INLINE_FUNCTION void rotate_polar_vec(const GReal Xin[GR_DIM], const GReal vin[GR_DIM], const GReal angle,
-                                             const GReal Xout[GR_DIM], GReal vout[GR_DIM],
-                                             const bool spherical=true)
+KOKKOS_INLINE_FUNCTION void rotate_polar_vec(const GReal Xin[GR_DIM],
+    const GReal vin[GR_DIM], const GReal angle, const GReal Xout[GR_DIM],
+    GReal vout[GR_DIM], const bool spherical = true)
 {
     // Make sure we don't break the trivial case
     if (m::abs(angle) < 1e-20) {
-        DLOOP1 vout[mu] = vin[mu];
+        DLOOP1
+            vout[mu] = vin[mu];
         return;
     }
-    
+
     // Again, there are clever ways to do this by mapping to a spherical surface, etc
     // But this seems much more straightforward, and this is more flexible in letting us
     // define any rotation or translation we want in Cartesian coordinates.
@@ -134,9 +142,11 @@ KOKKOS_INLINE_FUNCTION void rotate_polar_vec(const GReal Xin[GR_DIM], const GRea
         // Note we use the *inverse* matrix here
         GReal dXdx[GR_DIM][GR_DIM] = {0};
         set_dXdx_sph2cart(Xin, dXdx);
-        DLOOP2 vin_cart[mu] += dXdx[mu][nu]*vin[nu];
+        DLOOP2
+            vin_cart[mu] += dXdx[mu][nu] * vin[nu];
     } else {
-        DLOOP1 vin_cart[mu] = vin[mu];
+        DLOOP1
+            vin_cart[mu] = vin[mu];
     }
 
     // Rotate about the y axis
@@ -149,7 +159,8 @@ KOKKOS_INLINE_FUNCTION void rotate_polar_vec(const GReal Xin[GR_DIM], const GRea
     R[3][3] = cos(angle);
 
     GReal vout_cart[GR_DIM] = {0};
-    DLOOP2 vout_cart[mu] += R[mu][nu] * vin_cart[nu];
+    DLOOP2
+        vout_cart[mu] += R[mu][nu] * vin_cart[nu];
 
     // Convert back
     if (spherical) {
@@ -157,10 +168,13 @@ KOKKOS_INLINE_FUNCTION void rotate_polar_vec(const GReal Xin[GR_DIM], const GRea
         GReal dXdx[GR_DIM][GR_DIM] = {0}, dxdX[GR_DIM][GR_DIM] = {0};
         set_dXdx_sph2cart(Xout, dXdx);
         invert(&dXdx[0][0], &dxdX[0][0]);
-        DLOOP1 vout[mu] = 0;
-        DLOOP2 vout[mu] += dxdX[mu][nu]*vout_cart[nu];
+        DLOOP1
+            vout[mu] = 0;
+        DLOOP2
+            vout[mu] += dxdX[mu][nu] * vout_cart[nu];
     } else {
-        DLOOP1 vout[mu] = vout_cart[mu];
+        DLOOP1
+            vout[mu] = vout_cart[mu];
     }
 }
 
@@ -172,15 +186,11 @@ KOKKOS_INLINE_FUNCTION void set_ut(const Real gcov[GR_DIM][GR_DIM], Real ucon[GR
     Real AA, BB, CC;
 
     AA = gcov[0][0];
-    BB = 2. * (gcov[0][1] * ucon[1] +
-               gcov[0][2] * ucon[2] +
-               gcov[0][3] * ucon[3]);
-    CC = 1. + gcov[1][1] * ucon[1] * ucon[1] +
-         gcov[2][2] * ucon[2] * ucon[2] +
+    BB = 2. * (gcov[0][1] * ucon[1] + gcov[0][2] * ucon[2] + gcov[0][3] * ucon[3]);
+    CC = 1. + gcov[1][1] * ucon[1] * ucon[1] + gcov[2][2] * ucon[2] * ucon[2] +
          gcov[3][3] * ucon[3] * ucon[3] +
-         2. * (gcov[1][2] * ucon[1] * ucon[2] +
-               gcov[1][3] * ucon[1] * ucon[3] +
-               gcov[2][3] * ucon[2] * ucon[3]);
+         2. * (gcov[1][2] * ucon[1] * ucon[2] + gcov[1][3] * ucon[1] * ucon[3] +
+                  gcov[2][3] * ucon[2] * ucon[3]);
 
     Real discr = BB * BB - 4. * AA * CC;
     ucon[0] = (-BB - m::sqrt(discr)) / (2. * AA);
@@ -188,11 +198,12 @@ KOKKOS_INLINE_FUNCTION void set_ut(const Real gcov[GR_DIM][GR_DIM], Real ucon[GR
 
 /**
  * Make primitive velocities u-twiddle out of 4-velocity.  See Gammie '04
- * 
+ *
  * This function and set_ut together can turn any desired 3-velocity into a
  * form usable to initialize uvec in KHARMA; see bondi.hpp for usage.
  */
-KOKKOS_INLINE_FUNCTION void fourvel_to_prim(const Real gcon[GR_DIM][GR_DIM], const Real ucon[GR_DIM], Real u_prim[NVEC])
+KOKKOS_INLINE_FUNCTION void fourvel_to_prim(
+    const Real gcon[GR_DIM][GR_DIM], const Real ucon[GR_DIM], Real u_prim[NVEC])
 {
     Real alpha2 = -1.0 / gcon[0][0];
     // Note gamma/alpha is ucon[0]

--- a/kharma/coordinates/gr_coordinates.cpp
+++ b/kharma/coordinates/gr_coordinates.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: gr_coordinates.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,7 +33,7 @@
  */
 
 /*
- * Coordinate functions for GR 
+ * Coordinate functions for GR
  */
 
 #include "gr_coordinates.hpp"
@@ -50,38 +50,51 @@ using Kokkos::Rank;
 
 #if FAST_CARTESIAN
 /**
- * Fast Cartesian GRCoordinates objects just use the underlying UniformCartesian object for everything
+ * Fast Cartesian GRCoordinates objects just use the underlying UniformCartesian object
+ * for everything
  */
-GRCoordinates::GRCoordinates(const RegionSize &rs, ParameterInput *pin): UniformCartesian(rs, pin) {}
-GRCoordinates::GRCoordinates(const GRCoordinates &src, int coarsen): UniformCartesian(src, coarsen) {}
+GRCoordinates::GRCoordinates(const RegionSize& rs, ParameterInput* pin)
+    : UniformCartesian(rs, pin)
+{}
+GRCoordinates::GRCoordinates(const GRCoordinates& src, int coarsen)
+    : UniformCartesian(src, coarsen)
+{}
 #else
 // Internal function for initializing cache
 void init_GRCoordinates(GRCoordinates& G);
 
 /**
- * Construct a GRCoordinates object with a transformation according to preferences set in the package
+ * Construct a GRCoordinates object with a transformation according to preferences set in
+ * the package
  */
-GRCoordinates::GRCoordinates(const RegionSize &rs, ParameterInput *pin): UniformCartesian(rs, pin),
-    coords(pin)
+GRCoordinates::GRCoordinates(const RegionSize& rs, ParameterInput* pin)
+    : UniformCartesian(rs, pin)
+    , coords(pin)
 {
     // TODO use new .symmetric?
-    n1 = rs.nx(X1DIR) + 2*Globals::nghost;
-    n2 = rs.nx(X2DIR) > 1 ? rs.nx(X2DIR) + 2*Globals::nghost : 1;
-    n3 = rs.nx(X3DIR) > 1 ? rs.nx(X3DIR) + 2*Globals::nghost : 1;
-    //cout << "Initialized coordinates with nghost " << Globals::nghost << std::endl;
+    n1 = rs.nx(X1DIR) + 2 * Globals::nghost;
+    n2 = rs.nx(X2DIR) > 1 ? rs.nx(X2DIR) + 2 * Globals::nghost : 1;
+    n3 = rs.nx(X3DIR) > 1 ? rs.nx(X3DIR) + 2 * Globals::nghost : 1;
+    // cout << "Initialized coordinates with nghost " << Globals::nghost << std::endl;
 
-    connection_average_points = pin->GetOrAddInteger("coordinates", "connection_average_points", 1);
-    correct_connections = pin->GetOrAddBoolean("coordinates", "correct_connections", false);
+    connection_average_points =
+        pin->GetOrAddInteger("coordinates", "connection_average_points", 1);
+    correct_connections =
+        pin->GetOrAddBoolean("coordinates", "correct_connections", false);
 
     init_GRCoordinates(*this);
 }
 
-GRCoordinates::GRCoordinates(const GRCoordinates &src, int coarsen): UniformCartesian(src, coarsen),
-    coords(src.coords), n1(src.n1/coarsen), n2(src.n2/coarsen), n3(src.n3/coarsen),
-    connection_average_points(src.connection_average_points),
-    correct_connections(src.correct_connections)
+GRCoordinates::GRCoordinates(const GRCoordinates& src, int coarsen)
+    : UniformCartesian(src, coarsen)
+    , coords(src.coords)
+    , n1(src.n1 / coarsen)
+    , n2(src.n2 / coarsen)
+    , n3(src.n3 / coarsen)
+    , connection_average_points(src.connection_average_points)
+    , correct_connections(src.correct_connections)
 {
-    //std::cerr << "Calling coarsen constructor" << std::endl;
+    // std::cerr << "Calling coarsen constructor" << std::endl;
     init_GRCoordinates(*this);
 }
 
@@ -93,42 +106,45 @@ GRCoordinates::GRCoordinates(const GRCoordinates &src, int coarsen): UniformCart
  * This needs to be defined *outside* of the GRCoordinates object, because of some
  * fun issues with C++ Lambda capture, which Kokkos brings to the fore
  */
-void init_GRCoordinates(GRCoordinates& G) {
+void init_GRCoordinates(GRCoordinates& G)
+{
     const int n1 = G.n1;
     const int n2 = G.n2;
-    //const int n3 = G.n3;
+    // const int n3 = G.n3;
     const bool correct_connections = G.correct_connections;
     const int connection_average_points = G.connection_average_points;
 
-    //cerr << "Creating GRCoordinate cache size " << n1 << " " << n2 << std::endl;
-    // Cache geometry.  May be faster than re-computing. May not be.
-    G.gcon_direct = GeomTensor2("gcon", NLOC, n2+1, n1+1, GR_DIM, GR_DIM);
-    G.gcov_direct = GeomTensor2("gcov", NLOC, n2+1, n1+1, GR_DIM, GR_DIM);
-    G.gdet_direct = GeomScalar("gdet", NLOC, n2+1, n1+1);
+    // cerr << "Creating GRCoordinate cache size " << n1 << " " << n2 << std::endl;
+    //  Cache geometry.  May be faster than re-computing. May not be.
+    G.gcon_direct = GeomTensor2("gcon", NLOC, n2 + 1, n1 + 1, GR_DIM, GR_DIM);
+    G.gcov_direct = GeomTensor2("gcov", NLOC, n2 + 1, n1 + 1, GR_DIM, GR_DIM);
+    G.gdet_direct = GeomScalar("gdet", NLOC, n2 + 1, n1 + 1);
     G.conn_direct = GeomTensor3("conn", n2, n1, GR_DIM, GR_DIM, GR_DIM);
     G.gdet_conn_direct = GeomTensor3("conn", n2, n1, GR_DIM, GR_DIM, GR_DIM);
 
     // Member variables have an implicit this->
-    // C++ Lambdas (and therefore Kokkos Lambdas) capture pointers to objects, not full objects
-    // Hence, you *CANNOT* use this->, or members, from inside kernels
+    // C++ Lambdas (and therefore Kokkos Lambdas) capture pointers to objects, not full
+    // objects Hence, you *CANNOT* use this->, or members, from inside kernels
     auto gcon_local = G.gcon_direct;
     auto gcov_local = G.gcov_direct;
     auto gdet_local = G.gdet_direct;
     auto conn_local = G.conn_direct;
     auto gdet_conn_local = G.gdet_conn_direct;
 
-    Kokkos::parallel_for("init_geom", MDRangePolicy<Rank<2>>({0,0}, {n2+1, n1+1}),
-        KOKKOS_LAMBDA (const int& j, const int& i) {
+    Kokkos::parallel_for("init_geom", MDRangePolicy<Rank<2>>({0, 0}, {n2 + 1, n1 + 1}),
+        KOKKOS_LAMBDA(const int& j, const int& i)
+        {
             // Iterate through locations. This could be done in fancy ways, but
             // this highlights what's actually going on.
-            for (int iloc =0; iloc < NLOC; iloc++) {
-                Loci loc = (Loci) iloc;
+            for (int iloc = 0; iloc < NLOC; iloc++) {
+                Loci loc = (Loci)iloc;
                 // radius of points to sample, floor(npoints/2)
                 const int radius = connection_average_points / 2;
                 const int diameter = connection_average_points;
-                const int square = connection_average_points*connection_average_points;
+                const int square = connection_average_points * connection_average_points;
                 if (loc == Loci::center || loc == Loci::face3) {
-                    // This prevents overstepping conn's bounds by halting in the last zone
+                    // This prevents overstepping conn's bounds by halting in the last
+                    // zone
                     if (i >= n1 || j >= n2) continue;
                     // Get a square of points evenly across each cell,
                     // over both nontrivial geometry directions 1,2
@@ -138,42 +154,49 @@ void init_GRCoordinates(GRCoordinates& G) {
                             GReal X[GR_DIM];
                             G.coord(0, j, i, loc, X);
                             GReal Xn1[GR_DIM], Xn2[GR_DIM];
-                            G.coord(0, j, i+1, loc, Xn1);
-                            G.coord(0, j+1, i, loc, Xn2);
-                            X[1] += (Xn1[1] - X[1])/connection_average_points * k;
-                            X[2] += (Xn2[2] - X[2])/connection_average_points * l;
+                            G.coord(0, j, i + 1, loc, Xn1);
+                            G.coord(0, j + 1, i, loc, Xn2);
+                            X[1] += (Xn1[1] - X[1]) / connection_average_points * k;
+                            X[2] += (Xn2[2] - X[2]) / connection_average_points * l;
                             // Get geometry at points
                             GReal gcov_loc[GR_DIM][GR_DIM], gcon_loc[GR_DIM][GR_DIM];
                             G.coords.gcov_native(X, gcov_loc);
-                            const GReal gdet = G.coords.gcon_from_gcov(gcov_loc, gcon_loc);
+                            const GReal gdet =
+                                G.coords.gcon_from_gcov(gcov_loc, gcon_loc);
                             // Add to running averages
                             gdet_local(loc, j, i) += gdet / square;
                             DLOOP2 {
-                                gcov_local(loc, j, i, mu, nu) += gcov_loc[mu][nu] / square;
-                                gcon_local(loc, j, i, mu, nu) += gcon_loc[mu][nu] / square;
+                                gcov_local(loc, j, i, mu, nu) +=
+                                    gcov_loc[mu][nu] / square;
+                                gcon_local(loc, j, i, mu, nu) +=
+                                    gcon_loc[mu][nu] / square;
                             }
                             if (loc == Loci::center) {
                                 // In the center, get the connection and gdet*connection
                                 Real conn_loc[GR_DIM][GR_DIM][GR_DIM];
                                 G.coords.conn_native(X, DELTA, conn_loc);
                                 DLOOP3 {
-                                    conn_local(j, i, mu, nu, lam) += conn_loc[mu][nu][lam] / square;
-                                    gdet_conn_local(j, i, mu, nu, lam) += gdet*conn_loc[mu][nu][lam] / square;
+                                    conn_local(j, i, mu, nu, lam) +=
+                                        conn_loc[mu][nu][lam] / square;
+                                    gdet_conn_local(j, i, mu, nu, lam) +=
+                                        gdet * conn_loc[mu][nu][lam] / square;
                                 }
                             }
                         }
                     }
                 } else if (loc == Loci::face1 || loc == Loci::face2) {
-                    for (int k=-radius; k <= radius; k++) {
-                        // Like the above, but only average over a particular face (line for 2D geometry)
+                    for (int k = -radius; k <= radius; k++) {
+                        // Like the above, but only average over a particular face (line
+                        // for 2D geometry)
                         GReal X[GR_DIM];
                         G.coord(0, j, i, loc, X);
                         GReal Xn1[GR_DIM];
                         // Step in the nontrivial direction perpendicular to the normal
                         const int avg_dir = (loc == Loci::face1) ? X2DIR : X1DIR;
                         // Get the direction/distance
-                        G.coord(0, j + (avg_dir == X2DIR), i + (avg_dir == X1DIR), loc, Xn1);
-                        X[avg_dir] += (Xn1[avg_dir] - X[avg_dir])/diameter * k;
+                        G.coord(
+                            0, j + (avg_dir == X2DIR), i + (avg_dir == X1DIR), loc, Xn1);
+                        X[avg_dir] += (Xn1[avg_dir] - X[avg_dir]) / diameter * k;
                         // Get geometry at the point
                         GReal gcov_loc[GR_DIM][GR_DIM], gcon_loc[GR_DIM][GR_DIM];
                         G.coords.gcov_native(X, gcov_loc);
@@ -201,29 +224,32 @@ void init_GRCoordinates(GRCoordinates& G) {
                     }
                 }
             }
-        }
-    );
+        });
     if (correct_connections) {
-        Kokkos::parallel_for("geom_corrections", MDRangePolicy<Rank<2>>({0,0}, {n2, n1}),
-            KOKKOS_LAMBDA (const int& j, const int& i) {
+        Kokkos::parallel_for("geom_corrections", MDRangePolicy<Rank<2>>({0, 0}, {n2, n1}),
+            KOKKOS_LAMBDA(const int& j, const int& i)
+            {
                 // In the two directions the grid changes, make sure that we *exactly*
-                // satisfy the req't gdet*conn^mu_mu_nu = d_nu gdet, when evaluated on faces
-                // This will make the source term exactly balance the flux differences,
-                // crucial near the poles
+                // satisfy the req't gdet*conn^mu_mu_nu = d_nu gdet, when evaluated on
+                // faces This will make the source term exactly balance the flux
+                // differences, crucial near the poles
                 GReal X[GR_DIM];
                 G.coord(0, j, i, Loci::center, X);
                 if (1) { //(m::abs(X[2] - 0) < 0.08 || m::abs(X[2] - 1.0) < 0.08)) {
-                    for (int lam=1; lam < GR_DIM; lam++) {
+                    for (int lam = 1; lam < GR_DIM; lam++) {
                         const Loci loc = loc_of(lam);
                         // Get gdet values at faces we calculated above
                         GReal Xfm[GR_DIM], Xfp[GR_DIM];
                         G.coord(0, j, i, loc, Xfm);
                         G.coord(0, j + (lam == X2DIR), i + (lam == X1DIR), loc, Xfp);
                         double gdetfm = gdet_local(loc, j, i);
-                        double gdetfp = gdet_local(loc, j + (lam == X2DIR), i + (lam == X1DIR));
-                        GReal target = (gdetfp - gdetfm) / (Xfp[lam] - Xfm[lam] + SMALL_NUM);
+                        double gdetfp =
+                            gdet_local(loc, j + (lam == X2DIR), i + (lam == X1DIR));
+                        GReal target =
+                            (gdetfp - gdetfm) / (Xfp[lam] - Xfm[lam] + SMALL_NUM);
 
-                        // Then sum the coefficients and record nonzero ones for modification
+                        // Then sum the coefficients and record nonzero ones for
+                        // modification
                         GReal test_sum = 0;
                         GReal sum_portions = 0;
                         GReal portions[GR_DIM] = {0};
@@ -232,19 +258,25 @@ void init_GRCoordinates(GRCoordinates& G) {
                             portions[mu] = m::abs(gdet_conn_local(j, i, mu, mu, lam));
                             sum_portions += portions[mu];
                         }
-                        DLOOP1 portions[mu] /= sum_portions;
-                        //printf("Zone %d %d target: %.3g test_sum: %.3g correction: %.3g\n", i, j, target, test_sum, diff);
+                        DLOOP1
+                            portions[mu] /= sum_portions;
+                        // printf("Zone %d %d target: %.3g test_sum: %.3g correction:
+                        // %.3g\n", i, j, target, test_sum, diff);
 
                         // Add the difference among components equally
                         const GReal diff = test_sum - target;
-                        DLOOP1 gdet_conn_local(j, i, mu, mu, lam) = gdet_conn_local(j, i, mu, mu, lam) - diff*portions[mu];
+                        DLOOP1
+                            gdet_conn_local(j, i, mu, mu, lam) =
+                                gdet_conn_local(j, i, mu, mu, lam) - diff * portions[mu];
 
-                        // This is separated and set equal, as there will be one self-assignment
-                        DLOOP1 gdet_conn_local(j, i, mu, lam, mu) = gdet_conn_local(j, i, mu, mu, lam);
+                        // This is separated and set equal, as there will be one
+                        // self-assignment
+                        DLOOP1
+                            gdet_conn_local(j, i, mu, lam, mu) =
+                                gdet_conn_local(j, i, mu, mu, lam);
                     }
                 }
-            }
-        );
+            });
     }
 }
 #endif // FAST_CARTESIAN

--- a/kharma/coordinates/gr_coordinates.hpp
+++ b/kharma/coordinates/gr_coordinates.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: gr_coordinates.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -57,7 +57,7 @@
 
 /**
  * Replacement/extension coordinate class for Parthenon
- * 
+ *
  * Parthenon's UniformCartesian coordinate class keeps, for each meshblock,
  * cell locations on a global X,Y,Z grid.
  * We wish to map these "logically-Cartesian" coordinates to volumes of interest,
@@ -65,10 +65,11 @@
  */
 class GRCoordinates : public parthenon::UniformCartesian
 {
-public:
-    // Coordinate geometry & transform object: metric functions, to/from KS coordinates, etc.
-    // Note we keep the actual object in GRCoordinates.  This is a royal pain to implement,
-    // but ensures it will get copied device-side by C++14 Lambdas, circumventing *so many* bugs
+  public:
+    // Coordinate geometry & transform object: metric functions, to/from KS coordinates,
+    // etc. Note we keep the actual object in GRCoordinates.  This is a royal pain to
+    // implement, but ensures it will get copied device-side by C++14 Lambdas,
+    // circumventing *so many* bugs
     CoordinateEmbedding coords;
 
     // Store the block size, since UniformCartesian doesn't
@@ -92,19 +93,25 @@ public:
     // "Full" constructors which generate new geometry caches
     // these call Kokkos internally so we must ensure they're only called host-side
 #pragma hd_warning_disable
-    GRCoordinates(const parthenon::RegionSize &rs, parthenon::ParameterInput *pin);
+    GRCoordinates(const parthenon::RegionSize& rs, parthenon::ParameterInput* pin);
 #pragma hd_warning_disable
-    GRCoordinates(const GRCoordinates &src, int coarsen);
+    GRCoordinates(const GRCoordinates& src, int coarsen);
 
-    // Interim & copy constructors so that Parthenon can use us like a UniformCartesian object,
-    // that is, host- & device-side indiscriminately
-    KOKKOS_FUNCTION GRCoordinates(): UniformCartesian() {};
-    KOKKOS_FUNCTION GRCoordinates(const GRCoordinates &src): UniformCartesian(src),
-        n1(src.n1), n2(src.n2), n3(src.n3), coords(src.coords),
-        connection_average_points(src.connection_average_points),
-        correct_connections(src.correct_connections)
+    // Interim & copy constructors so that Parthenon can use us like a UniformCartesian
+    // object, that is, host- & device-side indiscriminately
+    KOKKOS_FUNCTION GRCoordinates()
+        : UniformCartesian() {};
+    KOKKOS_FUNCTION GRCoordinates(const GRCoordinates& src)
+        : UniformCartesian(src)
+        , n1(src.n1)
+        , n2(src.n2)
+        , n3(src.n3)
+        , coords(src.coords)
+        , connection_average_points(src.connection_average_points)
+        , correct_connections(src.correct_connections)
     {
-        //std::cerr << "Calling copy constructor size " << src.n1 << " " << src.n2 << std::endl;
+        // std::cerr << "Calling copy constructor size " << src.n1 << " " << src.n2 <<
+        // std::endl;
 #if !FAST_CARTESIAN && !NO_CACHE
         gcon_direct = src.gcon_direct;
         gcov_direct = src.gcov_direct;
@@ -114,10 +121,11 @@ public:
 #endif
     };
 
-    // TODO(BSP) eliminate calls to this from Parthenon, grid should be const
+    // TODO(CEP) eliminate calls to this from Parthenon, grid should be const
     KOKKOS_FUNCTION GRCoordinates operator=(const GRCoordinates& src)
     {
-        //std::cerr << "Calling assignment operator size " << src.n1 << " " << src.n2 << std::endl;
+        // std::cerr << "Calling assignment operator size " << src.n1 << " " << src.n2 <<
+        // std::endl;
         UniformCartesian::operator=(src);
         coords = src.coords;
         n1 = src.n1;
@@ -137,7 +145,8 @@ public:
 
     // Correct the coordinate system name for outputs.
     // So far the only override we need.
-    const char *Name() const {
+    const char* Name() const
+    {
         if (coords.is_spherical()) {
             return "TransformedSpherical";
         } else if (coords.is_transformed()) {
@@ -148,93 +157,111 @@ public:
     }
 
     // TODO Test these vs going all-in on full-matrix versions and computing on the fly
-    KOKKOS_INLINE_FUNCTION Real gcon(const Loci loc, const int& j, const int& i, const int mu, const int nu) const;
-    KOKKOS_INLINE_FUNCTION Real gcov(const Loci loc, const int& j, const int& i, const int mu, const int nu) const;
+    KOKKOS_INLINE_FUNCTION Real gcon(
+        const Loci loc, const int& j, const int& i, const int mu, const int nu) const;
+    KOKKOS_INLINE_FUNCTION Real gcov(
+        const Loci loc, const int& j, const int& i, const int mu, const int nu) const;
     KOKKOS_INLINE_FUNCTION Real gdet(const Loci loc, const int& j, const int& i) const;
-    KOKKOS_INLINE_FUNCTION Real conn(const int& j, const int& i, const int mu, const int nu, const int lam) const;
-    KOKKOS_INLINE_FUNCTION Real gdet_conn(const int& j, const int& i, const int mu, const int nu, const int lam) const;
+    KOKKOS_INLINE_FUNCTION Real conn(
+        const int& j, const int& i, const int mu, const int nu, const int lam) const;
+    KOKKOS_INLINE_FUNCTION Real gdet_conn(
+        const int& j, const int& i, const int mu, const int nu, const int lam) const;
 
-    KOKKOS_INLINE_FUNCTION void gcon(const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const;
-    KOKKOS_INLINE_FUNCTION void gcov(const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const;
-    KOKKOS_INLINE_FUNCTION void conn(const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const;
-    KOKKOS_INLINE_FUNCTION void gdet_conn(const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const;
+    KOKKOS_INLINE_FUNCTION void gcon(
+        const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const;
+    KOKKOS_INLINE_FUNCTION void gcov(
+        const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const;
+    KOKKOS_INLINE_FUNCTION void conn(
+        const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const;
+    KOKKOS_INLINE_FUNCTION void gdet_conn(
+        const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const;
 
     // Coordinates of the GRCoordinates, i.e. "native"
-    KOKKOS_INLINE_FUNCTION void coord(const int& k, const int& j, const int& i, const Loci& loc, GReal X[GR_DIM]) const;
+    KOKKOS_INLINE_FUNCTION void coord(
+        const int& k, const int& j, const int& i, const Loci& loc, GReal X[GR_DIM]) const;
     // Coordinates of the embedding system, usually r,th,phi[KS] or x1,x2,x3[Cartesian]
-    KOKKOS_INLINE_FUNCTION void coord_embed(const int& k, const int& j, const int& i, const Loci& loc, GReal Xembed[GR_DIM]) const;
+    KOKKOS_INLINE_FUNCTION void coord_embed(const int& k, const int& j, const int& i,
+        const Loci& loc, GReal Xembed[GR_DIM]) const;
     // Coordinates in specific systems (slow!)
-    KOKKOS_INLINE_FUNCTION GReal r(const int& k, const int& j, const int& i, const Loci& loc=Loci::center) const;
-    KOKKOS_INLINE_FUNCTION GReal th(const int& k, const int& j, const int& i, const Loci& loc=Loci::center) const;
-    KOKKOS_INLINE_FUNCTION GReal phi(const int& k, const int& j, const int& i, const Loci& loc=Loci::center) const;
-    KOKKOS_INLINE_FUNCTION GReal x(const int& k, const int& j, const int& i, const Loci& loc=Loci::center) const;
-    KOKKOS_INLINE_FUNCTION GReal y(const int& k, const int& j, const int& i, const Loci& loc=Loci::center) const;
-    KOKKOS_INLINE_FUNCTION GReal z(const int& k, const int& j, const int& i, const Loci& loc=Loci::center) const;
+    KOKKOS_INLINE_FUNCTION GReal r(
+        const int& k, const int& j, const int& i, const Loci& loc = Loci::center) const;
+    KOKKOS_INLINE_FUNCTION GReal th(
+        const int& k, const int& j, const int& i, const Loci& loc = Loci::center) const;
+    KOKKOS_INLINE_FUNCTION GReal phi(
+        const int& k, const int& j, const int& i, const Loci& loc = Loci::center) const;
+    KOKKOS_INLINE_FUNCTION GReal x(
+        const int& k, const int& j, const int& i, const Loci& loc = Loci::center) const;
+    KOKKOS_INLINE_FUNCTION GReal y(
+        const int& k, const int& j, const int& i, const Loci& loc = Loci::center) const;
+    KOKKOS_INLINE_FUNCTION GReal z(
+        const int& k, const int& j, const int& i, const Loci& loc = Loci::center) const;
 
     // Transformations using the cached geometry
     KOKKOS_INLINE_FUNCTION void lower(const Real vcon[GR_DIM], Real vcov[GR_DIM],
-                                        const int& k, const int& j, const int& i, const Loci loc) const;
+        const int& k, const int& j, const int& i, const Loci loc) const;
     KOKKOS_INLINE_FUNCTION void raise(const Real vcov[GR_DIM], Real vcon[GR_DIM],
-                                        const int& k, const int& j, const int& i, const Loci loc) const;
+        const int& k, const int& j, const int& i, const Loci loc) const;
 };
 
 /**
  * Function to return native coordinates on the GRCoordinates
  */
-KOKKOS_INLINE_FUNCTION void GRCoordinates::coord(const int& k, const int& j, const int& i, const Loci& loc, Real X[GR_DIM]) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::coord(
+    const int& k, const int& j, const int& i, const Loci& loc, Real X[GR_DIM]) const
 {
     X[0] = 0;
-    switch(loc)
-    {
-    case Loci::face1:
-        X[1] = Xf<1>(i);
-        X[2] = Xc<2>(j);
-        X[3] = Xc<3>(k);
-        break;
-    case Loci::face2:
-        X[1] = Xc<1>(i);
-        X[2] = Xf<2>(j);
-        X[3] = Xc<3>(k);
-        break;
-    case Loci::face3:
-        X[1] = Xc<1>(i);
-        X[2] = Xc<2>(j);
-        X[3] = Xf<3>(k);
-        break;
-    case Loci::center:
-        X[1] = Xc<1>(i);
-        X[2] = Xc<2>(j);
-        X[3] = Xc<3>(k);
-        break;
-    case Loci::corner:
-        X[1] = Xf<1>(i);
-        X[2] = Xf<2>(j);
-        X[3] = Xf<3>(k);
-        break;
-    case Loci::outer_half:
-        X[1] = Xc<1>(i);
-        X[2] = (Xc<2>(j) + Xf<2>(j+1)) / 2;
-        X[3] = Xc<3>(k);
-        break;
-    case Loci::inner_half:
-        X[1] = Xc<1>(i);
-        X[2] = (Xc<2>(j) + Xf<2>(j)) / 2;
-        X[3] = Xc<3>(k);
-        break;
+    switch (loc) {
+        case Loci::face1:
+            X[1] = Xf<1>(i);
+            X[2] = Xc<2>(j);
+            X[3] = Xc<3>(k);
+            break;
+        case Loci::face2:
+            X[1] = Xc<1>(i);
+            X[2] = Xf<2>(j);
+            X[3] = Xc<3>(k);
+            break;
+        case Loci::face3:
+            X[1] = Xc<1>(i);
+            X[2] = Xc<2>(j);
+            X[3] = Xf<3>(k);
+            break;
+        case Loci::center:
+            X[1] = Xc<1>(i);
+            X[2] = Xc<2>(j);
+            X[3] = Xc<3>(k);
+            break;
+        case Loci::corner:
+            X[1] = Xf<1>(i);
+            X[2] = Xf<2>(j);
+            X[3] = Xf<3>(k);
+            break;
+        case Loci::outer_half:
+            X[1] = Xc<1>(i);
+            X[2] = (Xc<2>(j) + Xf<2>(j + 1)) / 2;
+            X[3] = Xc<3>(k);
+            break;
+        case Loci::inner_half:
+            X[1] = Xc<1>(i);
+            X[2] = (Xc<2>(j) + Xf<2>(j)) / 2;
+            X[3] = Xc<3>(k);
+            break;
     }
 }
 
-KOKKOS_INLINE_FUNCTION void GRCoordinates::lower(const Real vcon[GR_DIM], Real vcov[GR_DIM],
-                                        const int& k, const int& j, const int& i, const Loci loc) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::lower(const Real vcon[GR_DIM],
+    Real vcov[GR_DIM], const int& k, const int& j, const int& i, const Loci loc) const
 {
     gzero(vcov);
-    DLOOP2 vcov[mu] += gcov(loc, j, i, mu, nu) * vcon[nu];
+    DLOOP2
+        vcov[mu] += gcov(loc, j, i, mu, nu) * vcon[nu];
 }
-KOKKOS_INLINE_FUNCTION void GRCoordinates::raise(const Real vcov[GR_DIM], Real vcon[GR_DIM],
-                                        const int& k, const int& j, const int& i, const Loci loc) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::raise(const Real vcov[GR_DIM],
+    Real vcon[GR_DIM], const int& k, const int& j, const int& i, const Loci loc) const
 {
     gzero(vcon);
-    DLOOP2 vcon[mu] += gcon(loc, j, i, mu, nu) * vcov[nu];
+    DLOOP2
+        vcon[mu] += gcon(loc, j, i, mu, nu) * vcov[nu];
 }
 
 // Three different implementations of the metric functions:
@@ -242,49 +269,84 @@ KOKKOS_INLINE_FUNCTION void GRCoordinates::raise(const Real vcov[GR_DIM], Real v
 // NO_CACHE: Re-calculate from coordinates object on every access
 // NORMAL: Cache each zone center and return cached value thereafter
 #if FAST_CARTESIAN
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcon(const Loci loc, const int& j, const int& i, const int mu, const int nu) const
-{ return -2*(mu == 0 && nu == 0) + (mu == nu); }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcov(const Loci loc, const int& j, const int& i, const int mu, const int nu) const
-{ return -2*(mu == 0 && nu == 0) + (mu == nu); }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet(const Loci loc, const int& j, const int& i) const
-{ return 1; }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(const int& j, const int& i, const int mu, const int nu, const int lam) const
-{ return 0; }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet_conn(const int& j, const int& i, const int mu, const int nu, const int lam) const
-{ return 0; }
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcon(
+    const Loci loc, const int& j, const int& i, const int mu, const int nu) const
+{
+    return -2 * (mu == 0 && nu == 0) + (mu == nu);
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcov(
+    const Loci loc, const int& j, const int& i, const int mu, const int nu) const
+{
+    return -2 * (mu == 0 && nu == 0) + (mu == nu);
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet(
+    const Loci loc, const int& j, const int& i) const
+{
+    return 1;
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(
+    const int& j, const int& i, const int mu, const int nu, const int lam) const
+{
+    return 0;
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet_conn(
+    const int& j, const int& i, const int mu, const int nu, const int lam) const
+{
+    return 0;
+}
 
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gcon(const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const
-{DLOOP2 gcon[mu][nu] = -2*(mu == 0 && nu == 0) + (mu == nu);}
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gcov(const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const
-{DLOOP2 gcov[mu][nu] = -2*(mu == 0 && nu == 0) + (mu == nu);}
-KOKKOS_INLINE_FUNCTION void GRCoordinates::conn(const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
-{DLOOP3 conn[mu][nu][lam] = 0;}
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gdet_conn(const int& j, const int& i, Real gdet_conn[GR_DIM][GR_DIM][GR_DIM]) const
-{DLOOP3 gdet_conn[mu][nu][lam] = 0;}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gcon(
+    const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const
+{
+    DLOOP2
+        gcon[mu][nu] = -2 * (mu == 0 && nu == 0) + (mu == nu);
+}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gcov(
+    const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const
+{
+    DLOOP2
+        gcov[mu][nu] = -2 * (mu == 0 && nu == 0) + (mu == nu);
+}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::conn(
+    const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
+{
+    DLOOP3
+        conn[mu][nu][lam] = 0;
+}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gdet_conn(
+    const int& j, const int& i, Real gdet_conn[GR_DIM][GR_DIM][GR_DIM]) const
+{
+    DLOOP3
+        gdet_conn[mu][nu][lam] = 0;
+}
 #elif NO_CACHE
-// TODO these are currently VERY SLOW.  Rework them to generate just the desired component. (TODO gdet?...)
-// Except conn.  We never need conn fast.
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcon(const Loci loc, const int& j, const int& i, const int mu, const int nu) const
+// TODO these are currently VERY SLOW.  Rework them to generate just the desired
+// component. (TODO gdet?...) Except conn.  We never need conn fast.
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcon(
+    const Loci loc, const int& j, const int& i, const int mu, const int nu) const
 {
     GReal X[GR_DIM], gcon[GR_DIM][GR_DIM];
     coord(0, j, i, loc, X);
     coords.gcon_native(X, gcon);
     return gcon[mu][nu];
 }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcov(const Loci loc, const int& j, const int& i, const int mu, const int nu) const
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcov(
+    const Loci loc, const int& j, const int& i, const int mu, const int nu) const
 {
     GReal X[GR_DIM], gcov[GR_DIM][GR_DIM];
     coord(0, j, i, loc, X);
     coords.gcov_native(X, gcov);
     return gcov[mu][nu];
 }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet(const Loci loc, const int& j, const int& i) const
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet(
+    const Loci loc, const int& j, const int& i) const
 {
     GReal X[GR_DIM], gcon[GR_DIM][GR_DIM];
     coord(0, j, i, loc, X);
     return coords.gcon_native(X, gcon);
 }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(const int& j, const int& i, const int mu, const int nu, const int lam) const
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(
+    const int& j, const int& i, const int mu, const int nu, const int lam) const
 {
     GReal X[GR_DIM], conn[GR_DIM][GR_DIM][GR_DIM];
     coord(0, j, i, Loci::center, X);
@@ -292,50 +354,85 @@ KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(const int& j, const int& i, cons
     return conn[mu][nu][lam];
 }
 
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gcon(const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gcon(
+    const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const
 {
     GReal X[GR_DIM];
     coord(0, j, i, loc, X);
     coords.gcon_native(X, gcon);
 }
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gcov(const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gcov(
+    const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const
 {
     GReal X[GR_DIM];
     coord(0, j, i, loc, X);
     coords.gcov_native(X, gcov);
 }
-KOKKOS_INLINE_FUNCTION void GRCoordinates::conn(const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::conn(
+    const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
 {
     GReal X[GR_DIM];
     coord(0, j, i, Loci::center, X);
     coords.conn_native(X, conn);
 }
 #else
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcon(const Loci loc, const int& j, const int& i, const int mu, const int nu) const
-{ return gcon_direct(loc, j, i, mu, nu); }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcov(const Loci loc, const int& j, const int& i, const int mu, const int nu) const
-{ return gcov_direct(loc, j, i, mu, nu); }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet(const Loci loc, const int& j, const int& i) const
-{ return gdet_direct(loc, j, i); }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(const int& j, const int& i, const int mu, const int nu, const int lam) const
-{ return conn_direct(j, i, mu, nu, lam); }
-KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet_conn(const int& j, const int& i, const int mu, const int nu, const int lam) const
-{ return gdet_conn_direct(j, i, mu, nu, lam); }
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcon(
+    const Loci loc, const int& j, const int& i, const int mu, const int nu) const
+{
+    return gcon_direct(loc, j, i, mu, nu);
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gcov(
+    const Loci loc, const int& j, const int& i, const int mu, const int nu) const
+{
+    return gcov_direct(loc, j, i, mu, nu);
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet(
+    const Loci loc, const int& j, const int& i) const
+{
+    return gdet_direct(loc, j, i);
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::conn(
+    const int& j, const int& i, const int mu, const int nu, const int lam) const
+{
+    return conn_direct(j, i, mu, nu, lam);
+}
+KOKKOS_INLINE_FUNCTION Real GRCoordinates::gdet_conn(
+    const int& j, const int& i, const int mu, const int nu, const int lam) const
+{
+    return gdet_conn_direct(j, i, mu, nu, lam);
+}
 
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gcon(const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const
-{ DLOOP2 gcon[mu][nu] = gcon_direct(loc, j, i, mu, nu); }
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gcov(const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const
-{ DLOOP2 gcov[mu][nu] = gcov_direct(loc, j, i, mu, nu); }
-KOKKOS_INLINE_FUNCTION void GRCoordinates::conn(const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
-{ DLOOP3 conn[mu][nu][lam] = conn_direct(j, i, mu, nu, lam); }
-KOKKOS_INLINE_FUNCTION void GRCoordinates::gdet_conn(const int& j, const int& i, Real gdet_conn[GR_DIM][GR_DIM][GR_DIM]) const
-{ DLOOP3 gdet_conn[mu][nu][lam] = gdet_conn_direct(j, i, mu, nu, lam); }
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gcon(
+    const Loci loc, const int& j, const int& i, Real gcon[GR_DIM][GR_DIM]) const
+{
+    DLOOP2
+        gcon[mu][nu] = gcon_direct(loc, j, i, mu, nu);
+}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gcov(
+    const Loci loc, const int& j, const int& i, Real gcov[GR_DIM][GR_DIM]) const
+{
+    DLOOP2
+        gcov[mu][nu] = gcov_direct(loc, j, i, mu, nu);
+}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::conn(
+    const int& j, const int& i, Real conn[GR_DIM][GR_DIM][GR_DIM]) const
+{
+    DLOOP3
+        conn[mu][nu][lam] = conn_direct(j, i, mu, nu, lam);
+}
+KOKKOS_INLINE_FUNCTION void GRCoordinates::gdet_conn(
+    const int& j, const int& i, Real gdet_conn[GR_DIM][GR_DIM][GR_DIM]) const
+{
+    DLOOP3
+        gdet_conn[mu][nu][lam] = gdet_conn_direct(j, i, mu, nu, lam);
+}
 
 #endif
 
 // Two implementations: Fast Cartesian can skip some things
 #if FAST_CARTESIAN
-KOKKOS_INLINE_FUNCTION void GRCoordinates::coord_embed(const int& k, const int& j, const int& i, const Loci& loc, GReal Xembed[GR_DIM]) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::coord_embed(
+    const int& k, const int& j, const int& i, const Loci& loc, GReal Xembed[GR_DIM]) const
 {
     // Only supports null transform
     coord(k, j, i, loc, Xembed);
@@ -343,11 +440,17 @@ KOKKOS_INLINE_FUNCTION void GRCoordinates::coord_embed(const int& k, const int& 
 
 // TODO this properly.  We just never call r/th/phi in Cart yet anyway
 KOKKOS_INLINE_FUNCTION void r(const int& k, const int& j, const int& i) const
-{ return 0; }
+{
+    return 0;
+}
 KOKKOS_INLINE_FUNCTION void th(const int& k, const int& j, const int& i) const
-{ return 0; }
+{
+    return 0;
+}
 KOKKOS_INLINE_FUNCTION void phi(const int& k, const int& j, const int& i) const
-{ return 0; }
+{
+    return 0;
+}
 KOKKOS_INLINE_FUNCTION void x(const int& k, const int& j, const int& i) const
 {
     GReal Xembed[GR_DIM];
@@ -369,7 +472,8 @@ KOKKOS_INLINE_FUNCTION void z(const int& k, const int& j, const int& i) const
 
 #else
 
-KOKKOS_INLINE_FUNCTION void GRCoordinates::coord_embed(const int& k, const int& j, const int& i, const Loci& loc, GReal Xembed[GR_DIM]) const
+KOKKOS_INLINE_FUNCTION void GRCoordinates::coord_embed(
+    const int& k, const int& j, const int& i, const Loci& loc, GReal Xembed[GR_DIM]) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);
@@ -378,37 +482,43 @@ KOKKOS_INLINE_FUNCTION void GRCoordinates::coord_embed(const int& k, const int& 
 
 // These are basically just call-throughs with coord()
 // TODO should we cache, esp for e.g. floors?
-KOKKOS_INLINE_FUNCTION GReal GRCoordinates::r(const int& k, const int& j, const int& i, const Loci& loc) const
+KOKKOS_INLINE_FUNCTION GReal GRCoordinates::r(
+    const int& k, const int& j, const int& i, const Loci& loc) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);
     return coords.r_of(Xnative);
 }
-KOKKOS_INLINE_FUNCTION GReal GRCoordinates::th(const int& k, const int& j, const int& i, const Loci& loc) const
+KOKKOS_INLINE_FUNCTION GReal GRCoordinates::th(
+    const int& k, const int& j, const int& i, const Loci& loc) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);
     return coords.th_of(Xnative);
 }
-KOKKOS_INLINE_FUNCTION GReal GRCoordinates::phi(const int& k, const int& j, const int& i, const Loci& loc) const
+KOKKOS_INLINE_FUNCTION GReal GRCoordinates::phi(
+    const int& k, const int& j, const int& i, const Loci& loc) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);
     return coords.phi_of(Xnative);
 }
-KOKKOS_INLINE_FUNCTION GReal GRCoordinates::x(const int& k, const int& j, const int& i, const Loci& loc) const
+KOKKOS_INLINE_FUNCTION GReal GRCoordinates::x(
+    const int& k, const int& j, const int& i, const Loci& loc) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);
     return coords.x_of(Xnative);
 }
-KOKKOS_INLINE_FUNCTION GReal GRCoordinates::y(const int& k, const int& j, const int& i, const Loci& loc) const
+KOKKOS_INLINE_FUNCTION GReal GRCoordinates::y(
+    const int& k, const int& j, const int& i, const Loci& loc) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);
     return coords.y_of(Xnative);
 }
-KOKKOS_INLINE_FUNCTION GReal GRCoordinates::z(const int& k, const int& j, const int& i, const Loci& loc) const
+KOKKOS_INLINE_FUNCTION GReal GRCoordinates::z(
+    const int& k, const int& j, const int& i, const Loci& loc) const
 {
     GReal Xnative[GR_DIM];
     coord(k, j, i, loc, Xnative);

--- a/kharma/coordinates/matrix.hpp
+++ b/kharma/coordinates/matrix.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: matrix.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -38,7 +38,7 @@
 /**
  * Reasonably fast functions for handling 4x4 matrices and symbols
  * NOT GR AWARE
- * 
+ *
  * TODO
  * * Take matrix refs instead of ponters
  * * template over matrix types float vs double
@@ -50,61 +50,63 @@
  */
 KOKKOS_INLINE_FUNCTION Real dot(const Real v1[GR_DIM], const Real v2[GR_DIM])
 {
-    return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2] + v1[3]*v2[3];
+    return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3];
 }
 
-KOKKOS_INLINE_FUNCTION Real MINOR(const Real m[16], int r0, int r1, int r2, int c0, int c1, int c2)
+KOKKOS_INLINE_FUNCTION Real MINOR(
+    const Real m[16], int r0, int r1, int r2, int c0, int c1, int c2)
 {
-  return m[4*r0+c0]*(m[4*r1+c1]*m[4*r2+c2] - m[4*r2+c1]*m[4*r1+c2]) -
-         m[4*r0+c1]*(m[4*r1+c0]*m[4*r2+c2] - m[4*r2+c0]*m[4*r1+c2]) +
-         m[4*r0+c2]*(m[4*r1+c0]*m[4*r2+c1] - m[4*r2+c0]*m[4*r1+c1]);
+    return m[4 * r0 + c0] *
+               (m[4 * r1 + c1] * m[4 * r2 + c2] - m[4 * r2 + c1] * m[4 * r1 + c2]) -
+           m[4 * r0 + c1] *
+               (m[4 * r1 + c0] * m[4 * r2 + c2] - m[4 * r2 + c0] * m[4 * r1 + c2]) +
+           m[4 * r0 + c2] *
+               (m[4 * r1 + c0] * m[4 * r2 + c1] - m[4 * r2 + c0] * m[4 * r1 + c1]);
 }
 
 KOKKOS_INLINE_FUNCTION void adjoint(const Real m[16], Real adjOut[16])
 {
-  adjOut[ 0] =  MINOR(m,1,2,3,1,2,3);
-  adjOut[ 1] = -MINOR(m,0,2,3,1,2,3);
-  adjOut[ 2] =  MINOR(m,0,1,3,1,2,3);
-  adjOut[ 3] = -MINOR(m,0,1,2,1,2,3);
+    adjOut[0] = MINOR(m, 1, 2, 3, 1, 2, 3);
+    adjOut[1] = -MINOR(m, 0, 2, 3, 1, 2, 3);
+    adjOut[2] = MINOR(m, 0, 1, 3, 1, 2, 3);
+    adjOut[3] = -MINOR(m, 0, 1, 2, 1, 2, 3);
 
-  adjOut[ 4] = -MINOR(m,1,2,3,0,2,3);
-  adjOut[ 5] =  MINOR(m,0,2,3,0,2,3);
-  adjOut[ 6] = -MINOR(m,0,1,3,0,2,3);
-  adjOut[ 7] =  MINOR(m,0,1,2,0,2,3);
+    adjOut[4] = -MINOR(m, 1, 2, 3, 0, 2, 3);
+    adjOut[5] = MINOR(m, 0, 2, 3, 0, 2, 3);
+    adjOut[6] = -MINOR(m, 0, 1, 3, 0, 2, 3);
+    adjOut[7] = MINOR(m, 0, 1, 2, 0, 2, 3);
 
-  adjOut[ 8] =  MINOR(m,1,2,3,0,1,3);
-  adjOut[ 9] = -MINOR(m,0,2,3,0,1,3);
-  adjOut[10] =  MINOR(m,0,1,3,0,1,3);
-  adjOut[11] = -MINOR(m,0,1,2,0,1,3);
+    adjOut[8] = MINOR(m, 1, 2, 3, 0, 1, 3);
+    adjOut[9] = -MINOR(m, 0, 2, 3, 0, 1, 3);
+    adjOut[10] = MINOR(m, 0, 1, 3, 0, 1, 3);
+    adjOut[11] = -MINOR(m, 0, 1, 2, 0, 1, 3);
 
-  adjOut[12] = -MINOR(m,1,2,3,0,1,2);
-  adjOut[13] =  MINOR(m,0,2,3,0,1,2);
-  adjOut[14] = -MINOR(m,0,1,3,0,1,2);
-  adjOut[15] =  MINOR(m,0,1,2,0,1,2);
+    adjOut[12] = -MINOR(m, 1, 2, 3, 0, 1, 2);
+    adjOut[13] = MINOR(m, 0, 2, 3, 0, 1, 2);
+    adjOut[14] = -MINOR(m, 0, 1, 3, 0, 1, 2);
+    adjOut[15] = MINOR(m, 0, 1, 2, 0, 1, 2);
 }
 
 KOKKOS_INLINE_FUNCTION Real determinant(const Real m[16])
 {
-  return m[0]*MINOR(m,1,2,3,1,2,3) -
-         m[1]*MINOR(m,1,2,3,0,2,3) +
-         m[2]*MINOR(m,1,2,3,0,1,3) -
-         m[3]*MINOR(m,1,2,3,0,1,2);
+    return m[0] * MINOR(m, 1, 2, 3, 1, 2, 3) - m[1] * MINOR(m, 1, 2, 3, 0, 2, 3) +
+           m[2] * MINOR(m, 1, 2, 3, 0, 1, 3) - m[3] * MINOR(m, 1, 2, 3, 0, 1, 2);
 }
 
 /**
  * Matrix inversion. Call with pointers, i.e. &matrix_name[0][0]
  */
-KOKKOS_INLINE_FUNCTION Real invert(const Real *m, Real *invOut)
+KOKKOS_INLINE_FUNCTION Real invert(const Real* m, Real* invOut)
 {
-  adjoint(m, invOut);
+    adjoint(m, invOut);
 
-  Real det = determinant(m);
-  Real inv_det = 1. / det;
-  for (int i = 0; i < 16; ++i) {
-    invOut[i] *= inv_det;
-  }
+    Real det = determinant(m);
+    Real inv_det = 1. / det;
+    for (int i = 0; i < 16; ++i) {
+        invOut[i] *= inv_det;
+    }
 
-  return det;
+    return det;
 }
 
 /**
@@ -114,55 +116,55 @@ KOKKOS_INLINE_FUNCTION Real invert(const Real *m, Real *invOut)
 template<int n>
 KOKKOS_INLINE_FUNCTION int pp(int P[n])
 {
-  int x;
-  int p = 0;
-  int v[n] = {0};
+    int x;
+    int p = 0;
+    int v[n] = {0};
 
-  for (int j = 0; j < n; j++) {
-    if (v[j]) {
-      p++;
-    } else {
-      x = j;
-      do {
-        x = P[x];
-        v[x] = 1;
-      } while (x != j);
+    for (int j = 0; j < n; j++) {
+        if (v[j]) {
+            p++;
+        } else {
+            x = j;
+            do {
+                x = P[x];
+                v[x] = 1;
+            } while (x != j);
+        }
     }
-  }
 
-  if (p % 2 == 0) {
-    return 1;
-  } else {
-    return -1;
-  }
+    if (p % 2 == 0) {
+        return 1;
+    } else {
+        return -1;
+    }
 }
 
 // Completely antisymmetric 4D symbol
 KOKKOS_INLINE_FUNCTION int antisym(int a, int b, int c, int d)
 {
-  // Entries different? 
-  if (a == b) return 0;
-  if (a == c) return 0;
-  if (a == d) return 0;
-  if (b == c) return 0;
-  if (b == d) return 0;
-  if (c == d) return 0;
+    // Entries different?
+    if (a == b) return 0;
+    if (a == c) return 0;
+    if (a == d) return 0;
+    if (b == c) return 0;
+    if (b == d) return 0;
+    if (c == d) return 0;
 
-  // Determine parity of permutation
-  int p[4] = {a, b, c, d};
+    // Determine parity of permutation
+    int p[4] = {a, b, c, d};
 
-  return pp<4>(p);
+    return pp<4>(p);
 }
 
 KOKKOS_INLINE_FUNCTION int antisym(int a, int b, int c)
 {
-  // Entries different? 
-  if (a == b) return 0;
-  if (a == c) return 0;
-  if (b == c) return 0;
+    // Entries different?
+    if (a == b) return 0;
+    if (a == c) return 0;
+    if (b == c) return 0;
 
-  // Determine parity of permutation
-  int p[3] = {a, b, c};
+    // Determine parity of permutation
+    int p[3] = {a, b, c};
 
-  return pp<3>(p);
+    return pp<3>(p);
 }

--- a/kharma/coordinates/root_find.hpp
+++ b/kharma/coordinates/root_find.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: coordinate_systems.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,82 +40,100 @@
 /**
  * Root finder macro for X[2] since it is sometimes not analytically invertible
  * Written with a common interface for doing 2D solves, if those are ever required
- * 
+ *
  * TODO ASSUMES Xnative bounds are [0,1] and Xembed bounds are [0,M_PI]!!!!!
- * TODO I cannot find a remotely simple way to do this with templates or function pointers:
- *      if this is taken out of the enclosing scope we need to resolve coord_to_embed, which is haaaard
- * 
- * Takes names Xembed (filled, not modified), Xnative (filled, modifies X[2]), and calls function coord_to_embed
+ * TODO I cannot find a remotely simple way to do this with templates or function
+ * pointers: if this is taken out of the enclosing scope we need to resolve
+ * coord_to_embed, which is haaaard
+ *
+ * Takes names Xembed (filled, not modified), Xnative (filled, modifies X[2]), and calls
+ * function coord_to_embed
  */
-#define ROOT_FIND \
-    double th = Xembed[2];\
-    double tha, thb, thc;\
-\
-    double Xa[GR_DIM], Xb[GR_DIM], Xc[GR_DIM], Xtmp[GR_DIM];\
-    Xa[1] = Xnative[1];\
-    Xa[3] = Xnative[3];\
-\
-    Xb[1] = Xa[1];\
-    Xb[3] = Xa[3];\
-    Xc[1] = Xa[1];\
-    Xc[3] = Xa[3];\
-\
-    if (Xembed[2] < M_PI / 2.) {\
-        Xa[2] = 0.;\
-        Xb[2] = 0.5 + 1.e-14;\
-    } else {\
-        Xa[2] = 0.5 - 1.e-14;\
-        Xb[2] = 1.;\
-    }\
-\
-    coord_to_embed(Xa, Xtmp); tha = Xtmp[2];\
-    coord_to_embed(Xb, Xtmp); thb = Xtmp[2];\
-\
-    if (m::abs(tha-th) < ROOTFIND_TOL) {\
-        Xnative[2] = Xa[2]; return;\
-    } else if (m::abs(thb-th) < ROOTFIND_TOL) {\
-        Xnative[2] = Xb[2]; return;\
-    }\
-    for (int i = 0; i < 1000; i++) {\
-        Xc[2] = 0.5 * (Xa[2] + Xb[2]);\
-        coord_to_embed(Xc, Xtmp); thc = Xtmp[2];\
-\
-        if (m::abs(thc - th) < ROOTFIND_TOL) break;\
-        else if ((thc - th) * (thb - th) < 0.) Xa[2] = Xc[2];\
-        else Xb[2] = Xc[2];\
-    }\
+#define ROOT_FIND                                                                        \
+    double th = Xembed[2];                                                               \
+    double tha, thb, thc;                                                                \
+                                                                                         \
+    double Xa[GR_DIM], Xb[GR_DIM], Xc[GR_DIM], Xtmp[GR_DIM];                             \
+    Xa[1] = Xnative[1];                                                                  \
+    Xa[3] = Xnative[3];                                                                  \
+                                                                                         \
+    Xb[1] = Xa[1];                                                                       \
+    Xb[3] = Xa[3];                                                                       \
+    Xc[1] = Xa[1];                                                                       \
+    Xc[3] = Xa[3];                                                                       \
+                                                                                         \
+    if (Xembed[2] < M_PI / 2.) {                                                         \
+        Xa[2] = 0.;                                                                      \
+        Xb[2] = 0.5 + 1.e-14;                                                            \
+    } else {                                                                             \
+        Xa[2] = 0.5 - 1.e-14;                                                            \
+        Xb[2] = 1.;                                                                      \
+    }                                                                                    \
+                                                                                         \
+    coord_to_embed(Xa, Xtmp);                                                            \
+    tha = Xtmp[2];                                                                       \
+    coord_to_embed(Xb, Xtmp);                                                            \
+    thb = Xtmp[2];                                                                       \
+                                                                                         \
+    if (m::abs(tha - th) < ROOTFIND_TOL) {                                               \
+        Xnative[2] = Xa[2];                                                              \
+        return;                                                                          \
+    } else if (m::abs(thb - th) < ROOTFIND_TOL) {                                        \
+        Xnative[2] = Xb[2];                                                              \
+        return;                                                                          \
+    }                                                                                    \
+    for (int i = 0; i < 1000; i++) {                                                     \
+        Xc[2] = 0.5 * (Xa[2] + Xb[2]);                                                   \
+        coord_to_embed(Xc, Xtmp);                                                        \
+        thc = Xtmp[2];                                                                   \
+                                                                                         \
+        if (m::abs(thc - th) < ROOTFIND_TOL)                                             \
+            break;                                                                       \
+        else if ((thc - th) * (thb - th) < 0.)                                           \
+            Xa[2] = Xc[2];                                                               \
+        else                                                                             \
+            Xb[2] = Xc[2];                                                               \
+    }                                                                                    \
     Xnative[2] = Xc[2];
 
-#define ROOT_FIND_1 \
-    double r = Xembed[1];\
-    double ra, rb, rc;\
-\
-    double Xa[GR_DIM], Xb[GR_DIM], Xc[GR_DIM], Xtmp[GR_DIM];\
-    Xa[2] = Xnative[2];\
-    Xa[3] = Xnative[3];\
-\
-    Xb[2] = Xa[2];\
-    Xb[3] = Xa[3];\
-    Xc[2] = Xa[2];\
-    Xc[3] = Xa[3];\
-\
-    Xa[1] = 0.;\
-    Xb[1] = 100.;\
-\
-    coord_to_embed(Xa, Xtmp); ra = Xtmp[1];\
-    coord_to_embed(Xb, Xtmp); rb = Xtmp[1];\
-\
-    if (m::abs(ra-r) < ROOTFIND_TOL) {\
-        Xnative[1] = Xa[1]; return;\
-    } else if (m::abs(rb-r) < ROOTFIND_TOL) {\
-        Xnative[1] = Xb[1]; return;\
-    }\
-    for (int i = 0; i < 1000; i++) {\
-        Xc[1] = 0.5 * (Xa[1] + Xb[1]);\
-        coord_to_embed(Xc, Xtmp); rc = Xtmp[1];\
-\
-        if (m::abs(rc - r) < ROOTFIND_TOL) break;\
-        else if ((rc - r) * (rb - r) < 0.) Xa[1] = Xc[1];\
-        else Xb[1] = Xc[1];\
-    }\
+#define ROOT_FIND_1                                                                      \
+    double r = Xembed[1];                                                                \
+    double ra, rb, rc;                                                                   \
+                                                                                         \
+    double Xa[GR_DIM], Xb[GR_DIM], Xc[GR_DIM], Xtmp[GR_DIM];                             \
+    Xa[2] = Xnative[2];                                                                  \
+    Xa[3] = Xnative[3];                                                                  \
+                                                                                         \
+    Xb[2] = Xa[2];                                                                       \
+    Xb[3] = Xa[3];                                                                       \
+    Xc[2] = Xa[2];                                                                       \
+    Xc[3] = Xa[3];                                                                       \
+                                                                                         \
+    Xa[1] = 0.;                                                                          \
+    Xb[1] = 100.;                                                                        \
+                                                                                         \
+    coord_to_embed(Xa, Xtmp);                                                            \
+    ra = Xtmp[1];                                                                        \
+    coord_to_embed(Xb, Xtmp);                                                            \
+    rb = Xtmp[1];                                                                        \
+                                                                                         \
+    if (m::abs(ra - r) < ROOTFIND_TOL) {                                                 \
+        Xnative[1] = Xa[1];                                                              \
+        return;                                                                          \
+    } else if (m::abs(rb - r) < ROOTFIND_TOL) {                                          \
+        Xnative[1] = Xb[1];                                                              \
+        return;                                                                          \
+    }                                                                                    \
+    for (int i = 0; i < 1000; i++) {                                                     \
+        Xc[1] = 0.5 * (Xa[1] + Xb[1]);                                                   \
+        coord_to_embed(Xc, Xtmp);                                                        \
+        rc = Xtmp[1];                                                                    \
+                                                                                         \
+        if (m::abs(rc - r) < ROOTFIND_TOL)                                               \
+            break;                                                                       \
+        else if ((rc - r) * (rb - r) < 0.)                                               \
+            Xa[1] = Xc[1];                                                               \
+        else                                                                             \
+            Xb[1] = Xc[1];                                                               \
+    }                                                                                    \
     Xnative[1] = Xc[1];

--- a/kharma/current/current.cpp
+++ b/kharma/current/current.cpp
@@ -34,19 +34,23 @@
 
 #include "current.hpp"
 
-std::shared_ptr<KHARMAPackage> Current::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Current::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Current");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // 4-current jcon. Calculated only for output
     std::vector<int> s_fourvector({GR_DIM});
-    auto m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_fourvector);
+    auto m =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy},
+            s_fourvector);
     pkg->AddField("jcon", m);
 
     // Temporaries
     std::vector<int> s_vector({NVEC});
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_vector);
+    m = Metadata(
+        {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_vector);
     pkg->AddField("Current.uvec_c", m);
     pkg->AddField("Current.B_P_c", m);
 
@@ -55,7 +59,8 @@ std::shared_ptr<KHARMAPackage> Current::Initialize(ParameterInput *pin, std::sha
     return pkg;
 }
 
-TaskStatus Current::CalculateCurrent(MeshBlockData<Real> *rc0, MeshBlockData<Real> *rc1, const double& dt)
+TaskStatus Current::CalculateCurrent(
+    MeshBlockData<Real>* rc0, MeshBlockData<Real>* rc1, const double& dt)
 {
     auto pmb = rc0->GetBlockPointer();
     GridVector uvec_old = rc0->Get("prims.uvec").data;
@@ -76,45 +81,49 @@ TaskStatus Current::CalculateCurrent(MeshBlockData<Real> *rc0, MeshBlockData<Rea
     const IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
     const IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
     const IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
-    const IndexRange nv = IndexRange{0, NVEC-1};
+    const IndexRange nv = IndexRange{0, NVEC - 1};
     pmb->par_for("get_center", nv.s, nv.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &p, const int &k, const int &j, const int &i) {
-            uvec_c(p, k, j, i) = 0.5*(uvec_old(p, k, j, i) + uvec_new(p, k, j, i));
-            B_P_c(p, k, j, i) = 0.5*(B_P_old(p, k, j, i) + B_P_new(p, k, j, i));
-        }
-    );
+                 KOKKOS_LAMBDA(const int& p, const int& k, const int& j, const int& i)
+        {
+            uvec_c(p, k, j, i) = 0.5 * (uvec_old(p, k, j, i) + uvec_new(p, k, j, i));
+            B_P_c(p, k, j, i) = 0.5 * (B_P_old(p, k, j, i) + B_P_new(p, k, j, i));
+        });
 
     // Calculate j^{\mu} using centered differences for active zones
     const IndexRange ib_i = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
     const IndexRange jb_i = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
     const IndexRange kb_i = pmb->cellbounds.GetBoundsK(IndexDomain::interior);
-    const IndexRange n4v = IndexRange{0, GR_DIM-1};
-    pmb->par_for("jcon_calc", n4v.s, n4v.e, kb_i.s, kb_i.e, jb_i.s, jb_i.e, ib_i.s, ib_i.e,
-        KOKKOS_LAMBDA (const int &mu, const int &k, const int &j, const int &i) {
+    const IndexRange n4v = IndexRange{0, GR_DIM - 1};
+    pmb->par_for("jcon_calc", n4v.s, n4v.e, kb_i.s, kb_i.e, jb_i.s, jb_i.e, ib_i.s,
+        ib_i.e,
+        KOKKOS_LAMBDA(const int& mu, const int& k, const int& j, const int& i)
+        {
             // Get sqrt{-g}*F^{mu nu} at neighboring points
-            // TODO(BSP) this recalculates Fcon a lot...
+            // TODO(CEP) this recalculates Fcon a lot...
             const Real gF0p = get_gdet_Fcon(G, uvec_new, B_P_new, mu, 0, k, j, i);
             const Real gF0m = get_gdet_Fcon(G, uvec_old, B_P_old, mu, 0, k, j, i);
-            const Real gF1p = get_gdet_Fcon(G, uvec_c, B_P_c, mu, 1, k, j, i+1);
-            const Real gF1m = get_gdet_Fcon(G, uvec_c, B_P_c, mu, 1, k, j, i-1);
-            const Real gF2p = (ndim > 1) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 2, k, j+1, i) : 0.;
-            const Real gF2m = (ndim > 1) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 2, k, j-1, i) : 0.;
-            const Real gF3p = (ndim > 2) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 3, k+1, j, i) : 0.;
-            const Real gF3m = (ndim > 2) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 3, k-1, j, i) : 0.;
+            const Real gF1p = get_gdet_Fcon(G, uvec_c, B_P_c, mu, 1, k, j, i + 1);
+            const Real gF1m = get_gdet_Fcon(G, uvec_c, B_P_c, mu, 1, k, j, i - 1);
+            const Real gF2p =
+                (ndim > 1) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 2, k, j + 1, i) : 0.;
+            const Real gF2m =
+                (ndim > 1) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 2, k, j - 1, i) : 0.;
+            const Real gF3p =
+                (ndim > 2) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 3, k + 1, j, i) : 0.;
+            const Real gF3m =
+                (ndim > 2) ? get_gdet_Fcon(G, uvec_c, B_P_c, mu, 3, k - 1, j, i) : 0.;
 
             // Difference: D_mu F^{mu nu} = 4 \pi j^nu
             jcon(mu, k, j, i) = 1. / (m::sqrt(4. * M_PI) * G.gdet(Loci::center, j, i)) *
-                                ((gF0p - gF0m) / dt +
-                                (gF1p - gF1m) / (2 * G.Dxc<1>(i)) +
-                                (gF2p - gF2m) / (2 * G.Dxc<2>(j)) +
-                                (gF3p - gF3m) / (2 * G.Dxc<3>(k)));
-        }
-    );
+                                ((gF0p - gF0m) / dt + (gF1p - gF1m) / (2 * G.Dxc<1>(i)) +
+                                    (gF2p - gF2m) / (2 * G.Dxc<2>(j)) +
+                                    (gF3p - gF3m) / (2 * G.Dxc<3>(k)));
+        });
 
     return TaskStatus::complete;
 }
 
-void Current::FillOutput(MeshBlock *pmb, ParameterInput *pin)
+void Current::FillOutput(MeshBlock* pmb, ParameterInput* pin)
 {
     // The "preserve" container will only exist after we've taken a step,
     // catch that situation
@@ -126,7 +135,7 @@ void Current::FillOutput(MeshBlock *pmb, ParameterInput *pin)
     } catch (const std::runtime_error& e) {
         // We expect this to happen the first step
         // We just don't need to fill jcon the first time around
-        //std::cerr << "This should only happen once: " << e.what() << std::endl;
+        // std::cerr << "This should only happen once: " << e.what() << std::endl;
         return;
     }
 

--- a/kharma/current/current.hpp
+++ b/kharma/current/current.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: current.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,34 +36,37 @@
 #include <parthenon/parthenon.hpp>
 
 #include "decs.hpp"
-#include "matrix.hpp"
 #include "grmhd_functions.hpp"
+#include "matrix.hpp"
 
 namespace Current
 {
 /**
  * Initialize output field jcon
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Fill outputs, namely jcon.  Just calls CalculateCurrent below.
  */
-void FillOutput(MeshBlock *pmb, ParameterInput *pin);
+void FillOutput(MeshBlock* pmb, ParameterInput* pin);
 
 /**
- * Calculate the 4-current j^nu (jcon), given the MeshBlockData at the beginning and end of a step,
- * and the time between them.
+ * Calculate the 4-current j^nu (jcon), given the MeshBlockData at the beginning and end
+ * of a step, and the time between them.
  */
-TaskStatus CalculateCurrent(MeshBlockData<Real> *rc0, MeshBlockData<Real> *rc1, const double& dt);
+TaskStatus CalculateCurrent(
+    MeshBlockData<Real>* rc0, MeshBlockData<Real>* rc1, const double& dt);
 
 /**
- * Return mu, nu component of contravarient Maxwell tensor at grid zone i, j, k, multiplied by the
- * root negative metric determinant sqrt(-g).
- * Easier to calculate than the regular version as I needn't divide by gdet.
+ * Return mu, nu component of contravarient Maxwell tensor at grid zone i, j, k,
+ * multiplied by the root negative metric determinant sqrt(-g). Easier to calculate than
+ * the regular version as I needn't divide by gdet.
  */
-KOKKOS_INLINE_FUNCTION double get_gdet_Fcon(const GRCoordinates& G, GridVector uvec, GridVector B_P,
-                                        const int& mu, const int& nu, const int& k, const int& j, const int& i)
+KOKKOS_INLINE_FUNCTION double get_gdet_Fcon(const GRCoordinates& G, GridVector uvec,
+    GridVector B_P, const int& mu, const int& nu, const int& k, const int& j,
+    const int& i)
 {
     if (mu == nu) return 0.;
 

--- a/kharma/domain.hpp
+++ b/kharma/domain.hpp
@@ -63,7 +63,7 @@ KOKKOS_INLINE_FUNCTION bool inside(const int& k, const int& j, const int& i, con
     return !outside(k, j, i, b);
 }
 
-// TODO(BSP) these really should be in Parthenon
+// TODO(CEP) these really should be in Parthenon
 // There's a templated way to do it I forget, but this would be easier
 template<typename T>
 inline const int& GetNDim(MeshBlockData<T>* rc)

--- a/kharma/driver/imex_step.cpp
+++ b/kharma/driver/imex_step.cpp
@@ -35,55 +35,59 @@
 
 #include "decs.hpp"
 
-//Packages
+// Packages
 #include "b_cd.hpp"
 #include "b_cleanup.hpp"
 #include "b_ct.hpp"
 #include "b_flux_ct.hpp"
 #include "electrons.hpp"
+#include "grmhd.hpp"
 #include "inverter.hpp"
 #include "ismr.hpp"
-#include "grmhd.hpp"
 #include "wind.hpp"
 // Other headers
 #include "boundaries.hpp"
 #include "flux.hpp"
+#include "implicit.hpp"
 #include "kharma.hpp"
 #include "resize_restart.hpp"
-#include "implicit.hpp"
 
-#include <parthenon/parthenon.hpp>
-#include <interface/update.hpp>
 #include <amr_criteria/refinement_package.hpp>
+#include <interface/update.hpp>
+#include <parthenon/parthenon.hpp>
 
 using FC = Metadata::FlagCollection;
 
-TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int stage)
+TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t& blocks, int stage)
 {
     // Reminder that this list is created BEFORE any of the list contents are run!
-    // Prints or function calls here will likely not do what you want: instead, add to the list by calling tl.AddTask()
+    // Prints or function calls here will likely not do what you want: instead, add to the
+    // list by calling tl.AddTask()
 
     TaskCollection tc;
     TaskID t_none(0);
 
     // Which packages we've loaded affects which tasks we'll add to the list
-    auto& pkgs         = blocks[0]->packages.AllPackages();
-    auto& flux_pkg   = pkgs.at("Fluxes")->AllParams();
+    auto& pkgs = blocks[0]->packages.AllPackages();
+    auto& flux_pkg = pkgs.at("Fluxes")->AllParams();
     const bool use_b_cleanup = pkgs.count("B_Cleanup");
     const bool use_b_ct = pkgs.count("B_CT");
     const bool use_electrons = pkgs.count("Electrons");
     const bool use_fofc = flux_pkg.Get<bool>("use_fofc");
     const bool use_implicit = pkgs.count("Implicit");
     const bool use_jcon = pkgs.count("Current");
-    const bool use_linesearch = (use_implicit) ? pkgs.at("Implicit")->Param<bool>("linesearch") : false;
+    const bool use_linesearch =
+        (use_implicit) ? pkgs.at("Implicit")->Param<bool>("linesearch") : false;
     const bool emhd_enabled = pkgs.count("EMHD");
-    const bool use_ideal_guess = (emhd_enabled) ? pkgs.at("GRMHD")->Param<bool>("ideal_guess") : false;
+    const bool use_ideal_guess =
+        (emhd_enabled) ? pkgs.at("GRMHD")->Param<bool>("ideal_guess") : false;
 
     // Allocate/copy the things we need
-    // TODO these can now be reduced by including the var lists/flags which actually need to be allocated
+    // TODO these can now be reduced by including the var lists/flags which actually need
+    // to be allocated
     // TODO except the Copy they can be run on step 1 only
     if (stage == 1) {
-        auto &base = pmesh->mesh_data.Get("base");
+        auto& base = pmesh->mesh_data.Get("base");
         // Fluxes
         pmesh->mesh_data.Add("dUdt", base);
         for (int i = 1; i < integrator->nstages; i++)
@@ -95,22 +99,25 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
             static parthenon::Metadata::FlagVec preserve_flags;
             static std::vector<std::string> preserve_vars;
             if (preserve_vars.size() == 0) {
-                preserve_flags = {Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")};
-                preserve_vars = KHARMA::GetVariableNames(&(pmesh->packages), FC(preserve_flags));
+                preserve_flags = {
+                    Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")};
+                preserve_vars =
+                    KHARMA::GetVariableNames(&(pmesh->packages), FC(preserve_flags));
             }
             // Add the container once to avoid re-adding if we have lots of partitions
-            //pmesh->mesh_data.Add("preserve", base, preserve_vars);
+            // pmesh->mesh_data.Add("preserve", base, preserve_vars);
             // Ensure we copy the MHD variables every step with a task
             const int num_partitions = pmesh->DefaultNumPartitions();
-            TaskRegion &copy_region = tc.AddRegion(num_partitions);
+            TaskRegion& copy_region = tc.AddRegion(num_partitions);
             for (int i = 0; i < num_partitions; i++) {
-                auto &tl = copy_region[i];
-                tl.AddTask(t_none, Copy<MeshData<Real>>, preserve_flags,
-                            base.get(), pmesh->mesh_data.Add("preserve", base, preserve_vars).get());
+                auto& tl = copy_region[i];
+                tl.AddTask(t_none, Copy<MeshData<Real>>, preserve_flags, base.get(),
+                    pmesh->mesh_data.Add("preserve", base, preserve_vars).get());
             }
         }
-        // FOFC needs to determine whether the "real" U-divF will violate floors, and needs a safe place to do it.
-        // We populate it later, with each *sub-step*'s initial state
+        // FOFC needs to determine whether the "real" U-divF will violate floors, and
+        // needs a safe place to do it. We populate it later, with each *sub-step*'s
+        // initial state
         if (use_fofc) {
             pmesh->mesh_data.Add("fofc_source", base);
             pmesh->mesh_data.Add("fofc_guess", base);
@@ -128,52 +135,69 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
 
     static std::vector<std::string> sync_vars;
     if (sync_vars.size() == 0) {
-        // Build the universe of variables to let Parthenon see when exchanging boundaries.
-        // This is built to exclude incidental variables like B field initialization stuff, EMFs, etc.
-        // "Boundaries" packs in buffers e.g. Dirichlet boundaries
+        // Build the universe of variables to let Parthenon see when exchanging
+        // boundaries. This is built to exclude incidental variables like B field
+        // initialization stuff, EMFs, etc. "Boundaries" packs in buffers e.g. Dirichlet
+        // boundaries
         auto sync_flags = FC({Metadata::GetUserFlag("Primitive"), Metadata::Conserved,
-                              Metadata::Face, Metadata::GetUserFlag("Boundaries")}, true);
+                                 Metadata::Face, Metadata::GetUserFlag("Boundaries")},
+            true);
         sync_vars = KHARMA::GetVariableNames(&(pmesh->packages), sync_flags);
     }
 
     // Flux region: calculate and apply fluxes to update conserved values
     const int num_partitions = pmesh->DefaultNumPartitions();
-    TaskRegion &flux_region = tc.AddRegion(num_partitions);
+    TaskRegion& flux_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
-        auto &tl = flux_region[i];
+        auto& tl = flux_region[i];
         // Container names:
-        // '_full_step_init' refers to the fluid state at the start of the full time step (Si in iharm3d)
-        // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in iharm3d)
-        // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in iharm3d)
+        // '_full_step_init' refers to the fluid state at the start of the full time step
+        // (Si in iharm3d)
+        // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in
+        // iharm3d)
+        // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in
+        // iharm3d)
         // '_flux_src' refers to the mesh object corresponding to -divF + S
-        // '_solver' refers to the fluid state passed to the Implicit solver. At the end of the solve
-        // '_linesearch' refers to the fluid state updated while performing a linesearch in the solver
-        // copy P and U from solver state to sub_step_final state.
-        auto &md_full_step_init = pmesh->mesh_data.GetOrAdd("base", i);
-        auto &md_sub_step_init  = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], i);
-        auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
-        auto &md_flux_src       = pmesh->mesh_data.GetOrAdd("dUdt", i);
-        // Normally we put explicit update in md_solver, then add implicitly-evolved variables and copy back.
-        // If we're not doing an implicit solve at all, just write straight to sub_step_final
-        std::shared_ptr<MeshData<Real>> &md_solver = (use_implicit) ? pmesh->mesh_data.GetOrAdd("solver", i) : md_sub_step_final;
-        auto &md_sync = pmesh->mesh_data.AddShallow("sync"+integrator->stage_name[stage]+std::to_string(i), md_sub_step_final, sync_vars);
+        // '_solver' refers to the fluid state passed to the Implicit solver. At the end
+        // of the solve
+        // '_linesearch' refers to the fluid state updated while performing a linesearch
+        // in the solver copy P and U from solver state to sub_step_final state.
+        auto& md_full_step_init = pmesh->mesh_data.GetOrAdd("base", i);
+        auto& md_sub_step_init =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], i);
+        auto& md_sub_step_final =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+        auto& md_flux_src = pmesh->mesh_data.GetOrAdd("dUdt", i);
+        // Normally we put explicit update in md_solver, then add implicitly-evolved
+        // variables and copy back. If we're not doing an implicit solve at all, just
+        // write straight to sub_step_final
+        std::shared_ptr<MeshData<Real>>& md_solver =
+            (use_implicit) ? pmesh->mesh_data.GetOrAdd("solver", i) : md_sub_step_final;
+        auto& md_sync = pmesh->mesh_data.AddShallow(
+            "sync" + integrator->stage_name[stage] + std::to_string(i), md_sub_step_final,
+            sync_vars);
 
         // Start receiving flux corrections and ghost cells
-        auto t_start_recv_bound = tl.AddTask(t_none, parthenon::StartReceiveBoundBufs<parthenon::BoundaryType::any>, md_sub_step_final);
+        auto t_start_recv_bound = tl.AddTask(t_none,
+            parthenon::StartReceiveBoundBufs<parthenon::BoundaryType::any>,
+            md_sub_step_final);
         auto t_start_recv_flux = t_start_recv_bound;
         if (pmesh->multilevel || use_b_ct)
-            t_start_recv_flux = tl.AddTask(t_none, parthenon::StartReceiveFluxCorrections, md_sub_step_init);
+            t_start_recv_flux = tl.AddTask(
+                t_none, parthenon::StartReceiveFluxCorrections, md_sub_step_init);
 
         // Calculate the flux of each variable through each face
         // This reconstructs the primitives (P) at faces and uses them to calculate fluxes
         // of the conserved variables (U) through each face.
-        auto t_flux_calc = KHARMADriver::AddFluxCalculations(t_start_recv_flux, tl, md_sub_step_init.get());
+        auto t_flux_calc = KHARMADriver::AddFluxCalculations(
+            t_start_recv_flux, tl, md_sub_step_init.get());
         auto t_fluxes = t_flux_calc;
         if (use_fofc) {
-            auto &guess_src = pmesh->mesh_data.GetOrAdd("fofc_source", i);
-            auto &guess = pmesh->mesh_data.GetOrAdd("fofc_guess", i);
-            auto t_fluxes = KHARMADriver::AddFOFC(t_flux_calc, tl, md_sub_step_init.get(), md_full_step_init.get(),
-                                                  md_sub_step_init.get(), guess_src.get(), guess.get(), stage);
+            auto& guess_src = pmesh->mesh_data.GetOrAdd("fofc_source", i);
+            auto& guess = pmesh->mesh_data.GetOrAdd("fofc_guess", i);
+            auto t_fluxes = KHARMADriver::AddFOFC(t_flux_calc, tl, md_sub_step_init.get(),
+                md_full_step_init.get(), md_sub_step_init.get(), guess_src.get(),
+                guess.get(), stage);
         }
 
         // Any package modifications to the fluxes.  e.g.:
@@ -188,42 +212,59 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
             auto t_emf = t_flux_bounds;
             if (use_b_ct) {
                 // Pull out a container of only EMF to synchronize
-                auto &md_emf_only = pmesh->mesh_data.AddShallow("EMF", md_sub_step_init, std::vector<std::string>{"B_CT.emf"}); // TODO this gets weird if we partition
-                auto t_emf_local = tl.AddTask(t_flux_bounds, B_CT::CalculateEMF, md_sub_step_init.get());
+                auto& md_emf_only = pmesh->mesh_data.AddShallow("EMF", md_sub_step_init,
+                    std::vector<std::string>{
+                        "B_CT.emf"}); // TODO this gets weird if we partition
+                auto t_emf_local =
+                    tl.AddTask(t_flux_bounds, B_CT::CalculateEMF, md_sub_step_init.get());
                 t_emf = KHARMADriver::AddBoundarySync(t_emf_local, tl, md_emf_only);
             }
-            auto t_load_send_flux = tl.AddTask(t_emf, parthenon::LoadAndSendFluxCorrections, md_sub_step_init);
-            auto t_recv_flux = tl.AddTask(t_load_send_flux, parthenon::ReceiveFluxCorrections, md_sub_step_init);
-            t_flux_bounds = tl.AddTask(t_recv_flux, parthenon::SetFluxCorrections, md_sub_step_init);
+            auto t_load_send_flux = tl.AddTask(
+                t_emf, parthenon::LoadAndSendFluxCorrections, md_sub_step_init);
+            auto t_recv_flux = tl.AddTask(
+                t_load_send_flux, parthenon::ReceiveFluxCorrections, md_sub_step_init);
+            t_flux_bounds =
+                tl.AddTask(t_recv_flux, parthenon::SetFluxCorrections, md_sub_step_init);
         }
 
         // Apply the fluxes to calculate a change in cell-centered values "md_flux_src"
-        auto t_flux_div = tl.AddTask(t_flux_bounds, FluxDivergence, md_sub_step_init.get(), md_flux_src.get(),
-                                     std::vector<MetadataFlag>{Metadata::Independent, Metadata::Cell, Metadata::WithFluxes}, 0);
+        auto t_flux_div = tl.AddTask(t_flux_bounds, FluxDivergence,
+            md_sub_step_init.get(), md_flux_src.get(),
+            std::vector<MetadataFlag>{
+                Metadata::Independent, Metadata::Cell, Metadata::WithFluxes},
+            0);
 
         // Add any source terms: geometric \Gamma * T, wind, damping, etc etc
-        auto t_sources = tl.AddTask(t_flux_div, Packages::AddSource, md_sub_step_init.get(), md_flux_src.get(), IndexDomain::interior);
+        auto t_sources = tl.AddTask(t_flux_div, Packages::AddSource,
+            md_sub_step_init.get(), md_flux_src.get(), IndexDomain::interior);
 
         // Update explicit state with the explicit fluxes/sources
-        auto t_update = KHARMADriver::AddStateUpdate(t_sources, tl, md_full_step_init.get(), md_sub_step_init.get(),
-                                                     md_flux_src.get(), md_solver.get(),
-                                                     std::vector<MetadataFlag>{Metadata::GetUserFlag("Explicit"), Metadata::Independent},
-                                                     use_b_ct, stage);
+        auto t_update =
+            KHARMADriver::AddStateUpdate(t_sources, tl, md_full_step_init.get(),
+                md_sub_step_init.get(), md_flux_src.get(), md_solver.get(),
+                std::vector<MetadataFlag>{
+                    Metadata::GetUserFlag("Explicit"), Metadata::Independent},
+                use_b_ct, stage);
 
         // Update ideal HD variables so that they can be used as a guess for the solver.
         // Only used if emhd/ideal_guess is enabled.
-        // An additional `AddStateUpdate` task just for variables marked with the `IdealGuess` flag
+        // An additional `AddStateUpdate` task just for variables marked with the
+        // `IdealGuess` flag
         auto t_ideal_guess = t_update;
         if (use_ideal_guess) {
-            t_ideal_guess = KHARMADriver::AddStateUpdateIdealGuess(t_sources,  tl, md_full_step_init.get(), md_sub_step_init.get(),
-                                                     md_flux_src.get(), md_solver.get(),
-                                                     std::vector<MetadataFlag>{Metadata::GetUserFlag("IdealGuess"), Metadata::Independent},
-                                                     false, stage);
+            t_ideal_guess = KHARMADriver::AddStateUpdateIdealGuess(t_sources, tl,
+                md_full_step_init.get(), md_sub_step_init.get(), md_flux_src.get(),
+                md_solver.get(),
+                std::vector<MetadataFlag>{
+                    Metadata::GetUserFlag("IdealGuess"), Metadata::Independent},
+                false, stage);
         }
 
         // Make sure the primitive values of *explicitly-evolved* variables are updated.
-        // Packages with implicitly-evolved vars should only register BoundaryUtoP or BoundaryPtoU
-        auto t_explicit_UtoP = tl.AddTask(t_ideal_guess, Packages::MeshUtoP, md_solver.get(), IndexDomain::entire, false);
+        // Packages with implicitly-evolved vars should only register BoundaryUtoP or
+        // BoundaryPtoU
+        auto t_explicit_UtoP = tl.AddTask(t_ideal_guess, Packages::MeshUtoP,
+            md_solver.get(), IndexDomain::entire, false);
 
         // Done with explicit update
         auto t_explicit = t_explicit_UtoP;
@@ -231,126 +272,157 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
         auto t_implicit = t_explicit;
         if (use_implicit) {
             // Extra containers for implicit solve
-            std::shared_ptr<MeshData<Real>> &md_linesearch = (use_linesearch) ? pmesh->mesh_data.GetOrAdd("linesearch", i) : md_solver;
+            std::shared_ptr<MeshData<Real>>& md_linesearch =
+                (use_linesearch) ? pmesh->mesh_data.GetOrAdd("linesearch", i) : md_solver;
 
-            // Copy the current state of any implicitly-evolved vars (at least the prims) in as a guess.
-            // If we aren't using the ideal solution as the guess, set md_solver = md_sub_step_init
-            auto t_copy_guess       = t_explicit;
-            auto t_copy_emhd_vars   = t_explicit;
+            // Copy the current state of any implicitly-evolved vars (at least the prims)
+            // in as a guess. If we aren't using the ideal solution as the guess, set
+            // md_solver = md_sub_step_init
+            auto t_copy_guess = t_explicit;
+            auto t_copy_emhd_vars = t_explicit;
             if (use_ideal_guess) {
                 // This copies only q, dP for which we don't already have a guess
-                t_copy_emhd_vars = tl.AddTask(t_sources, Copy<MeshData<Real>>, std::vector<MetadataFlag>({Metadata::GetUserFlag("EMHDVar")}),
-                                        md_sub_step_init.get(), md_solver.get());
+                t_copy_emhd_vars = tl.AddTask(t_sources, Copy<MeshData<Real>>,
+                    std::vector<MetadataFlag>({Metadata::GetUserFlag("EMHDVar")}),
+                    md_sub_step_init.get(), md_solver.get());
                 t_copy_guess = t_copy_emhd_vars;
             } else {
-                t_copy_guess = tl.AddTask(t_sources, Copy<MeshData<Real>>, std::vector<MetadataFlag>({Metadata::GetUserFlag("Implicit")}),
-                                        md_sub_step_init.get(), md_solver.get());
+                t_copy_guess = tl.AddTask(t_sources, Copy<MeshData<Real>>,
+                    std::vector<MetadataFlag>({Metadata::GetUserFlag("Implicit")}),
+                    md_sub_step_init.get(), md_solver.get());
             }
 
             auto t_guess_ready = t_explicit | t_copy_guess;
 
-            // The `solver` MeshData object now has the implicit primitives corresponding to initial/half step and
-            // explicit variables have been updated to match the current step.
-            // Copy the primitives to the `linesearch` MeshData object if linesearch was enabled.
+            // The `solver` MeshData object now has the implicit primitives corresponding
+            // to initial/half step and explicit variables have been updated to match the
+            // current step. Copy the primitives to the `linesearch` MeshData object if
+            // linesearch was enabled.
             auto t_copy_linesearch = t_guess_ready;
             if (use_linesearch) {
-                t_copy_linesearch = tl.AddTask(t_guess_ready, Copy<MeshData<Real>>, std::vector<MetadataFlag>({Metadata::GetUserFlag("Primitive")}),
-                                                md_solver.get(), md_linesearch.get());
+                t_copy_linesearch = tl.AddTask(t_guess_ready, Copy<MeshData<Real>>,
+                    std::vector<MetadataFlag>({Metadata::GetUserFlag("Primitive")}),
+                    md_solver.get(), md_linesearch.get());
             }
 
             // Time-step implicit variables by root-finding the residual.
-            // This calculates the primitive values after the substep for all "isImplicit" variables --
-            // no need for separately adding the flux divergence or calling UtoP
-            auto t_implicit_step = tl.AddTask(t_copy_linesearch, Implicit::Step, md_full_step_init.get(), md_sub_step_init.get(),
-                                         md_flux_src.get(), md_linesearch.get(), md_solver.get(), integrator->beta[stage-1] * integrator->dt);
+            // This calculates the primitive values after the substep for all "isImplicit"
+            // variables -- no need for separately adding the flux divergence or calling
+            // UtoP
+            auto t_implicit_step =
+                tl.AddTask(t_copy_linesearch, Implicit::Step, md_full_step_init.get(),
+                    md_sub_step_init.get(), md_flux_src.get(), md_linesearch.get(),
+                    md_solver.get(), integrator->beta[stage - 1] * integrator->dt);
 
-            // Copy the entire solver state (everything defined on the grid, incl. our new Face variables) into the final state md_sub_step_final
-            // If we're entirely explicit, we just declare these equal
-            auto t_implicit_c = tl.AddTask(t_implicit_step, Copy<MeshData<Real>>, std::vector<MetadataFlag>({Metadata::Cell}),
-                                    md_solver.get(), md_sub_step_final.get());
-            t_implicit = tl.AddTask(t_implicit_step, WeightedSumDataFace<MetadataFlag>, std::vector<MetadataFlag>({Metadata::Face}),
-                                    md_solver.get(), md_solver.get(), 1.0, 0.0, md_sub_step_final.get());
+            // Copy the entire solver state (everything defined on the grid, incl. our new
+            // Face variables) into the final state md_sub_step_final If we're entirely
+            // explicit, we just declare these equal
+            auto t_implicit_c = tl.AddTask(t_implicit_step, Copy<MeshData<Real>>,
+                std::vector<MetadataFlag>({Metadata::Cell}), md_solver.get(),
+                md_sub_step_final.get());
+            t_implicit = tl.AddTask(t_implicit_step, WeightedSumDataFace<MetadataFlag>,
+                std::vector<MetadataFlag>({Metadata::Face}), md_solver.get(),
+                md_solver.get(), 1.0, 0.0, md_sub_step_final.get());
         }
 
-        // Apply all floors & limits (GRMHD,EMHD,etc), but do *not* immediately correct UtoP failures with FixUtoP --
-        // rather, we will synchronize (including pflags!) first.
-        // With an extra ghost zone, this *should* still allow binary-similar evolution between numbers of mesh blocks,
-        // but hasn't been tested to do so yet.
-        auto t_floors = tl.AddTask(t_implicit, Packages::MeshApplyFloors, md_sub_step_final.get(), IndexDomain::interior);
+        // Apply all floors & limits (GRMHD,EMHD,etc), but do *not* immediately correct
+        // UtoP failures with FixUtoP -- rather, we will synchronize (including pflags!)
+        // first. With an extra ghost zone, this *should* still allow binary-similar
+        // evolution between numbers of mesh blocks, but hasn't been tested to do so yet.
+        auto t_floors = tl.AddTask(t_implicit, Packages::MeshApplyFloors,
+            md_sub_step_final.get(), IndexDomain::interior);
 
         KHARMADriver::AddBoundarySync(t_floors, tl, md_sync);
     }
 
-    // Fix Region: prims/cons sync, floors, fixes, boundary conditions which need primitives
-    TaskRegion &fix_region = tc.AddRegion(num_partitions);
+    // Fix Region: prims/cons sync, floors, fixes, boundary conditions which need
+    // primitives
+    TaskRegion& fix_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
-        auto &tl  = fix_region[i];
-        auto &md_sub_step_init  = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage-1], i);
-        auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
-        auto &md_sync = pmesh->mesh_data.AddShallow("sync"+integrator->stage_name[stage]+std::to_string(i), md_sub_step_final, sync_vars);
+        auto& tl = fix_region[i];
+        auto& md_sub_step_init =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], i);
+        auto& md_sub_step_final =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+        auto& md_sync = pmesh->mesh_data.AddShallow(
+            "sync" + integrator->stage_name[stage] + std::to_string(i), md_sub_step_final,
+            sync_vars);
 
-        // If we're evolving the GRMHD variables explicitly, we need to fix UtoP variable inversion failures.
-        // If implicitly, we run a (very similar) fix for solver failures.
-        // Syncing bounds before calling this, and then running it over the whole domain, will make
-        // behavior for different mesh breakdowns much more similar (identical?), since bad zones in
-        // relevant ghost zone ranks will get to use all the same neighbors as if they were in the bulk
+        // If we're evolving the GRMHD variables explicitly, we need to fix UtoP variable
+        // inversion failures. If implicitly, we run a (very similar) fix for solver
+        // failures. Syncing bounds before calling this, and then running it over the
+        // whole domain, will make behavior for different mesh breakdowns much more
+        // similar (identical?), since bad zones in relevant ghost zone ranks will get to
+        // use all the same neighbors as if they were in the bulk
         // TODO fixups as a callback?
         auto t_fix_utop = t_none;
         if (!pkgs.at("GRMHD")->Param<bool>("implicit")) {
-            t_fix_utop = tl.AddTask(t_none, Inverter::MeshFixUtoP, md_sub_step_final.get());
+            t_fix_utop =
+                tl.AddTask(t_none, Inverter::MeshFixUtoP, md_sub_step_final.get());
         }
         auto t_fix_solve = t_fix_utop;
         if (use_implicit) {
-            t_fix_solve = tl.AddTask(t_fix_utop, Implicit::MeshFixSolve, md_sub_step_final.get());
+            t_fix_solve =
+                tl.AddTask(t_fix_utop, Implicit::MeshFixSolve, md_sub_step_final.get());
         }
 
         // Re-apply boundary conditions to reflect fixes
-        auto t_set_bc = tl.AddTask(t_fix_solve, parthenon::ApplyBoundaryConditionsOnCoarseOrFineMD, md_sync, false);
+        auto t_set_bc = tl.AddTask(t_fix_solve,
+            parthenon::ApplyBoundaryConditionsOnCoarseOrFineMD, md_sync, false);
 
-        // Any package- (likely, problem-) specific source terms which must be applied to primitive variables
-        // Apply these only after the final step so they're operator-split
+        // Any package- (likely, problem-) specific source terms which must be applied to
+        // primitive variables Apply these only after the final step so they're
+        // operator-split
         auto t_prim_source = t_set_bc;
         if (stage == integrator->nstages) {
-            t_prim_source = tl.AddTask(t_set_bc, Packages::MeshApplyPrimSource, md_sub_step_final.get());
+            t_prim_source = tl.AddTask(
+                t_set_bc, Packages::MeshApplyPrimSource, md_sub_step_final.get());
         }
         // Electron heating goes where it does in the KHARMA Driver, for the same reasons
         auto t_heat_electrons = t_prim_source;
         if (use_electrons) {
-            t_heat_electrons = tl.AddTask(t_prim_source, Electrons::MeshApplyElectronHeating,
-                                          md_sub_step_init.get(), md_sub_step_final.get(), stage == 1);
+            t_heat_electrons =
+                tl.AddTask(t_prim_source, Electrons::MeshApplyElectronHeating,
+                    md_sub_step_init.get(), md_sub_step_final.get(), stage == 1);
         }
 
         // Make sure *all* conserved vars are synchronized at step end
-        auto t_ptou = tl.AddTask(t_heat_electrons, Flux::MeshPtoU, md_sub_step_final.get(), IndexDomain::entire, false);
+        auto t_ptou = tl.AddTask(t_heat_electrons, Flux::MeshPtoU,
+            md_sub_step_final.get(), IndexDomain::entire, false);
 
         auto t_step_done = t_ptou;
         if (pkgs.count("ISMR")) {
             auto t_derefine_b = t_ptou;
             if (pkgs.count("B_CT"))
-                t_derefine_b = tl.AddTask(t_ptou, B_CT::DerefinePoles, md_sub_step_final.get());
-            t_step_done = tl.AddTask(t_derefine_b, ISMR::DerefinePoles, md_sub_step_final.get());
+                t_derefine_b =
+                    tl.AddTask(t_ptou, B_CT::DerefinePoles, md_sub_step_final.get());
+            t_step_done =
+                tl.AddTask(t_derefine_b, ISMR::DerefinePoles, md_sub_step_final.get());
         }
 
         // Estimate next time step based on ctop
         if (stage == integrator->nstages) {
-            auto t_new_dt =
-                tl.AddTask(t_step_done, Update::EstimateTimestep<MeshData<Real>>, md_sub_step_final.get());
+            auto t_new_dt = tl.AddTask(t_step_done,
+                Update::EstimateTimestep<MeshData<Real>>, md_sub_step_final.get());
 
             // Update refinement
             if (pmesh->adaptive) {
-                auto tag_refine = tl.AddTask(
-                    t_step_done, parthenon::Refinement::Tag<MeshData<Real>>, md_sub_step_final.get());
+                auto tag_refine = tl.AddTask(t_step_done,
+                    parthenon::Refinement::Tag<MeshData<Real>>, md_sub_step_final.get());
             }
         }
     }
 
     // B Field cleanup: this is a separate solve so it's split out
-    // It's also really slow when enabled so we don't care too much about limiting regions, etc.
-    if (use_b_cleanup && (stage == integrator->nstages) && B_Cleanup::CleanupThisStep(pmesh, tm.ncycle)) {
-        TaskRegion &cleanup_region = tc.AddRegion(num_partitions);
+    // It's also really slow when enabled so we don't care too much about limiting
+    // regions, etc.
+    if (use_b_cleanup && (stage == integrator->nstages) &&
+        B_Cleanup::CleanupThisStep(pmesh, tm.ncycle)) {
+        TaskRegion& cleanup_region = tc.AddRegion(num_partitions);
         for (int i = 0; i < num_partitions; i++) {
-            auto &tl = cleanup_region[i];
-            auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+            auto& tl = cleanup_region[i];
+            auto& md_sub_step_final =
+                pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
             tl.AddTask(t_none, B_Cleanup::CleanupDivergence, md_sub_step_final);
         }
     }
@@ -359,15 +431,17 @@ TaskCollection KHARMADriver::MakeImExTaskCollection(BlockList_t &blocks, int sta
     // ensure that primitive variables in ghost zones are *exactly*
     // identical to their physical counterparts, now that they have been
     // modified on each rank.
-    const auto &two_sync = pkgs.at("Driver")->Param<bool>("two_sync");
+    const auto& two_sync = pkgs.at("Driver")->Param<bool>("two_sync");
     if (two_sync) {
         for (int i = 0; i < num_partitions; i++) {
-            auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
-            auto &md_sync = pmesh->mesh_data.AddShallow("sync"+integrator->stage_name[stage]+std::to_string(i), md_sub_step_final, sync_vars);
+            auto& md_sub_step_final =
+                pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+            auto& md_sync = pmesh->mesh_data.AddShallow(
+                "sync" + integrator->stage_name[stage] + std::to_string(i),
+                md_sub_step_final, sync_vars);
             KHARMADriver::AddFullSyncRegion(tc, md_sync);
         }
     }
 
     return tc;
 }
-

--- a/kharma/driver/kharma_driver.cpp
+++ b/kharma/driver/kharma_driver.cpp
@@ -40,7 +40,8 @@
 #include "get_flux.hpp"
 #include "inverter.hpp"
 
-std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     // This function builds and returns a "KHARMAPackage" object, which is a light
     // superset of Parthenon's "StateDescriptor" class for packages.
@@ -51,15 +52,17 @@ std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(ParameterInput *pin, std
     // This "dictionary" is mostly immutable, and should always be treated as immutable,
     // except in the "Globals" package.
     auto pkg = std::make_shared<KHARMAPackage>("Driver");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Driver options
-    // The two current drivers are "kharma" or "imex", with the former being the usual KHARMA
-    // driver (formerly HARM driver), and the latter supporting implicit stepping of some or all variables
-    // Mostly, packages should react to e.g. the "sync_prims" option rather than the driver name
+    // The two current drivers are "kharma" or "imex", with the former being the usual
+    // KHARMA driver (formerly HARM driver), and the latter supporting implicit stepping
+    // of some or all variables Mostly, packages should react to e.g. the "sync_prims"
+    // option rather than the driver name
     std::vector<std::string> valid_drivers = {"harm", "kharma", "imex", "simple"};
     bool do_emhd = pin->GetOrAddBoolean("emhd", "on", false);
-    std::string driver_type_s = pin->GetOrAddString("driver", "type", (do_emhd) ? "imex" : "kharma", valid_drivers);
+    std::string driver_type_s = pin->GetOrAddString(
+        "driver", "type", (do_emhd) ? "imex" : "kharma", valid_drivers);
     DriverType driver_type;
     if (driver_type_s == "harm" || driver_type_s == "kharma") {
         driver_type = DriverType::kharma;
@@ -72,23 +75,24 @@ std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(ParameterInput *pin, std
     params.Add("name", driver_type_s);
 
     // Synchronize boundary variables twice. Ensures KHARMA is agnostic to the breakdown
-    // of meshblocks, at the cost of twice the MPI overhead, for potentially worse strong scaling.
-    // On by default, disable only after testing that, e.g., divB meets your requirements
+    // of meshblocks, at the cost of twice the MPI overhead, for potentially worse strong
+    // scaling. On by default, disable only after testing that, e.g., divB meets your
+    // requirements
     bool two_sync = pin->GetOrAddBoolean("driver", "two_sync", true);
     params.Add("two_sync", two_sync);
 
-    // When using the Implicit package we need to globally distinguish implicit & explicit vars
-    // All independent variables should be marked one or the other,
-    // so we define the flags here to avoid loading order issues
+    // When using the Implicit package we need to globally distinguish implicit & explicit
+    // vars All independent variables should be marked one or the other, so we define the
+    // flags here to avoid loading order issues
     Metadata::AddUserFlag("Implicit");
     Metadata::AddUserFlag("Explicit");
-    // Add a flag if we wish to use ideal variables explicitly evolved as guess for implicit update.
-    // GRIM uses the fluid state of the previous (sub-)step.
-    // The logic here is that the non-ideal variables do not significantly contribute to the
-    // stress-energy tensor. We can explicitly update the ideal MHD variables and hope that this
-    // takes us to a region in the parameter space of state variables that
-    // is close to the true solution. The corrections obtained from the implicit update would then
-    // be small corrections.
+    // Add a flag if we wish to use ideal variables explicitly evolved as guess for
+    // implicit update. GRIM uses the fluid state of the previous (sub-)step. The logic
+    // here is that the non-ideal variables do not significantly contribute to the
+    // stress-energy tensor. We can explicitly update the ideal MHD variables and hope
+    // that this takes us to a region in the parameter space of state variables that is
+    // close to the true solution. The corrections obtained from the implicit update would
+    // then be small corrections.
     Metadata::AddUserFlag("IdealGuess");
 
     // 1. One flag to mark the primitive variables specifically
@@ -103,52 +107,65 @@ std::shared_ptr<KHARMAPackage> KHARMADriver::Initialize(ParameterInput *pin, std
     // Indicate a 1-element face-centered field is split components of a vector
     Metadata::AddUserFlag("SplitVector");
 
-    // Synchronize primitive variables unless we're using the KHARMA driver that specifically doesn't
-    // This includes for AMR w/ImEx driver
-    // Note the "conserved" B field is always sync'd.  The "primitive" version only differs by sqrt(-g)
+    // Synchronize primitive variables unless we're using the KHARMA driver that
+    // specifically doesn't This includes for AMR w/ImEx driver Note the "conserved" B
+    // field is always sync'd.  The "primitive" version only differs by sqrt(-g)
     bool sync_prims = driver_type != DriverType::kharma;
     params.Add("sync_prims", sync_prims);
     if (sync_prims) {
         // For ImEx/simple drivers, sync/prolongate/restrict primitive variables directly
-        params.Add("prim_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Derived, Metadata::FillGhost, Metadata::GetUserFlag("Primitive")});
-        params.Add("cons_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Independent, Metadata::Restart, Metadata::WithFluxes, Metadata::Conserved});
+        params.Add(
+            "prim_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Derived,
+                              Metadata::FillGhost, Metadata::GetUserFlag("Primitive")});
+        params.Add("cons_flags",
+            std::vector<MetadataFlag>{Metadata::Real, Metadata::Independent,
+                Metadata::Restart, Metadata::WithFluxes, Metadata::Conserved});
     } else {
         // If we're in AMR or using the KHARMA driver anyway, sync conserved vars
-        params.Add("prim_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Derived, Metadata::GetUserFlag("Primitive")});
-        params.Add("cons_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Independent, Metadata::Restart, Metadata::FillGhost, Metadata::WithFluxes, Metadata::Conserved});
+        params.Add(
+            "prim_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Derived,
+                              Metadata::GetUserFlag("Primitive")});
+        params.Add(
+            "cons_flags", std::vector<MetadataFlag>{Metadata::Real, Metadata::Independent,
+                              Metadata::Restart, Metadata::FillGhost,
+                              Metadata::WithFluxes, Metadata::Conserved});
     }
 
     return pkg;
 }
 
-void KHARMADriver::AddFullSyncRegion(TaskCollection& tc, std::shared_ptr<MeshData<Real>> &md_sync)
+void KHARMADriver::AddFullSyncRegion(
+    TaskCollection& tc, std::shared_ptr<MeshData<Real>>& md_sync)
 {
     const TaskID t_none(0);
 
     // MPI boundary exchange, done over MeshData objects/partitions at once
     // Parthenon includes physical bounds
     const int num_partitions = pmesh->DefaultNumPartitions(); // Usually 1
-    TaskRegion &bound_sync = tc.AddRegion(num_partitions);
+    TaskRegion& bound_sync = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
-        auto &tl = bound_sync[i];
+        auto& tl = bound_sync[i];
         AddBoundarySync(t_none, tl, md_sync);
     }
 }
 
-TaskID KHARMADriver::AddBoundarySync(const TaskID t_start, TaskList &tl, std::shared_ptr<MeshData<Real>> &mc1)
+TaskID KHARMADriver::AddBoundarySync(
+    const TaskID t_start, TaskList& tl, std::shared_ptr<MeshData<Real>>& mc1)
 {
     Flag("AddBoundarySync");
     auto t_start_sync = t_start;
 
     // Pull the mesh pointer from mc1 so we can be a static method
     auto pmesh = mc1->GetMeshPointer();
-    auto &params = pmesh->packages.Get("Driver")->AllParams();
+    auto& params = pmesh->packages.Get("Driver")->AllParams();
     bool multilevel = pmesh->multilevel;
 
     // The Parthenon exchange tasks include applying physical boundary conditions now.
-    // We generally do not take advantage of this yet, but good to know when reasoning about initialization.
+    // We generally do not take advantage of this yet, but good to know when reasoning
+    // about initialization.
     Flag("ParthenonAddSync");
-    auto t_sync_done = parthenon::AddBoundaryExchangeTasks(t_start_sync, tl, mc1, multilevel);
+    auto t_sync_done =
+        parthenon::AddBoundaryExchangeTasks(t_start_sync, tl, mc1, multilevel);
     auto t_bounds = t_sync_done;
     EndFlag();
 
@@ -160,15 +177,18 @@ TaskID KHARMADriver::AddBoundarySync(const TaskID t_start, TaskList &tl, std::sh
         TaskID t_utop_final(0);
         int i_task = 0;
         for (int i_block = 0; i_block < mc1->NumBlocks(); i_block++) {
-            auto &rc = mc1->GetBlockData(i_block);
+            auto& rc = mc1->GetBlockData(i_block);
             for (int i_bnd = 0; i_bnd < BOUNDARY_NFACES; i_bnd++) {
                 if (rc->GetBlockPointer()->boundary_flag[i_bnd] == BoundaryFlag::block ||
-                    rc->GetBlockPointer()->boundary_flag[i_bnd] == BoundaryFlag::periodic) {
-                    const auto bdomain = KBoundaries::BoundaryDomain((BoundaryFace) i_bnd);
+                    rc->GetBlockPointer()->boundary_flag[i_bnd] ==
+                        BoundaryFlag::periodic) {
+                    const auto bdomain = KBoundaries::BoundaryDomain((BoundaryFace)i_bnd);
                     if (pkgs.count("B_FluxCT")) {
-                        t_all_utop[i_task] = tl.AddTask(t_sync_done, B_FluxCT::BlockUtoP, rc.get(), bdomain, false);
+                        t_all_utop[i_task] = tl.AddTask(
+                            t_sync_done, B_FluxCT::BlockUtoP, rc.get(), bdomain, false);
                     } else if (pkgs.count("B_CT")) {
-                        t_all_utop[i_task] = tl.AddTask(t_sync_done, B_CT::BlockUtoP, rc.get(), bdomain, false);
+                        t_all_utop[i_task] = tl.AddTask(
+                            t_sync_done, B_CT::BlockUtoP, rc.get(), bdomain, false);
                     }
                     t_utop_final = t_utop_final | t_all_utop[i_task];
                     i_task++;
@@ -182,7 +202,7 @@ TaskID KHARMADriver::AddBoundarySync(const TaskID t_start, TaskList &tl, std::sh
     return t_bounds;
 }
 
-TaskStatus KHARMADriver::SyncAllBounds(std::shared_ptr<MeshData<Real>> &md)
+TaskStatus KHARMADriver::SyncAllBounds(std::shared_ptr<MeshData<Real>>& md)
 {
     Flag("SyncAllBounds");
     TaskID t_none(0);
@@ -200,82 +220,121 @@ TaskStatus KHARMADriver::SyncAllBounds(std::shared_ptr<MeshData<Real>> &md)
     return TaskStatus::complete;
 }
 
-TaskID KHARMADriver::AddFluxCalculations(TaskID& t_start, TaskList& tl, MeshData<Real> *md)
+TaskID KHARMADriver::AddFluxCalculations(
+    TaskID& t_start, TaskList& tl, MeshData<Real>* md)
 {
     // Pull reconstruction option to simplify use. TODO shorten?
-    auto pmb0  = md->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     auto& pkgs = pmb0->packages.AllPackages();
-    const KReconstruction::Type& recon = pkgs.at("Fluxes")->Param<KReconstruction::Type>("recon");
+    const KReconstruction::Type& recon =
+        pkgs.at("Fluxes")->Param<KReconstruction::Type>("recon");
 
     // Pre-calculate B field cell-center values
     auto t_start_fluxes = t_start;
     if (md->GetMeshPointer()->packages.AllPackages().count("B_CT"))
-        t_start_fluxes = tl.AddTask(t_start, B_CT::MeshUtoP, md, IndexDomain::entire, false);
+        t_start_fluxes =
+            tl.AddTask(t_start, B_CT::MeshUtoP, md, IndexDomain::entire, false);
 
     // Calculate fluxes in each direction using given reconstruction
-    // Must be spelled out so as to generate each templated version of GetFlux<> to be available at runtime
-    // Details in flux/get_flux.hpp
-    // TODO(BSP) This could be a macro, maybe... But there's no easy foreach(enum_val): instantiate pattern
+    // Must be spelled out so as to generate each templated version of GetFlux<> to be
+    // available at runtime Details in flux/get_flux.hpp
+    // TODO(CEP) This could be a macro, maybe... But there's no easy foreach(enum_val):
+    // instantiate pattern
     using RType = KReconstruction::Type;
     TaskID t_calculate_flux1, t_calculate_flux2, t_calculate_flux3;
     switch (recon) {
-    case RType::donor_cell:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell, X3DIR>, md);
-        break;
-    case RType::donor_cell_c:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell_c, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell_c, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell_c, X3DIR>, md);
-        break;
-    case RType::linear_vl:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_vl, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_vl, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_vl, X3DIR>, md);
-        break;
-    case RType::linear_mc:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_mc, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_mc, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_mc, X3DIR>, md);
-        break;
-    case RType::weno5_lower_edges:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_lower_edges, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_lower_edges, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_lower_edges, X3DIR>, md);
-        break;
-    case RType::weno5_lower_poles:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_lower_poles, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_lower_poles, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_lower_poles, X3DIR>, md);
-        break;
-    case RType::weno5:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5, X3DIR>, md);
-        break;
-    case RType::weno5_linear:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_linear, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_linear, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_linear, X3DIR>, md);
-        break;
-    case RType::ppm:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppm, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppm, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppm, X3DIR>, md);
-        break;
-    case RType::ppmx:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppmx, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppmx, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppmx, X3DIR>, md);
-        break;
-    case RType::mp5:
-        t_calculate_flux1 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X1DIR>, md);
-        t_calculate_flux2 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X2DIR>, md);
-        t_calculate_flux3 = tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X3DIR>, md);
-        break;
-    default:
-        throw std::invalid_argument("Unsupported reconstruction algorithm! Main supported algorithms: linear_mc, weno5, weno5_linear");
+        case RType::donor_cell:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell, X3DIR>, md);
+            break;
+        case RType::donor_cell_c:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell_c, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell_c, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::donor_cell_c, X3DIR>, md);
+            break;
+        case RType::linear_vl:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_vl, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_vl, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_vl, X3DIR>, md);
+            break;
+        case RType::linear_mc:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_mc, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_mc, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::linear_mc, X3DIR>, md);
+            break;
+        case RType::weno5_lower_edges:
+            t_calculate_flux1 = tl.AddTask(
+                t_start_fluxes, Flux::GetFlux<RType::weno5_lower_edges, X1DIR>, md);
+            t_calculate_flux2 = tl.AddTask(
+                t_start_fluxes, Flux::GetFlux<RType::weno5_lower_edges, X2DIR>, md);
+            t_calculate_flux3 = tl.AddTask(
+                t_start_fluxes, Flux::GetFlux<RType::weno5_lower_edges, X3DIR>, md);
+            break;
+        case RType::weno5_lower_poles:
+            t_calculate_flux1 = tl.AddTask(
+                t_start_fluxes, Flux::GetFlux<RType::weno5_lower_poles, X1DIR>, md);
+            t_calculate_flux2 = tl.AddTask(
+                t_start_fluxes, Flux::GetFlux<RType::weno5_lower_poles, X2DIR>, md);
+            t_calculate_flux3 = tl.AddTask(
+                t_start_fluxes, Flux::GetFlux<RType::weno5_lower_poles, X3DIR>, md);
+            break;
+        case RType::weno5:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5, X3DIR>, md);
+            break;
+        case RType::weno5_linear:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_linear, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_linear, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::weno5_linear, X3DIR>, md);
+            break;
+        case RType::ppm:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppm, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppm, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppm, X3DIR>, md);
+            break;
+        case RType::ppmx:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppmx, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppmx, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::ppmx, X3DIR>, md);
+            break;
+        case RType::mp5:
+            t_calculate_flux1 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X1DIR>, md);
+            t_calculate_flux2 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X2DIR>, md);
+            t_calculate_flux3 =
+                tl.AddTask(t_start_fluxes, Flux::GetFlux<RType::mp5, X3DIR>, md);
+            break;
+        default:
+            throw std::invalid_argument(
+                "Unsupported reconstruction algorithm! Main supported algorithms: "
+                "linear_mc, weno5, weno5_linear");
     }
     auto t_calc_fluxes = t_calculate_flux1 | t_calculate_flux2 | t_calculate_flux3;
 
@@ -287,46 +346,58 @@ TaskID KHARMADriver::AddFluxCalculations(TaskID& t_start, TaskList& tl, MeshData
     return t_ctop;
 }
 
-TaskID KHARMADriver::AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real> *md,
-                             MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init,
-                             MeshData<Real> *guess_src, MeshData<Real> *guess, int stage)
+TaskID KHARMADriver::AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real>* md,
+    MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+    MeshData<Real>* guess_src, MeshData<Real>* guess, int stage)
 {
     Flag("FOFC");
     // Pull reconstruction option to simplify use. TODO shorten?
-    auto pmb0  = md->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     auto& pkgs = pmb0->packages.AllPackages();
 
-    const Floors::Prescription fofc_floors       = pmb0->packages.Get("Fluxes")->Param<Floors::Prescription>("fofc_prescription");
-    const Floors::Prescription fofc_floors_inner = pmb0->packages.Get("Fluxes")->Param<Floors::Prescription>("fofc_prescription_inner");
+    const Floors::Prescription fofc_floors =
+        pmb0->packages.Get("Fluxes")->Param<Floors::Prescription>("fofc_prescription");
+    const Floors::Prescription fofc_floors_inner =
+        pmb0->packages.Get("Fluxes")->Param<Floors::Prescription>(
+            "fofc_prescription_inner");
 
     // Populate guess source term with divergence of the existing fluxes
     // NOTE this does not include source terms!  Though, could call them here tbh
     auto t_guess_divergence = tl.AddTask(t_start, FluxDivergence, md, guess_src,
-                                        std::vector<MetadataFlag>{Metadata::Cell, Metadata::WithFluxes}, 3);
+        std::vector<MetadataFlag>{Metadata::Cell, Metadata::WithFluxes}, 3);
     // Add geometric source term to more accurately predict floor hits.
     // Could add everything here with Packages::AddSource but would be slower
-    // also would need to deal with B_CT::AddSource == flux update, which we don't want/need
+    // also would need to deal with B_CT::AddSource == flux update, which we don't
+    // want/need
     auto t_guess_sources = t_guess_divergence;
     if (pmb0->packages.Get("Fluxes")->Param<bool>("fofc_use_source_term")) {
-        auto t_guess_sources = tl.AddTask(t_guess_divergence, Flux::AddGeoSourceTask, md, guess_src, IndexDomain::entire);
+        auto t_guess_sources = tl.AddTask(t_guess_divergence, Flux::AddGeoSourceTask, md,
+            guess_src, IndexDomain::entire);
     }
     // Update the guess state with the guess source term, and our existing state
-    // Note this includes updating cell-centered B with the fluxes -- we don't care if this version has div
+    // Note this includes updating cell-centered B with the fluxes -- we don't care if
+    // this version has div
     auto t_guess_update = KHARMADriver::AddStateUpdate(t_guess_sources, tl,
-                                                       md_full_step_init, md_sub_step_init, guess_src, guess,
-                                                       {Metadata::WithFluxes, Metadata::Cell},
-                                                       false, stage);
-    // Recover primitive variables of the guess (carefully, since code-wide functions respect B at faces!)
-    auto t_guess_Bp = tl.AddTask(t_guess_update, B_FluxCT::MeshUtoP, guess, IndexDomain::entire, false);
-    auto t_guess_prims = tl.AddTask(t_guess_Bp, Inverter::MeshUtoP, guess, IndexDomain::entire, false);
+        md_full_step_init, md_sub_step_init, guess_src, guess,
+        {Metadata::WithFluxes, Metadata::Cell}, false, stage);
+    // Recover primitive variables of the guess (carefully, since code-wide functions
+    // respect B at faces!)
+    auto t_guess_Bp =
+        tl.AddTask(t_guess_update, B_FluxCT::MeshUtoP, guess, IndexDomain::entire, false);
+    auto t_guess_prims =
+        tl.AddTask(t_guess_Bp, Inverter::MeshUtoP, guess, IndexDomain::entire, false);
     // Check and mark floors
-    auto t_mark_floors = tl.AddTask(t_guess_prims, Floors::DetermineGRMHDFloors, guess, IndexDomain::entire, fofc_floors, fofc_floors_inner);
+    auto t_mark_floors = tl.AddTask(t_guess_prims, Floors::DetermineGRMHDFloors, guess,
+        IndexDomain::entire, fofc_floors, fofc_floors_inner);
     // Determine which cells are FOFC in our block
     auto t_mark_fofc = tl.AddTask(t_mark_floors, Flux::MarkFOFC, guess);
     // Sync the FOFC flag with neighbors
     // TODO this shouldn't be necessary, eliminate ASAP
-    std::shared_ptr<MeshData<Real>> md_shr{md, [](MeshData<Real> *) {}/*No-Op Deleter*/};
-    auto &md_fofc = pmesh->mesh_data.AddShallow("FOFC", md_shr, std::vector<std::string>{"fofcflag"});
+    std::shared_ptr<MeshData<Real>> md_shr{md, [](MeshData<Real>*)
+        {
+        } /*No-Op Deleter*/};
+    auto& md_fofc =
+        pmesh->mesh_data.AddShallow("FOFC", md_shr, std::vector<std::string>{"fofcflag"});
     auto t_sync_fofc = KHARMADriver::AddBoundarySync(t_mark_fofc, tl, md_fofc);
     // Finally, replace any fluxes bordering marked zones with donor-cell/LLF versions
     auto t_fofc = tl.AddTask(t_sync_fofc, Flux::FOFC, md, guess);
@@ -335,104 +406,102 @@ TaskID KHARMADriver::AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real> *md,
     return t_fofc;
 }
 
-TaskID KHARMADriver::AddStateUpdate(TaskID& t_start, TaskList& tl, MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init,
-                                    MeshData<Real> *md_flux_src, MeshData<Real> *md_update, std::vector<MetadataFlag> flags,
-                                    bool update_face, int stage)
+TaskID KHARMADriver::AddStateUpdate(TaskID& t_start, TaskList& tl,
+    MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+    MeshData<Real>* md_flux_src, MeshData<Real>* md_update,
+    std::vector<MetadataFlag> flags, bool update_face, int stage)
 {
     // Update all explicitly-evolved variables using the source term
     // Add any proportion of the step start required by the integrator (e.g., RK2)
-    std::vector<MetadataFlag> flags_cell = flags; flags_cell.push_back(Metadata::Cell);
-    std::vector<MetadataFlag> flags_face = flags; flags_face.push_back(Metadata::Face);
+    std::vector<MetadataFlag> flags_cell = flags;
+    flags_cell.push_back(Metadata::Cell);
+    std::vector<MetadataFlag> flags_face = flags;
+    flags_face.push_back(Metadata::Face);
     // TODO splitting this is stupid, but maybe the parallelization actually helps? Eh.
-    auto t_avg_data_c = tl.AddTask(t_start, Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
-                                std::vector<MetadataFlag>(flags_cell),
-                                md_sub_step_init, md_full_step_init,
-                                integrator->gam0[stage-1], integrator->gam1[stage-1],
-                                md_update);
+    auto t_avg_data_c = tl.AddTask(t_start,
+        Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
+        std::vector<MetadataFlag>(flags_cell), md_sub_step_init, md_full_step_init,
+        integrator->gam0[stage - 1], integrator->gam1[stage - 1], md_update);
     auto t_avg_data = t_avg_data_c;
     if (update_face) {
         t_avg_data = tl.AddTask(t_start, WeightedSumDataFace<MetadataFlag>,
-                                std::vector<MetadataFlag>(flags_face),
-                                md_sub_step_init, md_full_step_init,
-                                integrator->gam0[stage-1], integrator->gam1[stage-1],
-                                md_update);
+            std::vector<MetadataFlag>(flags_face), md_sub_step_init, md_full_step_init,
+            integrator->gam0[stage - 1], integrator->gam1[stage - 1], md_update);
     }
     // apply du/dt to the result
-    auto t_update_c = tl.AddTask(t_avg_data, Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
-                                std::vector<MetadataFlag>(flags_cell),
-                                md_update, md_flux_src,
-                                1.0, integrator->beta[stage-1] * integrator->dt,
-                                md_update);
+    auto t_update_c = tl.AddTask(t_avg_data,
+        Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
+        std::vector<MetadataFlag>(flags_cell), md_update, md_flux_src, 1.0,
+        integrator->beta[stage - 1] * integrator->dt, md_update);
     auto t_update = t_update_c;
     if (update_face) {
         t_update = tl.AddTask(t_avg_data, WeightedSumDataFace<MetadataFlag>,
-                                std::vector<MetadataFlag>(flags_face),
-                                md_update, md_flux_src,
-                                1.0, integrator->beta[stage-1] * integrator->dt,
-                                md_update);
+            std::vector<MetadataFlag>(flags_face), md_update, md_flux_src, 1.0,
+            integrator->beta[stage - 1] * integrator->dt, md_update);
     }
 
-    // We'll be running UtoP after this, which needs a guess in order to converge, so we copy in md_sub_step_init
+    // We'll be running UtoP after this, which needs a guess in order to converge, so we
+    // copy in md_sub_step_init
     auto t_copy_prims = t_update;
-    auto pmb0  = md_full_step_init->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = md_full_step_init->GetBlockData(0)->GetBlockPointer();
     auto& pkgs = pmb0->packages.AllPackages();
 
     // If we're explicitly evolving, UtoP needs a guess
     // TODO why is this necessary still?  Is it necessary on every AddStateUpdate?
     if (!pkgs.at("GRMHD")->Param<bool>("implicit")) {
         t_copy_prims = tl.AddTask(t_start, Copy<MeshData<Real>>,
-                                    std::vector<MetadataFlag>({Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")}),
-                                    md_sub_step_init, md_update);
+            std::vector<MetadataFlag>(
+                {Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")}),
+            md_sub_step_init, md_update);
     }
 
     return t_copy_prims | t_update;
 }
 
-TaskID KHARMADriver::AddStateUpdateIdealGuess(TaskID& t_start, TaskList& tl, MeshData<Real> *md_full_step_init,
-                                    MeshData<Real> *md_sub_step_init, MeshData<Real> *md_flux_src, MeshData<Real> *md_update,
-                                    std::vector<MetadataFlag> flags, bool update_face, int stage)
+TaskID KHARMADriver::AddStateUpdateIdealGuess(TaskID& t_start, TaskList& tl,
+    MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+    MeshData<Real>* md_flux_src, MeshData<Real>* md_update,
+    std::vector<MetadataFlag> flags, bool update_face, int stage)
 {
     // Update variables marked as IdealGuess
     // Add any proportion of the step start required by the integrator (e.g., RK2)
-    std::vector<MetadataFlag> flags_cell = flags; flags_cell.push_back(Metadata::Cell);
-    std::vector<MetadataFlag> flags_face = flags; flags_face.push_back(Metadata::Face);
+    std::vector<MetadataFlag> flags_cell = flags;
+    flags_cell.push_back(Metadata::Cell);
+    std::vector<MetadataFlag> flags_face = flags;
+    flags_face.push_back(Metadata::Face);
     // TODO splitting this is stupid, but maybe the parallelization actually helps? Eh.
-    auto t_avg_data_c = tl.AddTask(t_start, Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
-                                std::vector<MetadataFlag>(flags_cell),
-                                md_sub_step_init, md_full_step_init,
-                                integrator->gam0[stage-1], integrator->gam1[stage-1],
-                                md_update);
+    auto t_avg_data_c = tl.AddTask(t_start,
+        Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
+        std::vector<MetadataFlag>(flags_cell), md_sub_step_init, md_full_step_init,
+        integrator->gam0[stage - 1], integrator->gam1[stage - 1], md_update);
     auto t_avg_data = t_avg_data_c;
     if (update_face) {
         t_avg_data = tl.AddTask(t_start, WeightedSumDataFace<MetadataFlag>,
-                                std::vector<MetadataFlag>(flags_face),
-                                md_sub_step_init, md_full_step_init,
-                                integrator->gam0[stage-1], integrator->gam1[stage-1],
-                                md_update);
+            std::vector<MetadataFlag>(flags_face), md_sub_step_init, md_full_step_init,
+            integrator->gam0[stage - 1], integrator->gam1[stage - 1], md_update);
     }
     // apply du/dt to the result
-    auto t_update_c = tl.AddTask(t_avg_data, Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
-                                std::vector<MetadataFlag>(flags_cell),
-                                md_update, md_flux_src,
-                                1.0, integrator->beta[stage-1] * integrator->dt,
-                                md_update);
+    auto t_update_c = tl.AddTask(t_avg_data,
+        Update::WeightedSumData<std::vector<MetadataFlag>, MeshData<Real>>,
+        std::vector<MetadataFlag>(flags_cell), md_update, md_flux_src, 1.0,
+        integrator->beta[stage - 1] * integrator->dt, md_update);
     auto t_update = t_update_c;
     if (update_face) {
         t_update = tl.AddTask(t_avg_data, WeightedSumDataFace<MetadataFlag>,
-                                std::vector<MetadataFlag>(flags_face),
-                                md_update, md_flux_src,
-                                1.0, integrator->beta[stage-1] * integrator->dt,
-                                md_update);
+            std::vector<MetadataFlag>(flags_face), md_update, md_flux_src, 1.0,
+            integrator->beta[stage - 1] * integrator->dt, md_update);
     }
 
-    // We'll be running UtoP after this, which needs a guess in order to converge, so we copy in md_sub_step_init
+    // We'll be running UtoP after this, which needs a guess in order to converge, so we
+    // copy in md_sub_step_init
     auto t_copy_prims = t_update;
-    auto pmb0  = md_full_step_init->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = md_full_step_init->GetBlockData(0)->GetBlockPointer();
     auto& pkgs = pmb0->packages.AllPackages();
     if (pkgs.at("GRMHD")->Param<bool>("ideal_guess")) {
         t_copy_prims = tl.AddTask(t_start, Copy<MeshData<Real>>,
-                                    std::vector<MetadataFlag>({Metadata::GetUserFlag("HD"), Metadata::GetUserFlag("Primitive")}),
-                                    md_sub_step_init, md_update);
+            std::vector<MetadataFlag>(
+                {Metadata::GetUserFlag("HD"), Metadata::GetUserFlag("Primitive")}),
+            md_sub_step_init, md_update);
     }
 
     return t_copy_prims | t_update;
@@ -440,25 +509,25 @@ TaskID KHARMADriver::AddStateUpdateIdealGuess(TaskID& t_start, TaskList& tl, Mes
 
 void KHARMADriver::SetGlobalTimeStep()
 {
-  // TODO(BSP) apply the limits from GRMHD package here
-  if (tm.dt < 0.1 * std::numeric_limits<Real>::max()) {
-    tm.dt *= 2.0;
-  }
-  Real big = std::numeric_limits<Real>::max();
-  for (auto const &pmb : pmesh->block_list) {
-    tm.dt = std::min(tm.dt, pmb->NewDt());
-    pmb->SetAllowedDt(big);
-  }
+    // TODO(CEP) apply the limits from GRMHD package here
+    if (tm.dt < 0.1 * std::numeric_limits<Real>::max()) {
+        tm.dt *= 2.0;
+    }
+    Real big = std::numeric_limits<Real>::max();
+    for (auto const& pmb : pmesh->block_list) {
+        tm.dt = std::min(tm.dt, pmb->NewDt());
+        pmb->SetAllowedDt(big);
+    }
 
-    // TODO(BSP) start reduce at the end of the per-meshblock stuff, then check it here
+    // TODO(CEP) start reduce at the end of the per-meshblock stuff, then check it here
 #ifdef MPI_PARALLEL
-  PARTHENON_MPI_CHECK(MPI_Allreduce(MPI_IN_PLACE, &tm.dt, 1, MPI_PARTHENON_REAL, MPI_MIN,
-                                    MPI_COMM_WORLD));
+    PARTHENON_MPI_CHECK(MPI_Allreduce(
+        MPI_IN_PLACE, &tm.dt, 1, MPI_PARTHENON_REAL, MPI_MIN, MPI_COMM_WORLD));
 #endif
 
-  if (tm.time < tm.tlim &&
-      (tm.tlim - tm.time) < tm.dt) // timestep would take us past desired endpoint
-    tm.dt = tm.tlim - tm.time;
+    if (tm.time < tm.tlim &&
+        (tm.tlim - tm.time) < tm.dt) // timestep would take us past desired endpoint
+        tm.dt = tm.tlim - tm.time;
 }
 
 void KHARMADriver::PostExecute(DriverStatus status)

--- a/kharma/driver/kharma_driver.hpp
+++ b/kharma/driver/kharma_driver.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: kharma_driver.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,192 +42,218 @@
 using namespace parthenon;
 
 // See Initialize()
-enum class DriverType{kharma, imex, simple};
+enum class DriverType { kharma, imex, simple };
 
 /**
  * This is the "Driver" class for KHARMA.
- * A Driver object orchestrates everything that has to be done to a mesh to constitute a step.
- * This means handling RK2/4/predictor-corrector stepping
- * 
- * Somewhat confusingly, but very conveniently, it is also a package; therefore, it defines
- * a static member function Initialize(), which returns a StateDescriptor.
- * Many things in that list are referenced by other packages dependent on this one.
- * 
+ * A Driver object orchestrates everything that has to be done to a mesh to constitute a
+ * step. This means handling RK2/4/predictor-corrector stepping
+ *
+ * Somewhat confusingly, but very conveniently, it is also a package; therefore, it
+ * defines a static member function Initialize(), which returns a StateDescriptor. Many
+ * things in that list are referenced by other packages dependent on this one.
+ *
  * Documentation on this thing: https://github.com/AFD-Illinois/kharma/wiki/The-Driver
  */
-class KHARMADriver : public MultiStageDriver {
-    public:
-        KHARMADriver(ParameterInput *pin, ApplicationInput *app_in, Mesh *pm) : MultiStageDriver(pin, app_in, pm) {}
+class KHARMADriver : public MultiStageDriver
+{
+  public:
+    KHARMADriver(ParameterInput* pin, ApplicationInput* app_in, Mesh* pm)
+        : MultiStageDriver(pin, app_in, pm)
+    {}
 
-        static std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+    static std::shared_ptr<KHARMAPackage> Initialize(
+        ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
-        // Eliminate Parthenon's print statements when starting up the driver, we have a bunch of our own
-        void PreExecute() override { timer_main.reset(); }
+    // Eliminate Parthenon's print statements when starting up the driver, we have a bunch
+    // of our own
+    void PreExecute() override { timer_main.reset(); }
 
-        // Also override the timestep calculation, so we can start moving options etc out of GRMHD package
-        void SetGlobalTimeStep() override;
+    // Also override the timestep calculation, so we can start moving options etc out of
+    // GRMHD package
+    void SetGlobalTimeStep() override;
 
-        // And the PostExecute, so we can add a package callback here
-        void PostExecute(DriverStatus status) override;
+    // And the PostExecute, so we can add a package callback here
+    void PostExecute(DriverStatus status) override;
 
-        /**
-         * Make a TaskCollection according to which step type was chosen (kharma, imex, simple).
-         * This represents all tasks to be done in this sub-step (i.e., one TaskList per
-         * stage of the integrator)
-         */
-        TaskCollection MakeTaskCollection(BlockList_t &blocks, int stage) override;
+    /**
+     * Make a TaskCollection according to which step type was chosen (kharma, imex,
+     * simple). This represents all tasks to be done in this sub-step (i.e., one TaskList
+     * per stage of the integrator)
+     */
+    TaskCollection MakeTaskCollection(BlockList_t& blocks, int stage) override;
 
-        /**
-         * The default step, synchronizing conserved variables and then recovering primitive variables in the ghost zones.
-         * See https://github.com/AFD-Illinois/kharma/wiki/The-Driver#kharma-step
-         */
-        TaskCollection MakeDefaultTaskCollection(BlockList_t &blocks, int stage);
+    /**
+     * The default step, synchronizing conserved variables and then recovering primitive
+     * variables in the ghost zones. See
+     * https://github.com/AFD-Illinois/kharma/wiki/The-Driver#kharma-step
+     */
+    TaskCollection MakeDefaultTaskCollection(BlockList_t& blocks, int stage);
 
-        /**
-         * This step syncs primitive variables and treats them as fundamental
-         * This accommodates semi-implicit stepping, allowing evolving theories with implicit source terms such as extended MHD
-         * See https://github.com/AFD-Illinois/kharma/wiki/The-Driver#imex-step
-         */
-        TaskCollection MakeImExTaskCollection(BlockList_t &blocks, int stage);
+    /**
+     * This step syncs primitive variables and treats them as fundamental
+     * This accommodates semi-implicit stepping, allowing evolving theories with implicit
+     * source terms such as extended MHD See
+     * https://github.com/AFD-Illinois/kharma/wiki/The-Driver#imex-step
+     */
+    TaskCollection MakeImExTaskCollection(BlockList_t& blocks, int stage);
 
-        /**
-         * A simple step for experimentation/new implementations.  Does NOT support Face-CT, or much of anything optional.
-         * See https://github.com/AFD-Illinois/kharma/wiki/The-Driver#simple-step
-         */
-        TaskCollection MakeSimpleTaskCollection(BlockList_t &blocks, int stage);
+    /**
+     * A simple step for experimentation/new implementations.  Does NOT support Face-CT,
+     * or much of anything optional. See
+     * https://github.com/AFD-Illinois/kharma/wiki/The-Driver#simple-step
+     */
+    TaskCollection MakeSimpleTaskCollection(BlockList_t& blocks, int stage);
 
-        // BUNDLES
-        // The different drivers share substantially similar portions of the full task list, which we gather into
-        // single functions here
-        /**
-         * Add the flux calculations in each direction.  Since the flux functions are templated on which
-         * reconstruction is being used, this amounts to a lot of shared lines.
-         */
-        static TaskID AddFluxCalculations(TaskID& t_start, TaskList& tl, MeshData<Real> *md);
+    // BUNDLES
+    // The different drivers share substantially similar portions of the full task list,
+    // which we gather into single functions here
+    /**
+     * Add the flux calculations in each direction.  Since the flux functions are
+     * templated on which reconstruction is being used, this amounts to a lot of shared
+     * lines.
+     */
+    static TaskID AddFluxCalculations(TaskID& t_start, TaskList& tl, MeshData<Real>* md);
 
-        /**
-         * Add first-order flux corrections.  This is split out because it needs an additional MeshData object for the "guess"
-         * TODO(BSP) Maybe a less-cowardly approach to adding MeshDatas lets me shove this into AddFluxCalculations
-         */
-        TaskID AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real> *md,
-                             MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init,
-                             MeshData<Real> *guess_src, MeshData<Real> *guess, int stage);
-        /**
-         * This function updates a state md_update with the results of an explicit source term calculation
-         * placed in md_flux_src.  It includes initialization/RK factors and so requires full- and sub-step
-         * initial states too.
-         */
-        TaskID AddStateUpdate(TaskID& t_start, TaskList& tl, MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init,
-                                MeshData<Real> *md_flux_src, MeshData<Real> *md_update, std::vector<MetadataFlag> flags,
-                                bool update_face, int stage);
+    /**
+     * Add first-order flux corrections.  This is split out because it needs an additional
+     * MeshData object for the "guess"
+     * TODO(CEP) Maybe a less-cowardly approach to adding MeshDatas lets me shove this
+     * into AddFluxCalculations
+     */
+    TaskID AddFOFC(TaskID& t_start, TaskList& tl, MeshData<Real>* md,
+        MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+        MeshData<Real>* guess_src, MeshData<Real>* guess, int stage);
+    /**
+     * This function updates a state md_update with the results of an explicit source term
+     * calculation placed in md_flux_src.  It includes initialization/RK factors and so
+     * requires full- and sub-step initial states too.
+     */
+    TaskID AddStateUpdate(TaskID& t_start, TaskList& tl,
+        MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+        MeshData<Real>* md_flux_src, MeshData<Real>* md_update,
+        std::vector<MetadataFlag> flags, bool update_face, int stage);
 
-        /**
-         * This function updates a state md_update with the results of an explicit source term calculation
-         * placed in md_flux_src. It is similar to `AddStateUpdate` but applies only to variables marked
-         * with the `IdealGuess` flag.
-         */
-        TaskID AddStateUpdateIdealGuess(TaskID& t_start, TaskList& tl, MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init,
-                                MeshData<Real> *md_flux_src, MeshData<Real> *md_update, std::vector<MetadataFlag> flags,
-                                bool update_face, int stage);
+    /**
+     * This function updates a state md_update with the results of an explicit source term
+     * calculation placed in md_flux_src. It is similar to `AddStateUpdate` but applies
+     * only to variables marked with the `IdealGuess` flag.
+     */
+    TaskID AddStateUpdateIdealGuess(TaskID& t_start, TaskList& tl,
+        MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+        MeshData<Real>* md_flux_src, MeshData<Real>* md_update,
+        std::vector<MetadataFlag> flags, bool update_face, int stage);
 
-        /**
-         * Add a synchronization retion to an existing TaskCollection tc.
-         * Since the region is self-contained, does not return a TaskID
-         */
-        void AddFullSyncRegion(TaskCollection& tc, std::shared_ptr<MeshData<Real>> &md);
+    /**
+     * Add a synchronization retion to an existing TaskCollection tc.
+     * Since the region is self-contained, does not return a TaskID
+     */
+    void AddFullSyncRegion(TaskCollection& tc, std::shared_ptr<MeshData<Real>>& md);
 
-        /**
-         * Add just the synchronization step to a task list tl, dependent upon taskID t_start, syncing mesh mc1
-         * 
-         * This sequence is used identically in several places, so it makes sense
-         * to define once and use elsewhere.
-         */
-        static TaskID AddBoundarySync(const TaskID t_start, TaskList &tl, std::shared_ptr<MeshData<Real>> &md);
+    /**
+     * Add just the synchronization step to a task list tl, dependent upon taskID t_start,
+     * syncing mesh mc1
+     *
+     * This sequence is used identically in several places, so it makes sense
+     * to define once and use elsewhere.
+     */
+    static TaskID AddBoundarySync(
+        const TaskID t_start, TaskList& tl, std::shared_ptr<MeshData<Real>>& md);
 
-        /**
-         * Single call to sync all boundary conditions (MPI/internal and domain/physical boundaries)
-         * Used anytime boundary sync is needed outside the usual loop of steps.
-         * 
-         * Only use this during the run if you're debugging!
-         */
-        static TaskStatus SyncAllBounds(std::shared_ptr<MeshData<Real>> &md);
+    /**
+     * Single call to sync all boundary conditions (MPI/internal and domain/physical
+     * boundaries) Used anytime boundary sync is needed outside the usual loop of steps.
+     *
+     * Only use this during the run if you're debugging!
+     */
+    static TaskStatus SyncAllBounds(std::shared_ptr<MeshData<Real>>& md);
 
-        // TODO swapped versions of these
-        /**
-         * Copy variables matching 'flags' from 'source' to 'dest'.
-         * Mostly makes things easier to read.
-         */
-        template<typename T>
-        static TaskStatus Copy(std::vector<MetadataFlag> flags, T* source, T* dest)
-        {
-            return Update::WeightedSumData<std::vector<MetadataFlag>, T>(flags, source, source, 1., 0., dest);
-        }
+    // TODO swapped versions of these
+    /**
+     * Copy variables matching 'flags' from 'source' to 'dest'.
+     * Mostly makes things easier to read.
+     */
+    template<typename T>
+    static TaskStatus Copy(std::vector<MetadataFlag> flags, T* source, T* dest)
+    {
+        return Update::WeightedSumData<std::vector<MetadataFlag>, T>(
+            flags, source, source, 1., 0., dest);
+    }
 
-        template<typename MDType>
-        static TaskStatus WeightedSumDataFace(const std::vector<MDType> &flags, MeshData<Real> *in1, MeshData<Real> *in2, const Real w1, const Real w2,
-                                MeshData<Real> *out)
-        {
-            Kokkos::Profiling::pushRegion("Task_WeightedSumDataFace");
-            const auto &x = in1->PackVariables(flags);
-            const auto &y = in2->PackVariables(flags);
-            const auto &z = out->PackVariables(flags);
-            parthenon::par_for(
-                DEFAULT_LOOP_PATTERN, "WeightedSumDataFace", DevExecSpace(), 0, x.GetDim(5) - 1, 0,
-                x.GetDim(4) - 1, 0, x.GetDim(3) - 1, 0, x.GetDim(2) - 1, 0, x.GetDim(1) - 1,
-                KOKKOS_LAMBDA(const int b, const int l, const int k, const int j, const int i) {
-                    // TOOD(someone) This is potentially dangerous and/or not intended behavior
-                    // as we still may want to update (or populate) z if any of those vars are
-                    // not allocated yet.
-                    if (x.IsAllocated(b, l) && y.IsAllocated(b, l) && z.IsAllocated(b, l)) {
-                        z(b, F1, l, k, j, i) = w1 * x(b, F1, l, k, j, i) + w2 * y(b, F1, l, k, j, i);
-                        z(b, F2, l, k, j, i) = w1 * x(b, F2, l, k, j, i) + w2 * y(b, F2, l, k, j, i);
-                        z(b, F3, l, k, j, i) = w1 * x(b, F3, l, k, j, i) + w2 * y(b, F3, l, k, j, i);
-                    }
-                });
-            Kokkos::Profiling::popRegion(); // Task_WeightedSumDataFace
-            return TaskStatus::complete;
-        }
-
-        /**
-         * Scale a variable by 'norm'.
-         * Mostly makes things easier to read.
-         */
-        static TaskStatus Scale(std::vector<std::string> vars,  MeshData<Real>* source, Real norm)
-        {
-            return Update::WeightedSumData<std::vector<std::string>, MeshData<Real>>(vars, source, source, norm, 0., source);
-        }
-        static TaskStatus ScaleFace(std::vector<std::string> vars,  MeshData<Real>* source, Real norm)
-        {
-            return WeightedSumDataFace(vars, source, source, norm, 0., source);
-        }
-
-        /**
-         * Replace Parthenon's `FluxDivergence` with a more adaptable version: pack on a customizable set
-         * of flags, optionally include a halo around physical zones (useful for predicting bad zones in FOFC)
-         */
-        static TaskStatus FluxDivergence(MeshData<Real> *in_obj, MeshData<Real> *dudt_obj,
-                                  std::vector<MetadataFlag> flags = {Metadata::WithFluxes, Metadata::Cell},
-                                  int halo=0)
-        {
-            const auto &vin = in_obj->PackVariablesAndFluxes(flags);
-            auto dudt = dudt_obj->PackVariables(flags);
-
-            const IndexRange3 b = KDomain::GetRange(in_obj, IndexDomain::interior, -halo, halo);
-
-            const int ndim = vin.GetNdim();
-            parthenon::par_for(
-                DEFAULT_LOOP_PATTERN, "FluxDivergenceMesh", DevExecSpace(), 0, vin.GetDim(5) - 1, 0,
-                vin.GetDim(4) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA(const int m, const int l, const int k, const int j, const int i) {
-                    if (dudt.IsAllocated(m, l) && vin.IsAllocated(m, l)) {
-                        const auto &coords = vin.GetCoords(m);
-                        const auto &v = vin(m);
-                        dudt(m, l, k, j, i) = Update::FluxDivHelper(l, k, j, i, ndim, coords, v);
-                    }
+    template<typename MDType>
+    static TaskStatus WeightedSumDataFace(const std::vector<MDType>& flags,
+        MeshData<Real>* in1, MeshData<Real>* in2, const Real w1, const Real w2,
+        MeshData<Real>* out)
+    {
+        Kokkos::Profiling::pushRegion("Task_WeightedSumDataFace");
+        const auto& x = in1->PackVariables(flags);
+        const auto& y = in2->PackVariables(flags);
+        const auto& z = out->PackVariables(flags);
+        parthenon::par_for(DEFAULT_LOOP_PATTERN, "WeightedSumDataFace", DevExecSpace(), 0,
+            x.GetDim(5) - 1, 0, x.GetDim(4) - 1, 0, x.GetDim(3) - 1, 0, x.GetDim(2) - 1,
+            0, x.GetDim(1) - 1,
+            KOKKOS_LAMBDA(const int b, const int l, const int k, const int j, const int i)
+            {
+                // TOOD(someone) This is potentially dangerous and/or not intended
+                // behavior as we still may want to update (or populate) z if any of those
+                // vars are not allocated yet.
+                if (x.IsAllocated(b, l) && y.IsAllocated(b, l) && z.IsAllocated(b, l)) {
+                    z(b, F1, l, k, j, i) =
+                        w1 * x(b, F1, l, k, j, i) + w2 * y(b, F1, l, k, j, i);
+                    z(b, F2, l, k, j, i) =
+                        w1 * x(b, F2, l, k, j, i) + w2 * y(b, F2, l, k, j, i);
+                    z(b, F3, l, k, j, i) =
+                        w1 * x(b, F3, l, k, j, i) + w2 * y(b, F3, l, k, j, i);
                 }
-            );
+            });
+        Kokkos::Profiling::popRegion(); // Task_WeightedSumDataFace
+        return TaskStatus::complete;
+    }
 
-            return TaskStatus::complete;
-        }
+    /**
+     * Scale a variable by 'norm'.
+     * Mostly makes things easier to read.
+     */
+    static TaskStatus Scale(
+        std::vector<std::string> vars, MeshData<Real>* source, Real norm)
+    {
+        return Update::WeightedSumData<std::vector<std::string>, MeshData<Real>>(
+            vars, source, source, norm, 0., source);
+    }
+    static TaskStatus ScaleFace(
+        std::vector<std::string> vars, MeshData<Real>* source, Real norm)
+    {
+        return WeightedSumDataFace(vars, source, source, norm, 0., source);
+    }
 
+    /**
+     * Replace Parthenon's `FluxDivergence` with a more adaptable version: pack on a
+     * customizable set of flags, optionally include a halo around physical zones (useful
+     * for predicting bad zones in FOFC)
+     */
+    static TaskStatus FluxDivergence(MeshData<Real>* in_obj, MeshData<Real>* dudt_obj,
+        std::vector<MetadataFlag> flags = {Metadata::WithFluxes, Metadata::Cell},
+        int halo = 0)
+    {
+        const auto& vin = in_obj->PackVariablesAndFluxes(flags);
+        auto dudt = dudt_obj->PackVariables(flags);
+
+        const IndexRange3 b =
+            KDomain::GetRange(in_obj, IndexDomain::interior, -halo, halo);
+
+        const int ndim = vin.GetNdim();
+        parthenon::par_for(DEFAULT_LOOP_PATTERN, "FluxDivergenceMesh", DevExecSpace(), 0,
+            vin.GetDim(5) - 1, 0, vin.GetDim(4) - 1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+            KOKKOS_LAMBDA(const int m, const int l, const int k, const int j, const int i)
+            {
+                if (dudt.IsAllocated(m, l) && vin.IsAllocated(m, l)) {
+                    const auto& coords = vin.GetCoords(m);
+                    const auto& v = vin(m);
+                    dudt(m, l, k, j, i) =
+                        Update::FluxDivHelper(l, k, j, i, ndim, coords, v);
+                }
+            });
+
+        return TaskStatus::complete;
+    }
 };

--- a/kharma/driver/kharma_step.cpp
+++ b/kharma/driver/kharma_step.cpp
@@ -34,11 +34,11 @@
 #include "kharma_driver.hpp"
 
 // TODO CLEAN
-//Packages
-#include "b_flux_ct.hpp"
+// Packages
 #include "b_cd.hpp"
 #include "b_cleanup.hpp"
 #include "b_ct.hpp"
+#include "b_flux_ct.hpp"
 #include "electrons.hpp"
 #include "grmhd.hpp"
 #include "inverter.hpp"
@@ -47,50 +47,51 @@
 // Other headers
 #include "boundaries.hpp"
 #include "flux.hpp"
-#include "kharma.hpp"
 #include "implicit.hpp"
+#include "kharma.hpp"
 #include "resize_restart.hpp"
 
-#include <parthenon/parthenon.hpp>
-#include <interface/update.hpp>
 #include <amr_criteria/refinement_package.hpp>
+#include <interface/update.hpp>
+#include <parthenon/parthenon.hpp>
 
 using FC = Metadata::FlagCollection;
 
-TaskCollection KHARMADriver::MakeTaskCollection(BlockList_t &blocks, int stage)
+TaskCollection KHARMADriver::MakeTaskCollection(BlockList_t& blocks, int stage)
 {
     DriverType driver_type = blocks[0]->packages.Get("Driver")->Param<DriverType>("type");
     Flag("MakeTaskCollection");
     TaskCollection tc;
     switch (driver_type) {
-    case DriverType::kharma:
-        tc = MakeDefaultTaskCollection(blocks, stage);
-        break;
-    case DriverType::imex:
-        tc = MakeImExTaskCollection(blocks, stage);
-        break;
-    case DriverType::simple:
-        tc = MakeSimpleTaskCollection(blocks, stage);
-        break;
+        case DriverType::kharma:
+            tc = MakeDefaultTaskCollection(blocks, stage);
+            break;
+        case DriverType::imex:
+            tc = MakeImExTaskCollection(blocks, stage);
+            break;
+        case DriverType::simple:
+            tc = MakeSimpleTaskCollection(blocks, stage);
+            break;
     }
     EndFlag();
     return tc;
 }
 
-TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int stage)
+TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t& blocks, int stage)
 {
     // Reminder that this list is created BEFORE any of the list contents are run!
-    // Prints or function calls here will likely not do what you want: instead, add to the list by calling tl.AddTask()
+    // Prints or function calls here will likely not do what you want: instead, add to the
+    // list by calling tl.AddTask()
 
     // TaskCollections are a collection of TaskRegions.
-    // Each TaskRegion can operate on eash meshblock separately, i.e. one MeshBlockData object (slower),
-    // or on a collection of MeshBlock objects called the MeshData
+    // Each TaskRegion can operate on eash meshblock separately, i.e. one MeshBlockData
+    // object (slower), or on a collection of MeshBlock objects called the MeshData
     TaskCollection tc;
     const TaskID t_none(0);
 
     // Which packages we load affects which tasks we'll add to the list
     auto& pkgs = pmesh->packages.AllPackages();
-    auto& flux_pkg   = pkgs.at("Fluxes")->AllParams();
+    auto& flux_pkg = pkgs.at("Fluxes")->AllParams();
     const bool use_b_cleanup = pkgs.count("B_Cleanup");
     const bool use_b_ct = pkgs.count("B_CT");
     const bool use_electrons = pkgs.count("Electrons");
@@ -98,10 +99,11 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
     const bool use_jcon = pkgs.count("Current");
 
     // Allocate/copy the things we need
-    // TODO these can now be reduced by including the var lists/flags which actually need to be allocated
+    // TODO these can now be reduced by including the var lists/flags which actually need
+    // to be allocated
     // TODO except the Copy they can be run on step 1 only
     if (stage == 1) {
-        auto &base = pmesh->mesh_data.Get();
+        auto& base = pmesh->mesh_data.Get();
         // Fluxes
         pmesh->mesh_data.Add("dUdt", base);
         for (int i = 1; i < integrator->nstages; i++)
@@ -113,22 +115,25 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
             static parthenon::Metadata::FlagVec preserve_flags;
             static std::vector<std::string> preserve_vars;
             if (preserve_vars.size() == 0) {
-                preserve_flags = {Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")};
-                preserve_vars = KHARMA::GetVariableNames(&(pmesh->packages), FC(preserve_flags));
+                preserve_flags = {
+                    Metadata::GetUserFlag("MHD"), Metadata::GetUserFlag("Primitive")};
+                preserve_vars =
+                    KHARMA::GetVariableNames(&(pmesh->packages), FC(preserve_flags));
             }
             // Add the container once to avoid re-adding if we have lots of partitions
-            //pmesh->mesh_data.Add("preserve", base, preserve_vars);
+            // pmesh->mesh_data.Add("preserve", base, preserve_vars);
             // Ensure we copy the MHD variables every step with a task
             const int num_partitions = pmesh->DefaultNumPartitions();
-            TaskRegion &copy_region = tc.AddRegion(num_partitions);
+            TaskRegion& copy_region = tc.AddRegion(num_partitions);
             for (int i = 0; i < num_partitions; i++) {
-                auto &tl = copy_region[i];
-                tl.AddTask(t_none, Copy<MeshData<Real>>, preserve_flags,
-                            base.get(), pmesh->mesh_data.Add("preserve", base, preserve_vars).get());
+                auto& tl = copy_region[i];
+                tl.AddTask(t_none, Copy<MeshData<Real>>, preserve_flags, base.get(),
+                    pmesh->mesh_data.Add("preserve", base, preserve_vars).get());
             }
         }
-        // FOFC needs to determine whether the "real" U-divF will violate floors, and needs a safe place to do it.
-        // We populate it later, with each *sub-step*'s initial state
+        // FOFC needs to determine whether the "real" U-divF will violate floors, and
+        // needs a safe place to do it. We populate it later, with each *sub-step*'s
+        // initial state
         if (use_fofc) {
             pmesh->mesh_data.Add("fofc_source", base);
             pmesh->mesh_data.Add("fofc_guess", base);
@@ -139,47 +144,61 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
 
     static std::vector<std::string> sync_vars;
     if (sync_vars.size() == 0) {
-        // Build the universe of variables to let Parthenon see when exchanging boundaries.
-        // This is built to exclude incidental variables like B field initialization stuff, EMFs, etc.
-        // "Boundaries" packs in buffers e.g. Dirichlet boundaries
+        // Build the universe of variables to let Parthenon see when exchanging
+        // boundaries. This is built to exclude incidental variables like B field
+        // initialization stuff, EMFs, etc. "Boundaries" packs in buffers e.g. Dirichlet
+        // boundaries
         auto sync_flags = FC({Metadata::GetUserFlag("Primitive"), Metadata::Conserved,
-                              Metadata::Face, Metadata::GetUserFlag("Boundaries")}, true);
+                                 Metadata::Face, Metadata::GetUserFlag("Boundaries")},
+            true);
         sync_vars = KHARMA::GetVariableNames(&(pmesh->packages), sync_flags);
     }
 
     // Flux region: calculate and apply fluxes to update conserved values
     const int num_partitions = pmesh->DefaultNumPartitions();
-    TaskRegion &flux_region = tc.AddRegion(num_partitions);
+    TaskRegion& flux_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
-        auto &tl = flux_region[i];
+        auto& tl = flux_region[i];
         // Container names:
-        // '_full_step_init' refers to the fluid state at the start of the full time step (Si in iharm3d)
-        // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in iharm3d)
-        // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in iharm3d)
+        // '_full_step_init' refers to the fluid state at the start of the full time step
+        // (Si in iharm3d)
+        // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in
+        // iharm3d)
+        // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in
+        // iharm3d)
         // '_flux_src' refers to the mesh object corresponding to -divF + S
-        auto &md_full_step_init = pmesh->mesh_data.GetOrAdd("base", i);
-        auto &md_sub_step_init  = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], i);
-        auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
-        auto &md_flux_src       = pmesh->mesh_data.GetOrAdd("dUdt", i);
-        // TODO this doesn't work still for some reason, even if the shallow copy has all variables
-        auto &md_sync = pmesh->mesh_data.AddShallow("sync"+integrator->stage_name[stage]+std::to_string(i), md_sub_step_final, sync_vars);
+        auto& md_full_step_init = pmesh->mesh_data.GetOrAdd("base", i);
+        auto& md_sub_step_init =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], i);
+        auto& md_sub_step_final =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+        auto& md_flux_src = pmesh->mesh_data.GetOrAdd("dUdt", i);
+        // TODO this doesn't work still for some reason, even if the shallow copy has all
+        // variables
+        auto& md_sync = pmesh->mesh_data.AddShallow(
+            "sync" + integrator->stage_name[stage] + std::to_string(i), md_sub_step_final,
+            sync_vars);
 
         // Start receiving flux corrections and ghost cells
-        auto t_start_recv_bound = tl.AddTask(t_none, parthenon::StartReceiveBoundBufs<parthenon::BoundaryType::any>, md_sync);
+        auto t_start_recv_bound = tl.AddTask(t_none,
+            parthenon::StartReceiveBoundBufs<parthenon::BoundaryType::any>, md_sync);
         auto t_start_recv_flux = t_start_recv_bound;
         if (pmesh->multilevel || use_b_ct)
-            t_start_recv_flux = tl.AddTask(t_none, parthenon::StartReceiveFluxCorrections, md_sub_step_init);
+            t_start_recv_flux = tl.AddTask(
+                t_none, parthenon::StartReceiveFluxCorrections, md_sub_step_init);
 
         // Calculate the flux of each variable through each face
         // This reconstructs the primitives (P) at faces and uses them to calculate fluxes
         // of the conserved variables (U) through each face.
-        auto t_flux_calc = KHARMADriver::AddFluxCalculations(t_start_recv_flux, tl, md_sub_step_init.get());
+        auto t_flux_calc = KHARMADriver::AddFluxCalculations(
+            t_start_recv_flux, tl, md_sub_step_init.get());
         auto t_fluxes = t_flux_calc;
         if (use_fofc) {
-            auto &guess_src = pmesh->mesh_data.GetOrAdd("fofc_source", i);
-            auto &guess = pmesh->mesh_data.GetOrAdd("fofc_guess", i);
-            auto t_fluxes = KHARMADriver::AddFOFC(t_flux_calc, tl, md_sub_step_init.get(), md_full_step_init.get(),
-                                                  md_sub_step_init.get(), guess_src.get(), guess.get(), stage);
+            auto& guess_src = pmesh->mesh_data.GetOrAdd("fofc_source", i);
+            auto& guess = pmesh->mesh_data.GetOrAdd("fofc_guess", i);
+            auto t_fluxes = KHARMADriver::AddFOFC(t_flux_calc, tl, md_sub_step_init.get(),
+                md_full_step_init.get(), md_sub_step_init.get(), guess_src.get(),
+                guess.get(), stage);
         }
 
         // Any package modifications to the fluxes.  e.g.:
@@ -194,27 +213,39 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
             auto t_emf = t_flux_bounds;
             if (use_b_ct) {
                 // Pull out a container of only EMF to synchronize
-                auto &md_emf_only = pmesh->mesh_data.AddShallow("EMF", md_sub_step_init, std::vector<std::string>{"B_CT.emf"}); // TODO this gets weird if we partition
-                auto t_emf_local = tl.AddTask(t_flux_bounds, B_CT::CalculateEMF, md_sub_step_init.get());
+                auto& md_emf_only = pmesh->mesh_data.AddShallow("EMF", md_sub_step_init,
+                    std::vector<std::string>{
+                        "B_CT.emf"}); // TODO this gets weird if we partition
+                auto t_emf_local =
+                    tl.AddTask(t_flux_bounds, B_CT::CalculateEMF, md_sub_step_init.get());
                 t_emf = KHARMADriver::AddBoundarySync(t_emf_local, tl, md_emf_only);
             }
-            auto t_load_send_flux = tl.AddTask(t_emf, parthenon::LoadAndSendFluxCorrections, md_sub_step_init);
-            auto t_recv_flux = tl.AddTask(t_load_send_flux, parthenon::ReceiveFluxCorrections, md_sub_step_init);
-            t_flux_bounds = tl.AddTask(t_recv_flux, parthenon::SetFluxCorrections, md_sub_step_init);
+            auto t_load_send_flux = tl.AddTask(
+                t_emf, parthenon::LoadAndSendFluxCorrections, md_sub_step_init);
+            auto t_recv_flux = tl.AddTask(
+                t_load_send_flux, parthenon::ReceiveFluxCorrections, md_sub_step_init);
+            t_flux_bounds =
+                tl.AddTask(t_recv_flux, parthenon::SetFluxCorrections, md_sub_step_init);
         }
 
         // Apply the fluxes to calculate a change in cell-centered values "md_flux_src"
-        auto t_flux_div = tl.AddTask(t_flux_bounds, FluxDivergence, md_sub_step_init.get(), md_flux_src.get(),
-                                     std::vector<MetadataFlag>{Metadata::Independent, Metadata::Cell, Metadata::WithFluxes}, 0);
+        auto t_flux_div = tl.AddTask(t_flux_bounds, FluxDivergence,
+            md_sub_step_init.get(), md_flux_src.get(),
+            std::vector<MetadataFlag>{
+                Metadata::Independent, Metadata::Cell, Metadata::WithFluxes},
+            0);
 
         // Add any source terms: geometric \Gamma * T, wind, damping, etc etc
         // Also where CT sets the change in face fields
-        auto t_sources = tl.AddTask(t_flux_div, Packages::AddSource, md_sub_step_init.get(), md_flux_src.get(), IndexDomain::interior);
+        auto t_sources = tl.AddTask(t_flux_div, Packages::AddSource,
+            md_sub_step_init.get(), md_flux_src.get(), IndexDomain::interior);
 
-        auto t_update = KHARMADriver::AddStateUpdate(t_sources, tl, md_full_step_init.get(), md_sub_step_init.get(),
-                                                  md_flux_src.get(), md_sub_step_final.get(),
-                                                  std::vector<MetadataFlag>{Metadata::GetUserFlag("Explicit"), Metadata::Independent},
-                                                  use_b_ct, stage);
+        auto t_update =
+            KHARMADriver::AddStateUpdate(t_sources, tl, md_full_step_init.get(),
+                md_sub_step_init.get(), md_flux_src.get(), md_sub_step_final.get(),
+                std::vector<MetadataFlag>{
+                    Metadata::GetUserFlag("Explicit"), Metadata::Independent},
+                use_b_ct, stage);
 
         KHARMADriver::AddBoundarySync(t_update, tl, md_sync);
     }
@@ -222,87 +253,110 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
     EndFlag();
     Flag("MakeTaskCollection::fixes");
 
-    // Fix Region: prims/cons sync, floors, fixes, boundary conditions which need primitives
-    TaskRegion &fix_region = tc.AddRegion(num_partitions);
+    // Fix Region: prims/cons sync, floors, fixes, boundary conditions which need
+    // primitives
+    TaskRegion& fix_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
-        auto &tl = fix_region[i];
-        auto &md_sub_step_init  = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage-1], i);
-        auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
-        auto &md_sync = pmesh->mesh_data.AddShallow("sync"+integrator->stage_name[stage]+std::to_string(i), md_sub_step_final, sync_vars);
+        auto& tl = fix_region[i];
+        auto& md_sub_step_init =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], i);
+        auto& md_sub_step_final =
+            pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+        auto& md_sync = pmesh->mesh_data.AddShallow(
+            "sync" + integrator->stage_name[stage] + std::to_string(i), md_sub_step_final,
+            sync_vars);
 
         // At this point, we've sync'd all internal boundaries using the conserved
         // variables. The physical boundaries (pole, inner/outer) are trickier,
         // since they must be applied to the primitive variables rho,u,u1,u2,u3
         // but should apply to conserved forms of everything else.
 
-        // This call fills the fluid primitive values in all physical zones, that is, including MPI boundaries but
-        // not the physical boundaries (which haven't been filled yet!)
-        // This relies on the primitives being calculated identically in MPI boundaries, vs their corresponding
-        // physical zones in the adjacent mesh block.  To ensure this, we seed the solver with the same values
-        // in each case, by synchronizing them along with the conserved values above.
-        auto t_utop = tl.AddTask(t_none, Packages::MeshUtoP, md_sub_step_final.get(), IndexDomain::entire, false);
+        // This call fills the fluid primitive values in all physical zones, that is,
+        // including MPI boundaries but not the physical boundaries (which haven't been
+        // filled yet!) This relies on the primitives being calculated identically in MPI
+        // boundaries, vs their corresponding physical zones in the adjacent mesh block.
+        // To ensure this, we seed the solver with the same values in each case, by
+        // synchronizing them along with the conserved values above.
+        auto t_utop = tl.AddTask(t_none, Packages::MeshUtoP, md_sub_step_final.get(),
+            IndexDomain::entire, false);
         // As soon as we have primitive variables, apply floors
-        auto t_floors = tl.AddTask(t_utop, Packages::MeshApplyFloors, md_sub_step_final.get(), IndexDomain::entire);
+        auto t_floors = tl.AddTask(t_utop, Packages::MeshApplyFloors,
+            md_sub_step_final.get(), IndexDomain::entire);
 
-        // Then, fix any inversions which failed. Fixups average the adjacent zones, so we want to work from
-        // post-floor data. Floors are re-applied after fixups.
-        auto t_fix_p = tl.AddTask(t_floors, Inverter::MeshFixUtoP, md_sub_step_final.get());
+        // Then, fix any inversions which failed. Fixups average the adjacent zones, so we
+        // want to work from post-floor data. Floors are re-applied after fixups.
+        auto t_fix_p =
+            tl.AddTask(t_floors, Inverter::MeshFixUtoP, md_sub_step_final.get());
 
         // Domain (non-internal) boundary conditions:
-        // This is a parthenon call, but in spherical coordinates it will call the KHARMA functions in
-        // boundaries.cpp, which apply physical boundary conditions based on the primitive variables of GRHD,
-        // and based on the conserved forms for everything else.  Note that because this is called *after*
-        // UtoP (since it needs bulk fluid primitives to apply GRMHD boundaries), this function
-        // must call UtoP *again* (for everything except the GRHD variables) to fill P in the ghost zones.
-        // This is why KHARMA packages need to implement their UtoP functions in the form
-        // UtoP(rc, domain, coarse): so that they can be run over just the boundary domains here.
-        auto t_set_bc = tl.AddTask(t_fix_p, parthenon::ApplyBoundaryConditionsOnCoarseOrFineMD, md_sync, false);
+        // This is a parthenon call, but in spherical coordinates it will call the KHARMA
+        // functions in boundaries.cpp, which apply physical boundary conditions based on
+        // the primitive variables of GRHD, and based on the conserved forms for
+        // everything else.  Note that because this is called *after* UtoP (since it needs
+        // bulk fluid primitives to apply GRMHD boundaries), this function must call UtoP
+        // *again* (for everything except the GRHD variables) to fill P in the ghost
+        // zones. This is why KHARMA packages need to implement their UtoP functions in
+        // the form UtoP(rc, domain, coarse): so that they can be run over just the
+        // boundary domains here.
+        auto t_set_bc = tl.AddTask(
+            t_fix_p, parthenon::ApplyBoundaryConditionsOnCoarseOrFineMD, md_sync, false);
 
         // Add primitive-variable source terms:
-        // In order to calculate dissipation, we must know the entropy at the beginning and end of the substep,
-        // and this must be calculated from the fluid primitive variables rho,u (and for stability, obey floors!).
-        // Only now do we have the end-of-step primitives in consistent, corrected forms.
-        // Luckily, ApplyElectronHeating should *not* need another synchronization of the ghost zones, as it is applied to
-        // all zones and has a stencil of only one zone.  As with UtoP, this trusts that evaluations
-        // of the same zone match between MeshBlocks.
+        // In order to calculate dissipation, we must know the entropy at the beginning
+        // and end of the substep, and this must be calculated from the fluid primitive
+        // variables rho,u (and for stability, obey floors!). Only now do we have the
+        // end-of-step primitives in consistent, corrected forms. Luckily,
+        // ApplyElectronHeating should *not* need another synchronization of the ghost
+        // zones, as it is applied to all zones and has a stencil of only one zone.  As
+        // with UtoP, this trusts that evaluations of the same zone match between
+        // MeshBlocks.
 
-        // Any package- (likely, problem-) specific source terms which must be applied to primitive variables
-        // Apply these only after the final step so they're operator-split
+        // Any package- (likely, problem-) specific source terms which must be applied to
+        // primitive variables Apply these only after the final step so they're
+        // operator-split
         auto t_prim_source = t_set_bc;
         if (stage == integrator->nstages) {
-            t_prim_source = tl.AddTask(t_set_bc, Packages::MeshApplyPrimSource, md_sub_step_final.get());
+            t_prim_source = tl.AddTask(
+                t_set_bc, Packages::MeshApplyPrimSource, md_sub_step_final.get());
         }
         // Electron heating goes where it does in HARMDriver, for the same reasons
         auto t_heat_electrons = t_prim_source;
         if (use_electrons) {
-            t_heat_electrons = tl.AddTask(t_prim_source, Electrons::MeshApplyElectronHeating,
-                                          md_sub_step_init.get(), md_sub_step_final.get(), stage == 1); // bool is generate_grf
+            t_heat_electrons =
+                tl.AddTask(t_prim_source, Electrons::MeshApplyElectronHeating,
+                    md_sub_step_init.get(), md_sub_step_final.get(),
+                    stage == 1); // bool is generate_grf
         }
 
         // Make sure *all* conserved vars are synchronized at step end
-        auto t_ptou = tl.AddTask(t_heat_electrons, Flux::MeshPtoU, md_sub_step_final.get(), IndexDomain::entire, false);
+        auto t_ptou = tl.AddTask(t_heat_electrons, Flux::MeshPtoU,
+            md_sub_step_final.get(), IndexDomain::entire, false);
 
         auto t_step_done = t_ptou;
         if (pkgs.count("ISMR")) {
             if (pkgs.at("ISMR")->Param<uint>("nlevels") > 0) {
                 auto t_derefine_b = t_ptou;
                 if (pkgs.count("B_CT"))
-                    t_derefine_b = tl.AddTask(t_ptou, B_CT::DerefinePoles, md_sub_step_final.get());
-                auto t_derefine_f = tl.AddTask(t_derefine_b, ISMR::DerefinePoles, md_sub_step_final.get());
-                auto t_floors_2 = tl.AddTask(t_derefine_f, Packages::MeshApplyFloors, md_sub_step_final.get(), IndexDomain::entire);
-                t_step_done = tl.AddTask(t_floors_2, Inverter::MeshFixUtoP, md_sub_step_final.get());
+                    t_derefine_b =
+                        tl.AddTask(t_ptou, B_CT::DerefinePoles, md_sub_step_final.get());
+                auto t_derefine_f = tl.AddTask(
+                    t_derefine_b, ISMR::DerefinePoles, md_sub_step_final.get());
+                auto t_floors_2 = tl.AddTask(t_derefine_f, Packages::MeshApplyFloors,
+                    md_sub_step_final.get(), IndexDomain::entire);
+                t_step_done = tl.AddTask(
+                    t_floors_2, Inverter::MeshFixUtoP, md_sub_step_final.get());
             }
         }
 
         // Estimate next time step based on ctop
         if (stage == integrator->nstages) {
-            auto t_new_dt =
-                tl.AddTask(t_step_done, Update::EstimateTimestep<MeshData<Real>>, md_sub_step_final.get());
+            auto t_new_dt = tl.AddTask(t_step_done,
+                Update::EstimateTimestep<MeshData<Real>>, md_sub_step_final.get());
 
             // Update refinement
             if (pmesh->adaptive) {
-                auto tag_refine = tl.AddTask(
-                    t_step_done, parthenon::Refinement::Tag<MeshData<Real>>, md_sub_step_final.get());
+                auto tag_refine = tl.AddTask(t_step_done,
+                    parthenon::Refinement::Tag<MeshData<Real>>, md_sub_step_final.get());
             }
         }
     }
@@ -311,24 +365,28 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
     Flag("MakeTaskCollection::extras");
 
     // B Field cleanup: this is a separate solve so it's split out
-    // It's also really slow when enabled so we don't care too much about limiting regions, etc.
-    if (use_b_cleanup && (stage == integrator->nstages) && B_Cleanup::CleanupThisStep(pmesh, tm.ncycle)) {
-        TaskRegion &cleanup_region = tc.AddRegion(1);
-        auto &tl = cleanup_region[0];
-        auto &md_sub_step_final = pmesh->mesh_data.Get(integrator->stage_name[stage]);
+    // It's also really slow when enabled so we don't care too much about limiting
+    // regions, etc.
+    if (use_b_cleanup && (stage == integrator->nstages) &&
+        B_Cleanup::CleanupThisStep(pmesh, tm.ncycle)) {
+        TaskRegion& cleanup_region = tc.AddRegion(1);
+        auto& tl = cleanup_region[0];
+        auto& md_sub_step_final = pmesh->mesh_data.Get(integrator->stage_name[stage]);
         tl.AddTask(t_none, B_Cleanup::CleanupDivergence, md_sub_step_final);
     }
 
-    // TODO TODO make faster for large num_partitions, also this should be shared whole between drivers
-    // Second boundary sync:
-    // ensure that primitive variables in ghost zones are *exactly*
-    // identical to their physical counterparts, now that they have been
-    // modified on each rank.
-    const auto &two_sync = pkgs.at("Driver")->Param<bool>("two_sync");
+    // TODO TODO make faster for large num_partitions, also this should be shared whole
+    // between drivers Second boundary sync: ensure that primitive variables in ghost
+    // zones are *exactly* identical to their physical counterparts, now that they have
+    // been modified on each rank.
+    const auto& two_sync = pkgs.at("Driver")->Param<bool>("two_sync");
     if (two_sync) {
         for (int i = 0; i < num_partitions; i++) {
-            auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
-            auto &md_sync = pmesh->mesh_data.AddShallow("sync"+integrator->stage_name[stage]+std::to_string(i), md_sub_step_final, sync_vars);
+            auto& md_sub_step_final =
+                pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], i);
+            auto& md_sync = pmesh->mesh_data.AddShallow(
+                "sync" + integrator->stage_name[stage] + std::to_string(i),
+                md_sub_step_final, sync_vars);
             KHARMADriver::AddFullSyncRegion(tc, md_sync);
         }
     }

--- a/kharma/driver/simple_step.cpp
+++ b/kharma/driver/simple_step.cpp
@@ -33,34 +33,39 @@
  */
 #include "kharma_driver.hpp"
 
-#include "inverter.hpp"
 #include "flux.hpp"
+#include "inverter.hpp"
 
-TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t &blocks, int stage)
+TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t& blocks, int stage)
 {
     // This is probably incompatible with just about everything,
     // but we at least check the big ones
     auto& pkgs = pmesh->packages.AllPackages();
     auto& flux_pkg = pkgs.at("Fluxes")->AllParams();
     auto& inverter_pkg = pkgs.at("Inverter")->AllParams();
-    PARTHENON_REQUIRE(!pkgs.count("B_CT"), "Face-centered B not compatible with simple driver!");
+    PARTHENON_REQUIRE(
+        !pkgs.count("B_CT"), "Face-centered B not compatible with simple driver!");
     // TODO require we're not using B_Cleanup as transport too
-    PARTHENON_REQUIRE(!pkgs.count("Electrons"), "Electrons not compatible with simple driver!");
-    PARTHENON_REQUIRE(!flux_pkg.Get<bool>("use_fofc"), "Flux corrections not compatible with simple driver!");
-    PARTHENON_REQUIRE(inverter_pkg.Get<Inverter::Type>("inverter_type") == Inverter::Type::kastaun,
-                      "Only the Kastaun primitive variable recovery is compatible with simple driver!");
-    PARTHENON_REQUIRE(!pkgs.count("Current"), "4-current output not compatible with simple driver!");
+    PARTHENON_REQUIRE(
+        !pkgs.count("Electrons"), "Electrons not compatible with simple driver!");
+    PARTHENON_REQUIRE(!flux_pkg.Get<bool>("use_fofc"),
+        "Flux corrections not compatible with simple driver!");
+    PARTHENON_REQUIRE(
+        inverter_pkg.Get<Inverter::Type>("inverter_type") == Inverter::Type::kastaun,
+        "Only the Kastaun primitive variable recovery is compatible with simple driver!");
+    PARTHENON_REQUIRE(
+        !pkgs.count("Current"), "4-current output not compatible with simple driver!");
 
-    // The `TaskCollection` holds everything we do in a step.  It consists of multiple `TaskRegion`s
-    // run serially.  Each `TaskRegion` can have multiple `TaskLists` which may someday be run
-    // in parallel with threading.  Individual tasks in a `TaskList` may also be run concurrently
-    // at some point, if their dependncies allow.
+    // The `TaskCollection` holds everything we do in a step.  It consists of multiple
+    // `TaskRegion`s run serially.  Each `TaskRegion` can have multiple `TaskLists` which
+    // may someday be run in parallel with threading.  Individual tasks in a `TaskList`
+    // may also be run concurrently at some point, if their dependncies allow.
     TaskCollection tc;
     TaskID t_none(0);
 
     // Allocate the fluid states ("containers") we need for each stage
     if (stage == 1) {
-        auto &base = pmesh->mesh_data.Get();
+        auto& base = pmesh->mesh_data.Get();
         // Fluxes
         pmesh->mesh_data.Add("dUdt", base);
         for (int i = 1; i < integrator->nstages; i++)
@@ -68,58 +73,69 @@ TaskCollection KHARMADriver::MakeSimpleTaskCollection(BlockList_t &blocks, int s
     }
 
     // We use a single region `flux_region` with a single task list we name `tl`.
-    TaskRegion &simple_region = tc.AddRegion(1);
-    auto &tl = simple_region[0];
+    TaskRegion& simple_region = tc.AddRegion(1);
+    auto& tl = simple_region[0];
     // Container names:
-    // '_full_step_init' refers to the fluid state at the start of the full time step (Si in iharm3d)
-    // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in iharm3d)
-    // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in iharm3d)
+    // '_full_step_init' refers to the fluid state at the start of the full time step (Si
+    // in iharm3d)
+    // '_sub_step_init' refers to the fluid state at the start of the sub step (Ss in
+    // iharm3d)
+    // '_sub_step_final' refers to the fluid state at the end of the sub step (Sf in
+    // iharm3d)
     // '_flux_src' refers to the mesh object corresponding to -divF + S
-    auto &md_full_step_init = pmesh->mesh_data.GetOrAdd("base", 0);
-    auto &md_sub_step_init  = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], 0);
-    auto &md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], 0);
-    auto &md_flux_src       = pmesh->mesh_data.GetOrAdd("dUdt", 0);
+    auto& md_full_step_init = pmesh->mesh_data.GetOrAdd("base", 0);
+    auto& md_sub_step_init =
+        pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage - 1], 0);
+    auto& md_sub_step_final = pmesh->mesh_data.GetOrAdd(integrator->stage_name[stage], 0);
+    auto& md_flux_src = pmesh->mesh_data.GetOrAdd("dUdt", 0);
 
     // Start by calculating the flux of each variable through each face
-    // This reconstructs the primitives (P) to cell faces and uses them to calculate fluxes
-    // of the conserved variables (U) through each face.
+    // This reconstructs the primitives (P) to cell faces and uses them to calculate
+    // fluxes of the conserved variables (U) through each face.
     auto t_fluxes = KHARMADriver::AddFluxCalculations(t_none, tl, md_sub_step_init.get());
 
     // Any package modifications to the fluxes, e.g. from Flux-CT
     auto t_fix_flux = tl.AddTask(t_fluxes, Packages::FixFlux, md_sub_step_init.get());
 
     // Apply the fluxes to calculate a change in cell-centered values "md_flux_src"
-    auto t_flux_div = tl.AddTask(t_fix_flux, FluxDivergence, md_sub_step_init.get(), md_flux_src.get(),
-                                std::vector<MetadataFlag>{Metadata::Independent, Metadata::Cell, Metadata::WithFluxes}, 0);
+    auto t_flux_div =
+        tl.AddTask(t_fix_flux, FluxDivergence, md_sub_step_init.get(), md_flux_src.get(),
+            std::vector<MetadataFlag>{
+                Metadata::Independent, Metadata::Cell, Metadata::WithFluxes},
+            0);
 
     // Add any package source terms: geometric \Gamma * T, wind, damping, etc etc
-    auto t_sources = tl.AddTask(t_flux_div, Packages::AddSource, md_sub_step_init.get(), md_flux_src.get(), IndexDomain::interior);
+    auto t_sources = tl.AddTask(t_flux_div, Packages::AddSource, md_sub_step_init.get(),
+        md_flux_src.get(), IndexDomain::interior);
 
     // Update the state with the explicit fluxes/sources
     // This includes copying in the primitive variable "guess" to md_sub_step_final
-    auto t_update = KHARMADriver::AddStateUpdate(t_sources, tl, md_full_step_init.get(), md_sub_step_init.get(),
-                                                    md_flux_src.get(), md_sub_step_final.get(),
-                                                    std::vector<MetadataFlag>{Metadata::Independent},
-                                                    false, stage);
+    auto t_update = KHARMADriver::AddStateUpdate(t_sources, tl, md_full_step_init.get(),
+        md_sub_step_init.get(), md_flux_src.get(), md_sub_step_final.get(),
+        std::vector<MetadataFlag>{Metadata::Independent}, false, stage);
 
     // Make sure the primitive values are updated.
-    auto t_UtoP = tl.AddTask(t_update, Packages::MeshUtoP, md_sub_step_final.get(), IndexDomain::interior, false);
+    auto t_UtoP = tl.AddTask(t_update, Packages::MeshUtoP, md_sub_step_final.get(),
+        IndexDomain::interior, false);
 
     // Apply any floors
-    auto t_floors = tl.AddTask(t_UtoP, Packages::MeshApplyFloors, md_sub_step_final.get(), IndexDomain::interior);
+    auto t_floors = tl.AddTask(t_UtoP, Packages::MeshApplyFloors, md_sub_step_final.get(),
+        IndexDomain::interior);
 
     // Boundary sync: fill primitive variables in ghost zones
     auto t_bounds = KHARMADriver::AddBoundarySync(t_floors, tl, md_sub_step_final);
 
     // Re-apply boundary conditions to reflect fixes
-    auto t_set_bc = tl.AddTask(t_bounds, parthenon::ApplyBoundaryConditionsOnCoarseOrFineMD, md_sub_step_final, false);
+    auto t_set_bc = tl.AddTask(t_bounds,
+        parthenon::ApplyBoundaryConditionsOnCoarseOrFineMD, md_sub_step_final, false);
 
     // Make sure *all* conserved vars are synchronized at step end
-    auto t_ptou = tl.AddTask(t_set_bc, Flux::MeshPtoU, md_sub_step_final.get(), IndexDomain::entire, false);
+    auto t_ptou = tl.AddTask(
+        t_set_bc, Flux::MeshPtoU, md_sub_step_final.get(), IndexDomain::entire, false);
     // Estimate next time step based on ctop
     if (stage == integrator->nstages) {
-        auto t_new_dt =
-            tl.AddTask(t_ptou, Update::EstimateTimestep<MeshData<Real>>, md_sub_step_final.get());
+        auto t_new_dt = tl.AddTask(
+            t_ptou, Update::EstimateTimestep<MeshData<Real>>, md_sub_step_final.get());
     }
 
     return tc;

--- a/kharma/electrons/electrons.cpp
+++ b/kharma/electrons/electrons.cpp
@@ -35,11 +35,11 @@
 
 #include "decs.hpp"
 #include "domain.hpp"
-#include "kharma_driver.hpp"
 #include "flux.hpp"
+#include "gaussian.hpp"
 #include "grmhd.hpp"
 #include "kharma.hpp"
-#include "gaussian.hpp"
+#include "kharma_driver.hpp"
 
 #include <parthenon/parthenon.hpp>
 #include <utils/string_utils.hpp>
@@ -49,26 +49,28 @@
 using namespace parthenon;
 
 // Used only in Howes model
-#define ME (9.1093826e-28  ) // Electron mass
-#define MP (1.67262171e-24 ) // Proton mass
+#define ME (9.1093826e-28)  // Electron mass
+#define MP (1.67262171e-24) // Proton mass
 
 namespace Electrons
 {
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Electrons");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Evolution parameters
-    Real gamma_e = pin->GetOrAddReal("electrons", "gamma_e", 4./3);
+    Real gamma_e = pin->GetOrAddReal("electrons", "gamma_e", 4. / 3);
     params.Add("gamma_e", gamma_e);
-    Real gamma_p = pin->GetOrAddReal("electrons", "gamma_p", 5./3);
+    Real gamma_p = pin->GetOrAddReal("electrons", "gamma_p", 5. / 3);
     params.Add("gamma_p", gamma_p);
 
     // Whether to enforce that dissipation be positive, i.e. increasing entropy
     // Probably more accurate to keep off.
-    bool enforce_positive_dissipation = pin->GetOrAddBoolean("electrons", "enforce_positive_dissipation", false);
+    bool enforce_positive_dissipation =
+        pin->GetOrAddBoolean("electrons", "enforce_positive_dissipation", false);
     params.Add("enforce_positive_dissipation", enforce_positive_dissipation);
 
     // This is used only in constant model
@@ -76,7 +78,8 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     params.Add("fel_constant", fel_const);
 
     // This prevented spurious heating when heat_electrons used pre-floored dissipation
-    bool suppress_highb_heat = pin->GetOrAddBoolean("electrons", "suppress_highb_heat", false);
+    bool suppress_highb_heat =
+        pin->GetOrAddBoolean("electrons", "suppress_highb_heat", false);
     params.Add("suppress_highb_heat", suppress_highb_heat);
 
     // Initialization
@@ -110,25 +113,29 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // Parse various mass and density units to set the different cooling rates
     // TODO actually respect them of course
-    std::vector<Real> masses = pin->GetOrAddVector<Real>("electrons", "masses", std::vector<Real>{});
+    std::vector<Real> masses =
+        pin->GetOrAddVector<Real>("electrons", "masses", std::vector<Real>{});
     if (masses.size() > 0) {
-        std::vector<std::string> mass_names = pin->GetVector<std::string>("electrons", "masses");
+        std::vector<std::string> mass_names =
+            pin->GetVector<std::string>("electrons", "masses");
         std::vector<std::vector<Real>> munits;
         for (auto mass_name : mass_names) {
-            munits.push_back(pin->GetVector<Real>("electrons", "munits_"+mass_name));
+            munits.push_back(pin->GetVector<Real>("electrons", "munits_" + mass_name));
         }
     }
 
     // Evolving e- implicitly is not tested.  Shouldn't be necessary even in EMHD
     auto& driver = packages->Get("Driver")->AllParams();
     auto driver_type = driver.Get<DriverType>("type");
-    bool implicit_e = (driver_type == DriverType::imex && pin->GetOrAddBoolean("electrons", "implicit", false));
+    bool implicit_e = (driver_type == DriverType::imex &&
+                       pin->GetOrAddBoolean("electrons", "implicit", false));
     params.Add("implicit", implicit_e);
 
     Metadata::AddUserFlag("Elec");
     MetadataFlag areWeImplicit = (implicit_e) ? Metadata::GetUserFlag("Implicit")
                                               : Metadata::GetUserFlag("Explicit");
-    std::vector<MetadataFlag> flags_elec = {Metadata::Cell, areWeImplicit, Metadata::GetUserFlag("Elec")};
+    std::vector<MetadataFlag> flags_elec = {
+        Metadata::Cell, areWeImplicit, Metadata::GetUserFlag("Elec")};
 
     auto flags_prim = driver.Get<std::vector<MetadataFlag>>("prim_flags");
     flags_prim.insert(flags_prim.end(), flags_elec.begin(), flags_elec.end());
@@ -142,8 +149,11 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     if ("driven_turbulence" == packages->Get("Globals")->Param<std::string>("problem")) {
         std::vector<int> s_vector({2});
-        Metadata m_vector = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_vector);
-        Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+        Metadata m_vector = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy},
+            s_vector);
+        Metadata m = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
         pkg->AddField("grf_normalized", m_vector);
         pkg->AddField("alfven_speed", m);
     }
@@ -190,8 +200,11 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     // Problem-specific fields
     if (packages->Get("Globals")->Param<std::string>("problem") == "driven_turbulence") {
         std::vector<int> s_vector({2});
-        Metadata m_vector = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_vector);
-        Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+        Metadata m_vector = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy},
+            s_vector);
+        Metadata m = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
         pkg->AddField("grf_normalized", m_vector);
         pkg->AddField("alfven_speed", m);
     }
@@ -199,12 +212,12 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     pkg->BlockUtoP = Electrons::BlockUtoP;
     pkg->BoundaryUtoP = Electrons::BlockUtoP;
     // If we wanted to apply the domian boundaries to primitive Electrons variables
-    //pkg->DomainBoundaryPtoU = Electrons::BlockPtoU;
+    // pkg->DomainBoundaryPtoU = Electrons::BlockPtoU;
 
     return pkg;
 }
 
-TaskStatus InitElectrons(MeshBlockData<Real> *rc, ParameterInput *pin)
+TaskStatus InitElectrons(MeshBlockData<Real>* rc, ParameterInput* pin)
 {
     Flag("InitElectrons");
     auto pmb = rc->GetBlockPointer();
@@ -216,7 +229,8 @@ TaskStatus InitElectrons(MeshBlockData<Real> *rc, ParameterInput *pin)
 
     // Need to distinguish KTOT from the other variables, so we record which it is
     PackIndexMap prims_map;
-    auto& e_P = rc->PackVariables({Metadata::GetUserFlag("Elec"), Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto& e_P = rc->PackVariables(
+        {Metadata::GetUserFlag("Elec"), Metadata::GetUserFlag("Primitive")}, prims_map);
     const int ktot_index = prims_map["prims.Ktot"].first;
     // Just need these two from the rest of Prims
     GridScalar rho = rc->Get("prims.rho").data;
@@ -230,28 +244,30 @@ TaskStatus InitElectrons(MeshBlockData<Real> *rc, ParameterInput *pin)
     int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);
-    pmb->par_for("UtoP_electrons", 0, e_P.GetDim(4)-1, ks, ke, js, je, is, ie,
-        KOKKOS_LAMBDA (const int &p, const int &k, const int &j, const int &i) {
+    pmb->par_for("UtoP_electrons", 0, e_P.GetDim(4) - 1, ks, ke, js, je, is, ie,
+                 KOKKOS_LAMBDA(const int& p, const int& k, const int& j, const int& i)
+        {
             if (p == ktot_index) {
                 // Initialize total entropy by definition,
                 e_P(p, k, j, i) = (gam - 1.) * u(k, j, i) * m::pow(rho(k, j, i), -gam);
             } else {
                 // and e- entropy by given constant initial fraction
-                e_P(p, k, j, i) = (game - 1.) * fel0 * u(k, j, i) * m::pow(rho(k, j, i), -game);
+                e_P(p, k, j, i) =
+                    (game - 1.) * fel0 * u(k, j, i) * m::pow(rho(k, j, i), -game);
             }
-        }
-    );
+        });
 
     EndFlag();
     return TaskStatus::complete;
 }
 
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
     // No need for a "map" here, we just want everything that fits these
-    auto& e_P = rc->PackVariables({Metadata::GetUserFlag("Elec"), Metadata::GetUserFlag("Primitive")});
+    auto& e_P = rc->PackVariables(
+        {Metadata::GetUserFlag("Elec"), Metadata::GetUserFlag("Primitive")});
     auto& e_U = rc->PackVariables({Metadata::GetUserFlag("Elec"), Metadata::Conserved});
     // And then the local density
     GridScalar rho_U = rc->Get("cons.rho").data;
@@ -260,19 +276,20 @@ void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     int is = bounds.is(domain), ie = bounds.ie(domain);
     int js = bounds.js(domain), je = bounds.je(domain);
     int ks = bounds.ks(domain), ke = bounds.ke(domain);
-    pmb->par_for("UtoP_electrons", 0, e_P.GetDim(4)-1, ks, ke, js, je, is, ie,
-        KOKKOS_LAMBDA (const int &p, const int &k, const int &j, const int &i) {
+    pmb->par_for("UtoP_electrons", 0, e_P.GetDim(4) - 1, ks, ke, js, je, is, ie,
+                 KOKKOS_LAMBDA(const int& p, const int& k, const int& j, const int& i)
+        {
             e_P(p, k, j, i) = e_U(p, k, j, i) / rho_U(k, j, i);
-        }
-    );
+        });
 }
 
-void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void BlockPtoU(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
     PackIndexMap prims_map, cons_map;
-    auto& P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+    auto& P = rc->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
     auto& U = rc->PackVariables({Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_p(prims_map, false), m_u(cons_map, true);
 
@@ -283,13 +300,14 @@ void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     int js = bounds.js(domain), je = bounds.je(domain);
     int ks = bounds.ks(domain), ke = bounds.ke(domain);
     pmb->par_for("PtoU_electrons", ks, ke, js, je, is, ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Electrons::p_to_u(G, P, m_p, k, j, i, U, m_u);
-        }
-    );
+        });
 }
 
-TaskStatus ApplyElectronHeating(MeshBlockData<Real> *rc_old, MeshBlockData<Real> *rc, bool generate_grf)
+TaskStatus ApplyElectronHeating(
+    MeshBlockData<Real>* rc_old, MeshBlockData<Real>* rc, bool generate_grf)
 {
     // Need to distinguish different electron models
     // So far, Parthenon's maps of the same sets of variables are consistent,
@@ -308,39 +326,51 @@ TaskStatus ApplyElectronHeating(MeshBlockData<Real> *rc_old, MeshBlockData<Real>
     const Real gamp = pmb->packages.Get("Electrons")->Param<Real>("gamma_p");
     const Real game = pmb->packages.Get("Electrons")->Param<Real>("gamma_e");
     const Real fel_const = pmb->packages.Get("Electrons")->Param<Real>("fel_constant");
-    const bool suppress_highb_heat = pmb->packages.Get("Electrons")->Param<bool>("suppress_highb_heat");
+    const bool suppress_highb_heat =
+        pmb->packages.Get("Electrons")->Param<bool>("suppress_highb_heat");
     // Floors
     const Real tptemin = pmb->packages.Get("Electrons")->Param<Real>("tp_over_te_min");
     const Real tptemax = pmb->packages.Get("Electrons")->Param<Real>("tp_over_te_max");
-    const bool enforce_positive_diss = pmb->packages.Get("Electrons")->Param<bool>("enforce_positive_dissipation");
+    const bool enforce_positive_diss =
+        pmb->packages.Get("Electrons")->Param<bool>("enforce_positive_dissipation");
     const bool limit_kel = pmb->packages.Get("Electrons")->Param<bool>("limit_kel");
 
-    // This function (and any primitive-variable sources) needs to be run over the entire domain,
-    // because the boundary zones have already been updated and so the same calculations must be applied
-    // in order to keep them consistent.
-    // See kharma_step.cpp for the full picture of what gets updated when.
+    // This function (and any primitive-variable sources) needs to be run over the entire
+    // domain, because the boundary zones have already been updated and so the same
+    // calculations must be applied in order to keep them consistent. See kharma_step.cpp
+    // for the full picture of what gets updated when.
     const IndexRange ib = rc->GetBoundsI(IndexDomain::entire);
     const IndexRange jb = rc->GetBoundsJ(IndexDomain::entire);
     const IndexRange kb = rc->GetBoundsK(IndexDomain::entire);
     pmb->par_for("heat_electrons", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             FourVectors Dtmp;
             GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
             Real bsq = dot(Dtmp.bcon, Dtmp.bcov);
 
             // Calculate the new total entropy in this cell considering heating
-            const Real k_energy_conserving = (gam-1.) * P_new(m_p.UU, k, j, i) / m::pow(P_new(m_p.RHO, k, j, i), gam);
+            const Real k_energy_conserving = (gam - 1.) * P_new(m_p.UU, k, j, i) /
+                                             m::pow(P_new(m_p.RHO, k, j, i), gam);
 
-            // Dissipation is the real entropy k_energy_conserving minus any advected entropy from the previous (sub-)step P_new(KTOT)
-            Real diss_tmp = (game-1.) / (gam-1.) * m::pow(P(m_p.RHO, k, j, i), gam - game) * (k_energy_conserving - P_new(m_p.KTOT, k, j, i));
-            //this is eq27                  ratio of heating: Qi/Qe                           advected entropy from prev step
-            // ^ denotes the solution corresponding to entropy conservation
+            // Dissipation is the real entropy k_energy_conserving minus any advected
+            // entropy from the previous (sub-)step P_new(KTOT)
+            Real diss_tmp = (game - 1.) / (gam - 1.) *
+                            m::pow(P(m_p.RHO, k, j, i), gam - game) *
+                            (k_energy_conserving - P_new(m_p.KTOT, k, j, i));
+            // this is eq27                  ratio of heating: Qi/Qe advected entropy from
+            // prev step
+            //  ^ denotes the solution corresponding to entropy conservation
 
-            // Under the flag "suppress_highb_heat", we set all dissipation to zero at sigma > 1.
-            diss_tmp = (suppress_highb_heat && (bsq / P(m_p.RHO, k, j, i) > 1.)) ? 0.0 : diss_tmp;
+            // Under the flag "suppress_highb_heat", we set all dissipation to zero at
+            // sigma > 1.
+            diss_tmp = (suppress_highb_heat && (bsq / P(m_p.RHO, k, j, i) > 1.))
+                           ? 0.0
+                           : diss_tmp;
 
             // Default is True diss_sign == Enforce nonnegative
-            // Due to floors we can end up with diss==0 or even *slightly* <0, so we require it to be positive here
+            // Due to floors we can end up with diss==0 or even *slightly* <0, so we
+            // require it to be positive here
             const Real diss = enforce_positive_diss ? m::max(diss_tmp, 0.0) : diss_tmp;
 
             // Reset the entropy to measure next (sub-)step's dissipation
@@ -349,91 +379,119 @@ TaskStatus ApplyElectronHeating(MeshBlockData<Real> *rc_old, MeshBlockData<Real>
             // We'll be applying floors inline as we heat electrons, so
             // we cache the floors as entropy limits so they'll be cheaper to apply.
             // Note tp_te_min -> kel_max & vice versa
-            const Real kel_max = P(m_p.KTOT, k, j, i) * m::pow(P(m_p.RHO, k, j, i), gam - game) /
-                                    (tptemin * (gam - 1.) / (gamp-1.) + (gam-1.) / (game-1.)); //0.001
-            const Real kel_min = P(m_p.KTOT, k, j, i) * m::pow(P(m_p.RHO, k, j, i), gam - game) /
-                                    (tptemax * (gam - 1.) / (gamp-1.) + (gam-1.) / (game-1.)); //1000
-            // Note this differs a little from Ressler '15, who ensure u_e/u_g > 0.01 rather than use temperatures
+            const Real kel_max =
+                P(m_p.KTOT, k, j, i) * m::pow(P(m_p.RHO, k, j, i), gam - game) /
+                (tptemin * (gam - 1.) / (gamp - 1.) + (gam - 1.) / (game - 1.)); // 0.001
+            const Real kel_min =
+                P(m_p.KTOT, k, j, i) * m::pow(P(m_p.RHO, k, j, i), gam - game) /
+                (tptemax * (gam - 1.) / (gamp - 1.) + (gam - 1.) / (game - 1.)); // 1000
+            // Note this differs a little from Ressler '15, who ensure u_e/u_g > 0.01
+            // rather than use temperatures
 
             // The ion temperature is useful for a few models, cache it too.
             // The minimum values on Tpr & Tel here ensure that for un-initialized zones,
-            // Tpr/Tel == Tel/Tpr == 1 != NaN.  This condition should not be hit after step 1
-            const Real Tpr = m::max((gamp - 1.) * P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i), SMALL_NUM);
+            // Tpr/Tel == Tel/Tpr == 1 != NaN.  This condition should not be hit after
+            // step
+            // 1
+            const Real Tpr =
+                m::max((gamp - 1.) * P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i), SMALL_NUM);
 
-            // Heat different electron passives based on different dissipation fraction models
-            // Expressions here closely adapted (read: stolen) from implementation in iharm3d
-            // courtesy of Cesar Diaz, see https://github.com/AFD-Illinois/iharm3d
+            // Heat different electron passives based on different dissipation fraction
+            // models Expressions here closely adapted (read: stolen) from implementation
+            // in iharm3d courtesy of Cesar Diaz, see
+            // https://github.com/AFD-Illinois/iharm3d
 
-            // In all of these the electron entropy stored value is the entropy conserving solution
-                                 // and then when updated it becomes the energy conserving solution
+            // In all of these the electron entropy stored value is the entropy conserving
+            // solution and then when updated it becomes the energy conserving solution
             if (m_p.K_CONSTANT >= 0) {
                 const Real fel = fel_const;
-                // Default is true then enforce kel limits with clamp/clip, else no restrictions on kel
+                // Default is true then enforce kel limits with clamp/clip, else no
+                // restrictions on kel
                 if (limit_kel) {
-                    P_new(m_p.K_CONSTANT, k, j, i) = clip(P_new(m_p.K_CONSTANT, k, j, i) + fel * diss, kel_min, kel_max);
+                    P_new(m_p.K_CONSTANT, k, j, i) = clip(
+                        P_new(m_p.K_CONSTANT, k, j, i) + fel * diss, kel_min, kel_max);
                 } else {
                     P_new(m_p.K_CONSTANT, k, j, i) += fel * diss;
                 }
             }
             if (m_p.K_HOWES >= 0) {
-                const Real Tel = m::max(P(m_p.K_HOWES, k, j, i) * m::pow(P(m_p.RHO, k, j, i), game-1), SMALL_NUM);
+                const Real Tel = m::max(
+                    P(m_p.K_HOWES, k, j, i) * m::pow(P(m_p.RHO, k, j, i), game - 1),
+                    SMALL_NUM);
 
                 const Real Trat = Tpr / Tel;
                 const Real pres = P(m_p.RHO, k, j, i) * Tpr; // Proton pressure
-                const Real beta = m::min(pres / bsq * 2, 1.e20);// If somebody enables electrons in a GRHD sim
+                const Real beta = m::min(pres / bsq * 2,
+                    1.e20); // If somebody enables electrons in a GRHD sim
 
                 const Real logTrat = log10(Trat);
-                const Real mbeta = 2. - 0.2*logTrat;
+                const Real mbeta = 2. - 0.2 * logTrat;
 
-                const Real c2 = (Trat <= 1.) ? 1.6/Trat : 1.2/Trat;
-                const Real c3 = (Trat <= 1.) ? 18. + 5.*logTrat : 18.;
+                const Real c2 = (Trat <= 1.) ? 1.6 / Trat : 1.2 / Trat;
+                const Real c3 = (Trat <= 1.) ? 18. + 5. * logTrat : 18.;
 
                 const Real beta_pow = m::pow(beta, mbeta);
-                const Real qrat = 0.92 * (c2*c2 + beta_pow)/(c3*c3 + beta_pow) * m::exp(-1./beta) * m::sqrt(MP/ME * Trat);
-                const Real fel = 1./(1. + qrat);
-                P_new(m_p.K_HOWES, k, j, i) = clip(P_new(m_p.K_HOWES, k, j, i) + fel * diss, kel_min, kel_max);
+                const Real qrat = 0.92 * (c2 * c2 + beta_pow) / (c3 * c3 + beta_pow) *
+                                  m::exp(-1. / beta) * m::sqrt(MP / ME * Trat);
+                const Real fel = 1. / (1. + qrat);
+                P_new(m_p.K_HOWES, k, j, i) =
+                    clip(P_new(m_p.K_HOWES, k, j, i) + fel * diss, kel_min, kel_max);
             }
             if (m_p.K_KAWAZURA >= 0) {
                 // Equation (2) in http://www.pnas.org/lookup/doi/10.1073/pnas.1812491116
-                const Real Tel = m::max(P(m_p.K_KAWAZURA, k, j, i) * m::pow(P(m_p.RHO, k, j, i), game-1), SMALL_NUM);
+                const Real Tel = m::max(
+                    P(m_p.K_KAWAZURA, k, j, i) * m::pow(P(m_p.RHO, k, j, i), game - 1),
+                    SMALL_NUM);
 
                 const Real Trat = Tpr / Tel;
                 const Real pres = P(m_p.RHO, k, j, i) * Tpr; // Proton pressure
-                const Real beta = m::min(pres / bsq * 2, 1.e20);// If somebody enables electrons in a GRHD sim
+                const Real beta = m::min(pres / bsq * 2,
+                    1.e20); // If somebody enables electrons in a GRHD sim
 
-                const Real QiQe = 35. / (1. + m::pow(beta/15., -1.4) * m::exp(-0.1 / Trat));
-                const Real fel = 1./(1. + QiQe);
-                P_new(m_p.K_KAWAZURA, k, j, i) = clip(P_new(m_p.K_KAWAZURA, k, j, i) + fel * diss, kel_min, kel_max);
+                const Real QiQe =
+                    35. / (1. + m::pow(beta / 15., -1.4) * m::exp(-0.1 / Trat));
+                const Real fel = 1. / (1. + QiQe);
+                P_new(m_p.K_KAWAZURA, k, j, i) =
+                    clip(P_new(m_p.K_KAWAZURA, k, j, i) + fel * diss, kel_min, kel_max);
             }
             // TODO KAWAZURA 19/20/21 separately?
             if (m_p.K_WERNER >= 0) {
-                // Equation (3) in http://academic.oup.com/mnras/article/473/4/4840/4265350
+                // Equation (3) in
+                // http://academic.oup.com/mnras/article/473/4/4840/4265350
                 const Real sigma = bsq / P(m_p.RHO, k, j, i);
-                const Real fel = 0.25 * (1 + m::sqrt((sigma/5.) / (2 + (sigma/5.))));
-                P_new(m_p.K_WERNER, k, j, i) = clip(P_new(m_p.K_WERNER, k, j, i) + fel * diss, kel_min, kel_max);
+                const Real fel = 0.25 * (1 + m::sqrt((sigma / 5.) / (2 + (sigma / 5.))));
+                P_new(m_p.K_WERNER, k, j, i) =
+                    clip(P_new(m_p.K_WERNER, k, j, i) + fel * diss, kel_min, kel_max);
             }
             if (m_p.K_ROWAN >= 0) {
-                // Equation (34) in https://iopscience.iop.org/article/10.3847/1538-4357/aa9380
+                // Equation (34) in
+                // https://iopscience.iop.org/article/10.3847/1538-4357/aa9380
                 const Real pres = (gamp - 1.) * P(m_p.UU, k, j, i); // Proton pressure
                 const Real pg = (gam - 1) * P(m_p.UU, k, j, i);
                 const Real beta = pres / bsq * 2;
                 const Real sigma = bsq / (P(m_p.RHO, k, j, i) + P(m_p.UU, k, j, i) + pg);
                 const Real betamax = 0.25 / sigma;
-                const Real fel = 0.5 * m::exp(-m::pow(1 - beta/betamax, 3.3) / (1 + 1.2*m::pow(sigma, 0.7)));
-                P_new(m_p.K_ROWAN, k, j, i) = clip(P_new(m_p.K_ROWAN, k, j, i) + fel * diss, kel_min, kel_max);
+                const Real fel = 0.5 * m::exp(-m::pow(1 - beta / betamax, 3.3) /
+                                              (1 + 1.2 * m::pow(sigma, 0.7)));
+                P_new(m_p.K_ROWAN, k, j, i) =
+                    clip(P_new(m_p.K_ROWAN, k, j, i) + fel * diss, kel_min, kel_max);
             }
             if (m_p.K_SHARMA >= 0) {
-                // Equation for \delta on  pg. 719 (Section 4) in https://iopscience.iop.org/article/10.1086/520800
-                const Real Tel = m::max(P(m_p.K_SHARMA, k, j, i) * m::pow(P(m_p.RHO, k, j, i), game-1), SMALL_NUM);
+                // Equation for \delta on  pg. 719 (Section 4) in
+                // https://iopscience.iop.org/article/10.1086/520800
+                const Real Tel = m::max(
+                    P(m_p.K_SHARMA, k, j, i) * m::pow(P(m_p.RHO, k, j, i), game - 1),
+                    SMALL_NUM);
 
-                const Real Trat_inv = Tel / Tpr; // Inverse of the temperature ratio in KAWAZURA
+                const Real Trat_inv =
+                    Tel / Tpr; // Inverse of the temperature ratio in KAWAZURA
                 const Real QeQi = 0.33 * m::sqrt(Trat_inv);
-                const Real fel = 1./(1.+1./QeQi);
-                P_new(m_p.K_SHARMA, k, j, i) = clip(P_new(m_p.K_SHARMA, k, j, i) + fel * diss, kel_min, kel_max);
+                const Real fel = 1. / (1. + 1. / QeQi);
+                P_new(m_p.K_SHARMA, k, j, i) =
+                    clip(P_new(m_p.K_SHARMA, k, j, i) + fel * diss, kel_min, kel_max);
             }
             // Conserved variables are updated at the end of the step
-        }
-    );
+        });
 
     const IndexRange myib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
     const IndexRange myjb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
@@ -449,110 +507,161 @@ TaskStatus ApplyElectronHeating(MeshBlockData<Real> *rc_old, MeshBlockData<Real>
         GridVector grf_normalized = rc->Get("grf_normalized").data;
         const Real t = pmb->packages.Get("Globals")->Param<Real>("time");
         Real counter = pmb->packages.Get("GRMHD")->Param<Real>("counter");
-        const Real dt_kick=  pmb->packages.Get("GRMHD")->Param<Real>("dt_kick");
+        const Real dt_kick = pmb->packages.Get("GRMHD")->Param<Real>("dt_kick");
         if (generate_grf && counter < t) {
             counter += dt_kick;
             pmb->packages.Get("GRMHD")->UpdateParam<Real>("counter", counter);
             printf("Kick applied at time %.32f\n", t);
 
-            const Real lx1=  pmb->packages.Get("GRMHD")->Param<Real>("lx1");
-            const Real lx2=  pmb->packages.Get("GRMHD")->Param<Real>("lx2");
-            const Real edot= pmb->packages.Get("GRMHD")->Param<Real>("drive_edot");
+            const Real lx1 = pmb->packages.Get("GRMHD")->Param<Real>("lx1");
+            const Real lx2 = pmb->packages.Get("GRMHD")->Param<Real>("lx2");
+            const Real edot = pmb->packages.Get("GRMHD")->Param<Real>("drive_edot");
             GridScalar alfven_speed = rc->Get("alfven_speed").data;
 
             int Nx1 = pmb->cellbounds.ncellsi(IndexDomain::interior);
             int Nx2 = pmb->cellbounds.ncellsj(IndexDomain::interior);
-            Real *dv0 =  (Real*) malloc(sizeof(Real)*Nx1*Nx2);
-            Real *dv1 =  (Real*) malloc(sizeof(Real)*Nx1*Nx2);
+            Real* dv0 = (Real*)malloc(sizeof(Real) * Nx1 * Nx2);
+            Real* dv1 = (Real*)malloc(sizeof(Real) * Nx1 * Nx2);
             create_grf(Nx1, Nx2, lx1, lx2, dv0, dv1);
 
-            Real mean_velocity_num0 = 0;    Kokkos::Sum<Real> mean_velocity_num0_reducer(mean_velocity_num0);
-            Real mean_velocity_num1 = 0;    Kokkos::Sum<Real> mean_velocity_num1_reducer(mean_velocity_num1);
-            Real tot_mass = 0;              Kokkos::Sum<Real> tot_mass_reducer(tot_mass);
-            pmb->par_reduce("forced_mhd_normal_kick_centering_mean_vel0", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                    local_result += cell_mass * dv0[(i-4)*Nx1+(j-4)];
-                }
-            , mean_velocity_num0_reducer);
-            pmb->par_reduce("forced_mhd_normal_kick_centering_mean_vel1", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                    local_result += cell_mass * dv1[(i-4)*Nx1+(j-4)];
-                }
-            , mean_velocity_num1_reducer);
-            pmb->par_reduce("forced_mhd_normal_kick_centering_tot_mass", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    local_result += (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                }
-            , tot_mass_reducer);
-            Real mean_velocity0 = mean_velocity_num0/tot_mass;
-            Real mean_velocity1 = mean_velocity_num1/tot_mass;
-            #pragma omp parallel for simd collapse(2)
-            for (size_t i = 0; i < Nx1 ; i ++) {
-                for (size_t j = 0; j < Nx2 ; j ++) {
-                    dv0[i*Nx1+j] -= mean_velocity0;
-                    dv1[i*Nx1+j] -= mean_velocity1;
+            Real mean_velocity_num0 = 0;
+            Kokkos::Sum<Real> mean_velocity_num0_reducer(mean_velocity_num0);
+            Real mean_velocity_num1 = 0;
+            Kokkos::Sum<Real> mean_velocity_num1_reducer(mean_velocity_num1);
+            Real tot_mass = 0;
+            Kokkos::Sum<Real> tot_mass_reducer(tot_mass);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_centering_mean_vel0", mykb.s, mykb.e, myjb.s,
+                myjb.e, myib.s, myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    Real cell_mass =
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                    local_result += cell_mass * dv0[(i - 4) * Nx1 + (j - 4)];
+                },
+                mean_velocity_num0_reducer);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_centering_mean_vel1", mykb.s, mykb.e, myjb.s,
+                myjb.e, myib.s, myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    Real cell_mass =
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                    local_result += cell_mass * dv1[(i - 4) * Nx1 + (j - 4)];
+                },
+                mean_velocity_num1_reducer);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_centering_tot_mass", mykb.s, mykb.e, myjb.s,
+                myjb.e, myib.s, myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    local_result +=
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                },
+                tot_mass_reducer);
+            Real mean_velocity0 = mean_velocity_num0 / tot_mass;
+            Real mean_velocity1 = mean_velocity_num1 / tot_mass;
+#pragma omp parallel for simd collapse(2)
+            for (size_t i = 0; i < Nx1; i++) {
+                for (size_t j = 0; j < Nx2; j++) {
+                    dv0[i * Nx1 + j] -= mean_velocity0;
+                    dv1[i * Nx1 + j] -= mean_velocity1;
                 }
             }
 
-            Real Bhalf = 0; Real A = 0; Real init_e = 0;
-            Kokkos::Sum<Real> Bhalf_reducer(Bhalf); Kokkos::Sum<Real> A_reducer(A); Kokkos::Sum<Real> init_e_reducer(init_e);
-            pmb->par_reduce("forced_mhd_normal_kick_normalization_Bhalf", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                    local_result += cell_mass * (dv0[(i-4)*Nx1+(j-4)]*uvec(0, k, j, i) + dv1[(i-4)*Nx1+(j-4)]*uvec(1, k, j, i));
-                }
-            , Bhalf_reducer);
-            pmb->par_reduce("forced_mhd_normal_kick_normalization_A", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                    local_result += cell_mass * (pow(dv0[(i-4)*Nx1+(j-4)], 2) + pow(dv1[(i-4)*Nx1+(j-4)], 2));
-                }
-            , A_reducer);
-            pmb->par_reduce("forced_mhd_normal_kick_init_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                    local_result += 0.5 * cell_mass * (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
-                }
-            , init_e_reducer);
+            Real Bhalf = 0;
+            Real A = 0;
+            Real init_e = 0;
+            Kokkos::Sum<Real> Bhalf_reducer(Bhalf);
+            Kokkos::Sum<Real> A_reducer(A);
+            Kokkos::Sum<Real> init_e_reducer(init_e);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_normalization_Bhalf", mykb.s, mykb.e, myjb.s,
+                myjb.e, myib.s, myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    Real cell_mass =
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                    local_result +=
+                        cell_mass * (dv0[(i - 4) * Nx1 + (j - 4)] * uvec(0, k, j, i) +
+                                        dv1[(i - 4) * Nx1 + (j - 4)] * uvec(1, k, j, i));
+                },
+                Bhalf_reducer);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_normalization_A", mykb.s, mykb.e, myjb.s, myjb.e,
+                myib.s, myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    Real cell_mass =
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                    local_result += cell_mass * (pow(dv0[(i - 4) * Nx1 + (j - 4)], 2) +
+                                                    pow(dv1[(i - 4) * Nx1 + (j - 4)], 2));
+                },
+                A_reducer);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_init_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s,
+                myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    Real cell_mass =
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                    local_result += 0.5 * cell_mass *
+                                    (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
+                },
+                init_e_reducer);
 
-            Real norm_const = (-Bhalf + pow(pow(Bhalf,2) + A*2*dt_kick*edot, 0.5))/A;  // going from k:(0, 0), j:(4, 515), i:(4, 515) inclusive
-            pmb->par_for("forced_mhd_normal_kick_setting", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i) {
-                    grf_normalized(0, k, j, i) = (dv0[(i-4)*Nx1+(j-4)]*norm_const);
-                    grf_normalized(1, k, j, i) = (dv1[(i-4)*Nx1+(j-4)]*norm_const);
+            Real norm_const =
+                (-Bhalf + pow(pow(Bhalf, 2) + A * 2 * dt_kick * edot, 0.5)) /
+                A; // going from k:(0, 0), j:(4, 515), i:(4, 515) inclusive
+            pmb->par_for("forced_mhd_normal_kick_setting", mykb.s, mykb.e, myjb.s, myjb.e,
+                myib.s, myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i)
+                {
+                    grf_normalized(0, k, j, i) =
+                        (dv0[(i - 4) * Nx1 + (j - 4)] * norm_const);
+                    grf_normalized(1, k, j, i) =
+                        (dv1[(i - 4) * Nx1 + (j - 4)] * norm_const);
                     uvec(0, k, j, i) += grf_normalized(0, k, j, i);
                     uvec(1, k, j, i) += grf_normalized(1, k, j, i);
                     FourVectors Dtmp;
                     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
                     Real bsq = dot(Dtmp.bcon, Dtmp.bcov);
-                    alfven_speed(k,j,i) = bsq/rho(k, j, i); //saving alfven speed for analysis purposes
-                }
-            );
+                    alfven_speed(k, j, i) =
+                        bsq / rho(k, j, i); // saving alfven speed for analysis purposes
+                });
 
-            Real finl_e = 0;    Kokkos::Sum<Real> finl_e_reducer(finl_e);
-            pmb->par_reduce("forced_mhd_normal_kick_finl_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-                KOKKOS_LAMBDA(const int k, const int j, const int i, Real &local_result) {
-                    Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                    local_result += 0.5 * cell_mass * (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
-                }
-            , finl_e_reducer);
-            printf("%.32f\n", A); printf("%.32f\n", Bhalf); printf("%.32f\n", norm_const);
-            printf("%.32f\n", (finl_e-init_e)/dt_kick);
-            free(dv0); free(dv1);
+            Real finl_e = 0;
+            Kokkos::Sum<Real> finl_e_reducer(finl_e);
+            pmb->par_reduce(
+                "forced_mhd_normal_kick_finl_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s,
+                myib.e,
+                KOKKOS_LAMBDA(const int k, const int j, const int i, Real& local_result)
+                {
+                    Real cell_mass =
+                        (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+                    local_result += 0.5 * cell_mass *
+                                    (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
+                },
+                finl_e_reducer);
+            printf("%.32f\n", A);
+            printf("%.32f\n", Bhalf);
+            printf("%.32f\n", norm_const);
+            printf("%.32f\n", (finl_e - init_e) / dt_kick);
+            free(dv0);
+            free(dv1);
         }
-        // This could be only the GRMHD vars, for this problem, but speed isn't really an issue
+        // This could be only the GRMHD vars, for this problem, but speed isn't really an
+        // issue
         Flux::BlockPtoU(rc, IndexDomain::interior);
     }
     EndFlag();
     return TaskStatus::complete;
 }
 
-void ApplyFloors(MeshBlockData<Real> *mbd, IndexDomain domain)
+void ApplyFloors(MeshBlockData<Real>* mbd, IndexDomain domain)
 {
-    auto pmb                 = mbd->GetBlockPointer();
-    auto packages            = pmb->packages;
+    auto pmb = mbd->GetBlockPointer();
+    auto packages = pmb->packages;
 
     PackIndexMap prims_map, cons_map;
     auto P = mbd->PackVariables({Metadata::GetUserFlag("Primitive")}, prims_map);
@@ -563,52 +672,56 @@ void ApplyFloors(MeshBlockData<Real> *mbd, IndexDomain domain)
     const auto& G = pmb->coords;
 
     const Real gam = packages.Get("GRMHD")->Param<Real>("gamma");
-    const Floors::Prescription floors       = packages.Get("Floors")->Param<Floors::Prescription>("prescription");
-    const Floors::Prescription floors_inner = packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
+    const Floors::Prescription floors =
+        packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+    const Floors::Prescription floors_inner =
+        packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
 
     const IndexRange3 b = KDomain::GetRange(mbd, domain);
     pmb->par_for("apply_electrons_floors", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-
-            // Also apply the ceiling to the advected entropy KTOT, if we're keeping track of that
-            // (either for electrons, or robust primitive inversions in future)
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
+            // Also apply the ceiling to the advected entropy KTOT, if we're
+            // keeping track of that (either for electrons, or robust primitive
+            // inversions in future)
             Real ktot_max;
             if (m_p.KTOT >= 0) {
-                if (floors.radius_dependent_floors && G.coords.is_spherical()
-                    && G.r(k, j, i) < floors.floors_switch_r) {
+                if (floors.radius_dependent_floors && G.coords.is_spherical() &&
+                    G.r(k, j, i) < floors.floors_switch_r) {
                     ktot_max = floors_inner.ktot_max;
                 } else {
                     ktot_max = floors.ktot_max;
                 }
 
                 if (P(m_p.KTOT, k, j, i) > ktot_max) {
-                    fflag(0, k, j, i) = Floors::FFlag::KTOT | (int) fflag(0, k, j, i);
+                    fflag(0, k, j, i) = Floors::FFlag::KTOT | (int)fflag(0, k, j, i);
                     P(m_p.KTOT, k, j, i) = ktot_max;
                 }
             }
 
-            // TODO(BSP) restore Ressler adjustment option
+            // TODO(CEP) restore Ressler adjustment option
             // Ressler adjusts KTOT & KEL to conserve u whenever adjusting rho
-            // but does *not* recommend adjusting them when u hits floors/ceilings
-            // This is in contrast to ebhlight, which heats electrons before applying *any* floors,
-            // and resets KTOT during floor application without touching KEL
-            // if (floors.adjust_k && (fflag() & FFlag::GEOM_RHO || fflag() & FFlag::B_RHO)) {
+            // but does *not* recommend adjusting them when u hits
+            // floors/ceilings This is in contrast to ebhlight, which heats
+            // electrons before applying *any* floors, and resets KTOT during
+            // floor application without touching KEL if (floors.adjust_k &&
+            // (fflag() & FFlag::GEOM_RHO || fflag() & FFlag::B_RHO)) {
             //     const Real reduce   = m::pow(rho / P(m_p.RHO, k, j, i), gam);
-            //     const Real reduce_e = m::pow(rho / P(m_p.RHO, k, j, i), 4./3); // TODO pipe in real gam_e
-            //     if (m_p.KTOT >= 0) P(m_p.KTOT, k, j, i) *= reduce;
-            //     if (m_p.K_CONSTANT >= 0) P(m_p.K_CONSTANT, k, j, i) *= reduce_e;
-            //     if (m_p.K_HOWES >= 0)    P(m_p.K_HOWES, k, j, i)    *= reduce_e;
-            //     if (m_p.K_KAWAZURA >= 0) P(m_p.K_KAWAZURA, k, j, i) *= reduce_e;
-            //     if (m_p.K_WERNER >= 0)   P(m_p.K_WERNER, k, j, i)   *= reduce_e;
-            //     if (m_p.K_ROWAN >= 0)    P(m_p.K_ROWAN, k, j, i)    *= reduce_e;
-            //     if (m_p.K_SHARMA >= 0)   P(m_p.K_SHARMA, k, j, i)   *= reduce_e;
+            //     const Real reduce_e = m::pow(rho / P(m_p.RHO, k, j, i), 4./3);
+            //     // TODO pipe in real gam_e if (m_p.KTOT >= 0) P(m_p.KTOT, k,
+            //     j, i) *= reduce; if (m_p.K_CONSTANT >= 0) P(m_p.K_CONSTANT, k,
+            //     j, i) *= reduce_e; if (m_p.K_HOWES >= 0)    P(m_p.K_HOWES, k,
+            //     j, i)    *= reduce_e; if (m_p.K_KAWAZURA >= 0)
+            //     P(m_p.K_KAWAZURA, k, j, i) *= reduce_e; if (m_p.K_WERNER >= 0)
+            //     P(m_p.K_WERNER, k, j, i)   *= reduce_e; if (m_p.K_ROWAN >= 0)
+            //     P(m_p.K_ROWAN, k, j, i)    *= reduce_e; if (m_p.K_SHARMA >= 0)
+            //     P(m_p.K_SHARMA, k, j, i)   *= reduce_e;
             // }
-        }
-    );
+        });
     Flux::BlockPtoU(mbd, domain);
 }
 
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *rc)
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* rc)
 {
     Flag("PostStepDiagnostics");
 
@@ -618,10 +731,10 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *rc)
     return TaskStatus::complete;
 }
 
-void FillOutput(MeshBlock *pmb, ParameterInput *pin)
+void FillOutput(MeshBlock* pmb, ParameterInput* pin)
 {
-    // Any variables or diagnostics that should be computed especially for output to a file,
-    // but which are not otherwise updated.
+    // Any variables or diagnostics that should be computed especially for output to a
+    // file, but which are not otherwise updated.
 }
 
 } // namespace Electrons

--- a/kharma/electrons/electrons.hpp
+++ b/kharma/electrons/electrons.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: electrons.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,76 +46,85 @@ using namespace parthenon;
  * as in Ressler+ 2015.
  * It tracks fluid total entropy in order to calculate stepwise changes, and electron
  * entropy fed by some fraction of dissipation.
- * It supports running any/all of several heating models (dissipation fractions) via runtime parameters.
+ * It supports running any/all of several heating models (dissipation fractions) via
+ * runtime parameters.
  *
  * Adapted very closely from work done for iharm3d by Cesar Diaz
  *
- * This implementation doubles as a guide to writing packages for KHARMA -- the comments provide basic
- * explanations about how they interact with KHARMA as a whole.
- * Most package functions are either registered as callbacks at the end of Initialize() (for Parthenon)
- * or added to the functions in kharma.cpp (for KHARMA).  Be sure to register all your functions when
- * first creating a package!
+ * This implementation doubles as a guide to writing packages for KHARMA -- the comments
+ * provide basic explanations about how they interact with KHARMA as a whole. Most package
+ * functions are either registered as callbacks at the end of Initialize() (for Parthenon)
+ * or added to the functions in kharma.cpp (for KHARMA).  Be sure to register all your
+ * functions when first creating a package!
  */
-namespace Electrons {
+namespace Electrons
+{
 /**
  * Initialization: declare any fields this package will evolve, initialize any parameters
- * 
- * For electrons, this means a total entropy Ktot to track dissipation, and electron entropies
- * for each model being run.
+ *
+ * For electrons, this means a total entropy Ktot to track dissipation, and electron
+ * entropies for each model being run.
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
- * In addition to the standard functions, packages can include extras.  This is called manually
- * at the end of problem initialization in problem.cpp
- * 
- * Function in this package: Initialize electron temperatures when setting up the problem. Trivial.
+ * In addition to the standard functions, packages can include extras.  This is called
+ * manually at the end of problem initialization in problem.cpp
+ *
+ * Function in this package: Initialize electron temperatures when setting up the problem.
+ * Trivial.
  */
-TaskStatus InitElectrons(MeshBlockData<Real> *rc, ParameterInput *pin);
-inline TaskStatus MeshInitElectrons(MeshData<Real> *md, ParameterInput *pin)
+TaskStatus InitElectrons(MeshBlockData<Real>* rc, ParameterInput* pin);
+inline TaskStatus MeshInitElectrons(MeshData<Real>* md, ParameterInput* pin)
 {
     Flag("MeshApplyElectronHeating");
-    for (int i=0; i < md->NumBlocks(); ++i)
+    for (int i = 0; i < md->NumBlocks(); ++i)
         InitElectrons(md->GetBlockData(i).get(), pin);
     EndFlag();
     return TaskStatus::complete;
 }
 
 /**
- * Any implementation of UtoP needs to take an IndexDomain enum and boundary "coarse" boolean.
- * This allows KHARMA to call it over the whole domain (IndexDomain::entire) or just on a boundary
- * after conserved variables have been updated.
- * 
- * Usually this should default to the entire domain, as the KHARMA algorithm relies on applying
- * UtoP over ghost zones.
- * 
- * Function in this package: Get the specific entropy primitive value, by dividing the total entropy K/(rho*u^0)
+ * Any implementation of UtoP needs to take an IndexDomain enum and boundary "coarse"
+ * boolean. This allows KHARMA to call it over the whole domain (IndexDomain::entire) or
+ * just on a boundary after conserved variables have been updated.
+ *
+ * Usually this should default to the entire domain, as the KHARMA algorithm relies on
+ * applying UtoP over ghost zones.
+ *
+ * Function in this package: Get the specific entropy primitive value, by dividing the
+ * total entropy K/(rho*u^0)
  */
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse=false);
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse = false);
 
 /**
- * This heating step is custom for this package.  It is added manually to any task list in the KHARMADriver,
- * at the very end of the step. For reasons mentioned there & above, it must update *all* zones, incl. ghosts.
+ * This heating step is custom for this package.  It is added manually to any task list in
+ * the KHARMADriver, at the very end of the step. For reasons mentioned there & above, it
+ * must update *all* zones, incl. ghosts.
  *
- * The function calculates how electrons should be heated and updates their entropy values,
- * using each step's total dissipation (advected vs actual fluid entropy)
- * It applies any or all of several different esimates for this split, to each of the several different
- * primitive variables "prims.Kel_X"
- * Finally, it checks the results against a minimum and maximum temperature ratio T_protons/T_electrons
- * 
+ * The function calculates how electrons should be heated and updates their entropy
+ * values, using each step's total dissipation (advected vs actual fluid entropy) It
+ * applies any or all of several different esimates for this split, to each of the several
+ * different primitive variables "prims.Kel_X" Finally, it checks the results against a
+ * minimum and maximum temperature ratio T_protons/T_electrons
+ *
  * To recap re: floors:
- * This function expects two sets of values {rho0, u0, Ktot0} from rc_old and {rho1, u1} from rc,
- * all of which obey all given floors.
- * It produces end-of-substep values {Ktot1, Kel_X1, Kel_Y1, etc}, which are also guaranteed to obey floors
- * 
+ * This function expects two sets of values {rho0, u0, Ktot0} from rc_old and {rho1, u1}
+ * from rc, all of which obey all given floors. It produces end-of-substep values {Ktot1,
+ * Kel_X1, Kel_Y1, etc}, which are also guaranteed to obey floors
+ *
  * TODO this function should update fflag to reflect temperature ratio floor hits
  */
-TaskStatus ApplyElectronHeating(MeshBlockData<Real> *rc_old, MeshBlockData<Real> *rc, bool generate_grf=false);
-inline TaskStatus MeshApplyElectronHeating(MeshData<Real> *md_old, MeshData<Real> *md, bool generate_grf=false)
+TaskStatus ApplyElectronHeating(
+    MeshBlockData<Real>* rc_old, MeshBlockData<Real>* rc, bool generate_grf = false);
+inline TaskStatus MeshApplyElectronHeating(
+    MeshData<Real>* md_old, MeshData<Real>* md, bool generate_grf = false)
 {
     Flag("MeshApplyElectronHeating");
-    for (int i=0; i < md->NumBlocks(); ++i)
-        ApplyElectronHeating(md_old->GetBlockData(i).get(), md->GetBlockData(i).get(), generate_grf);
+    for (int i = 0; i < md->NumBlocks(); ++i)
+        ApplyElectronHeating(
+            md_old->GetBlockData(i).get(), md->GetBlockData(i).get(), generate_grf);
     EndFlag();
     return TaskStatus::complete;
 }
@@ -125,48 +134,49 @@ inline TaskStatus MeshApplyElectronHeating(MeshData<Real> *md_old, MeshData<Real
  * Note that Kmin/max limits are applied immediately at heating,
  * *not* here.
  */
-void ApplyFloors(MeshBlockData<Real> *mbd, IndexDomain domain);
+void ApplyFloors(MeshBlockData<Real>* mbd, IndexDomain domain);
 
 /**
  * Diagnostics printed/computed after each step, called from kharma.cpp
- * 
+ *
  * Function in this package: Currently nothing
  */
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *rc);
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* rc);
 
 /**
  * Fill fields which are calculated only for output to dump files, called from kharma.cpp
- * 
+ *
  * Function in this package: Currently nothing
  */
-void FillOutput(MeshBlock *pmb, ParameterInput *pin);
+void FillOutput(MeshBlock* pmb, ParameterInput* pin);
 
 /**
  * KHARMA requires some method for getting conserved variables from primitives, as well.
- * 
+ *
  * However, unlike UtoP, p_to_u is implemented device-side. That means that any
- * package defining new primitive/conserved vars must not only provide a prim_to_flux here,
- * but add it to the list in Flux::prim_to_flux.
+ * package defining new primitive/conserved vars must not only provide a prim_to_flux
+ * here, but add it to the list in Flux::prim_to_flux.
  */
-KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                         const int& k, const int& j, const int& i,
-                                         const VariablePack<Real>& flux, const VarMap m_u, const Loci loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const int& k, const int& j,
+    const int& i, const VariablePack<Real>& flux, const VarMap m_u,
+    const Loci loc = Loci::center)
 {
-    // Take the factor from the primitives, in case we need to reorder this to happen before GRMHD::prim_to_flux later
-    const Real ut = GRMHD::lorentz_calc(G, P, m_p, k, j, i, loc) * m::sqrt(-G.gcon(loc, j, i, 0, 0));
+    // Take the factor from the primitives, in case we need to reorder this to happen
+    // before GRMHD::prim_to_flux later
+    const Real ut =
+        GRMHD::lorentz_calc(G, P, m_p, k, j, i, loc) * m::sqrt(-G.gcon(loc, j, i, 0, 0));
     const Real rho_ut = P(m_p.RHO, k, j, i) * ut * G.gdet(loc, j, i);
 
     flux(m_u.KTOT, k, j, i) = rho_ut * P(m_p.KTOT, k, j, i);
     if (m_p.K_CONSTANT >= 0)
         flux(m_u.K_CONSTANT, k, j, i) = rho_ut * P(m_p.K_CONSTANT, k, j, i);
-    if (m_p.K_HOWES >= 0)
-        flux(m_u.K_HOWES, k, j, i) = rho_ut * P(m_p.K_HOWES, k, j, i);
+    if (m_p.K_HOWES >= 0) flux(m_u.K_HOWES, k, j, i) = rho_ut * P(m_p.K_HOWES, k, j, i);
     if (m_p.K_KAWAZURA >= 0)
         flux(m_u.K_KAWAZURA, k, j, i) = rho_ut * P(m_p.K_KAWAZURA, k, j, i);
     if (m_p.K_WERNER >= 0)
         flux(m_u.K_WERNER, k, j, i) = rho_ut * P(m_p.K_WERNER, k, j, i);
-    if (m_p.K_ROWAN >= 0)
-        flux(m_u.K_ROWAN, k, j, i) = rho_ut * P(m_p.K_ROWAN, k, j, i);
+    if (m_p.K_ROWAN >= 0) flux(m_u.K_ROWAN, k, j, i) = rho_ut * P(m_p.K_ROWAN, k, j, i);
     if (m_p.K_SHARMA >= 0)
         flux(m_u.K_SHARMA, k, j, i) = rho_ut * P(m_p.K_SHARMA, k, j, i);
 }

--- a/kharma/electrons/gaussian.cpp
+++ b/kharma/electrons/gaussian.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: gaussian.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,7 +43,7 @@ float normalRand()
     // TODO this can definitely be Kokkosified
     std::random_device rd{};
     std::mt19937 gen{rd()};
-    std::normal_distribution<> d{0,1};
+    std::normal_distribution<> d{0, 1};
     return d(gen);
 }
 
@@ -51,72 +51,83 @@ float normalRand()
 
 #include "fftw3.h"
 
-void create_grf(int Nx1, int Nx2, double lx1, double lx2, 
-                    double * dv1, double * dv2)
+void create_grf(int Nx1, int Nx2, double lx1, double lx2, double* dv1, double* dv2)
 {
-    double dkx1 = 2*M_PI/lx1;
-    double dkx2 = 2*M_PI/lx2;
-    double Dx1 = lx1/Nx1;
-    double Dx2 = lx2/Nx2;
+    double dkx1 = 2 * M_PI / lx1;
+    double dkx2 = 2 * M_PI / lx2;
+    double Dx1 = lx1 / Nx1;
+    double Dx2 = lx2 / Nx2;
 
-    double kx1max = 2*M_PI/(2*Dx1);
-    double kx2max = 2*M_PI/(2*Dx2);
-    double k_peak = 4*M_PI/lx1;
+    double kx1max = 2 * M_PI / (2 * Dx1);
+    double kx2max = 2 * M_PI / (2 * Dx2);
+    double k_peak = 4 * M_PI / lx1;
 
     fftw_complex *dvkx1, *dvkx2;
-    dvkx1 = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * Nx1 * Nx2);
-    dvkx2 = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * Nx1 * Nx2);
+    dvkx1 = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * Nx1 * Nx2);
+    dvkx2 = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * Nx1 * Nx2);
 #pragma omp parallel for simd collapse(2)
-    for (size_t i = 0; i < Nx1 ; i ++) {
-        for (size_t j = 0; j < Nx2 ; j ++) {
+    for (size_t i = 0; i < Nx1; i++) {
+        for (size_t j = 0; j < Nx2; j++) {
             double retx1 = i * dkx1;
             double retx2 = j * dkx2;
-            if(retx1 > kx1max) retx1 = retx1 - 2*kx1max;
-            if(retx2 > kx2max) retx2 = retx2 - 2*kx2max;
+            if (retx1 > kx1max) retx1 = retx1 - 2 * kx1max;
+            if (retx2 > kx2max) retx2 = retx2 - 2 * kx2max;
             double curr_k_magn = pow(pow(retx1, 2) + pow(retx2, 2), 0.5);
 
-            double pwr_spct = pow(curr_k_magn, 6)*exp(-8*curr_k_magn/k_peak);
+            double pwr_spct = pow(curr_k_magn, 6) * exp(-8 * curr_k_magn / k_peak);
             if (curr_k_magn != 0) {
                 retx1 /= curr_k_magn;
                 retx2 /= curr_k_magn;
             }
 
-            double noisy_dvkx1_real = pwr_spct*normalRand(); double noisy_dvkx1_imag = pwr_spct*normalRand();
-            double noisy_dvkx2_real = pwr_spct*normalRand(); double noisy_dvkx2_imag = pwr_spct*normalRand();
+            double noisy_dvkx1_real = pwr_spct * normalRand();
+            double noisy_dvkx1_imag = pwr_spct * normalRand();
+            double noisy_dvkx2_real = pwr_spct * normalRand();
+            double noisy_dvkx2_imag = pwr_spct * normalRand();
 
-            //real part of kx, using real part of dot product, and the kx component. second line is imag part
-            double adj_dvkx1_real = (retx1*noisy_dvkx1_real + retx2*noisy_dvkx2_real)*retx1;
-            double adj_dvkx1_imag = (retx1*noisy_dvkx1_imag + retx2*noisy_dvkx2_imag)*retx1;
-            double adj_dvkx2_real = (retx1*noisy_dvkx1_real + retx2*noisy_dvkx2_real)*retx2;
-            double adj_dvkx2_imag = (retx1*noisy_dvkx1_imag + retx2*noisy_dvkx2_imag)*retx2;
+            // real part of kx, using real part of dot product, and the kx component.
+            // second line is imag part
+            double adj_dvkx1_real =
+                (retx1 * noisy_dvkx1_real + retx2 * noisy_dvkx2_real) * retx1;
+            double adj_dvkx1_imag =
+                (retx1 * noisy_dvkx1_imag + retx2 * noisy_dvkx2_imag) * retx1;
+            double adj_dvkx2_real =
+                (retx1 * noisy_dvkx1_real + retx2 * noisy_dvkx2_real) * retx2;
+            double adj_dvkx2_imag =
+                (retx1 * noisy_dvkx1_imag + retx2 * noisy_dvkx2_imag) * retx2;
 
-            dvkx1[i*Nx1+j][0] = noisy_dvkx1_real - adj_dvkx1_real;  dvkx1[i*Nx1+j][1] = noisy_dvkx1_imag - adj_dvkx1_imag;
-            dvkx2[i*Nx1+j][0] = noisy_dvkx2_real - adj_dvkx2_real;  dvkx2[i*Nx1+j][1] = noisy_dvkx2_imag - adj_dvkx2_imag;
+            dvkx1[i * Nx1 + j][0] = noisy_dvkx1_real - adj_dvkx1_real;
+            dvkx1[i * Nx1 + j][1] = noisy_dvkx1_imag - adj_dvkx1_imag;
+            dvkx2[i * Nx1 + j][0] = noisy_dvkx2_real - adj_dvkx2_real;
+            dvkx2[i * Nx1 + j][1] = noisy_dvkx2_imag - adj_dvkx2_imag;
         }
     }
 
     fftw_plan p_x1, p_x2;
-    p_x1 = fftw_plan_dft_2d(Nx1, Nx2, dvkx1, dvkx1, FFTW_BACKWARD, FFTW_ESTIMATE); //in-place
+    p_x1 = fftw_plan_dft_2d(Nx1, Nx2, dvkx1, dvkx1, FFTW_BACKWARD,
+        FFTW_ESTIMATE); // in-place
     p_x2 = fftw_plan_dft_2d(Nx1, Nx2, dvkx2, dvkx2, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fftw_execute(p_x1); //look for threads documentation
+    fftw_execute(p_x1); // look for threads documentation
     fftw_execute(p_x2);
 
-    fftw_destroy_plan(p_x1);  fftw_destroy_plan(p_x2);
+    fftw_destroy_plan(p_x1);
+    fftw_destroy_plan(p_x2);
 #pragma omp parallel for simd collapse(2)
-    for (size_t i = 0; i < Nx1 ; i ++) {
-        for (size_t j = 0; j < Nx2 ; j ++) {
-            dv1[i*Nx1+j] = dvkx1[i*Nx1+j][0];
-            dv2[i*Nx1+j] = dvkx2[i*Nx1+j][0];
+    for (size_t i = 0; i < Nx1; i++) {
+        for (size_t j = 0; j < Nx2; j++) {
+            dv1[i * Nx1 + j] = dvkx1[i * Nx1 + j][0];
+            dv2[i * Nx1 + j] = dvkx2[i * Nx1 + j][0];
         }
     }
-    fftw_free(dvkx1);   fftw_free(dvkx2);
+    fftw_free(dvkx1);
+    fftw_free(dvkx2);
 }
 
-#else 
+#else
 
-void create_grf(int Nx1, int Nx2, double lx1, double lx2, 
-                    double * dv1, double * dv2)
+void create_grf(int Nx1, int Nx2, double lx1, double lx2, double* dv1, double* dv2)
 {
-    throw std::runtime_error("Attempted to use an FFT to generate a Gaussian random field, but KHARMA was compiled without FFT support!");
+    throw std::runtime_error("Attempted to use an FFT to generate a Gaussian random "
+                             "field, but KHARMA was compiled without FFT support!");
 }
 #endif

--- a/kharma/electrons/gaussian.hpp
+++ b/kharma/electrons/gaussian.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: gaussian.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,4 +34,4 @@
 #pragma once
 
 float normalRand();
-void create_grf(int Nx1, int Nx2, double lx1, double lx2, double * dv1, double * dv2);
+void create_grf(int Nx1, int Nx2, double lx1, double lx2, double* dv1, double* dv2);

--- a/kharma/emhd/emhd.cpp
+++ b/kharma/emhd/emhd.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhd.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -48,20 +48,23 @@ using namespace parthenon;
 namespace EMHD
 {
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("EMHD");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // EMHD Problem/Closure parameters
     // GRIM uses a callback to a problem-specific implementation which sets these
     // We share implementations in one function, controlled by these parameters
     // These are always necessary for performing EGRMHD.
 
-    bool higher_order_terms  = pin->GetOrAddBoolean("emhd", "higher_order_terms", false);
+    bool higher_order_terms = pin->GetOrAddBoolean("emhd", "higher_order_terms", false);
     params.Add("higher_order_terms", higher_order_terms);
-    std::vector<std::string> allowed_closures = {"constant", "sound_speed", "soundspeed", "kappa_eta", "torus"};
-    std::string closure_type = pin->GetOrAddString("emhd", "closure_type", "torus", allowed_closures);
+    std::vector<std::string> allowed_closures = {
+        "constant", "sound_speed", "soundspeed", "kappa_eta", "torus"};
+    std::string closure_type =
+        pin->GetOrAddString("emhd", "closure_type", "torus", allowed_closures);
     params.Add("closure_type", closure_type);
 
     // Should the EMHD sector feedback onto the ideal MHD variables? The default is 'yes'.
@@ -76,21 +79,21 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
 
     // TODO consider erroring when (the correct subset of) these aren't present,
     // rather than have defaults that won't work well
-    Real tau              = pin->GetOrAddReal("emhd", "tau", 1.0);
+    Real tau = pin->GetOrAddReal("emhd", "tau", 1.0);
     Real conduction_alpha = pin->GetOrAddReal("emhd", "conduction_alpha", 1.0);
     params.Add("conduction_alpha", conduction_alpha);
-    Real viscosity_alpha  = pin->GetOrAddReal("emhd", "viscosity_alpha", 1.0);
+    Real viscosity_alpha = pin->GetOrAddReal("emhd", "viscosity_alpha", 1.0);
     params.Add("viscosity_alpha", viscosity_alpha);
-    
+
     Real kappa = pin->GetOrAddReal("emhd", "kappa", 1.0);
     params.Add("kappa", kappa);
-    Real eta   = pin->GetOrAddReal("emhd", "eta", 1.0);
+    Real eta = pin->GetOrAddReal("emhd", "eta", 1.0);
     params.Add("eta", eta);
 
     EMHD_parameters emhd_params;
     emhd_params.higher_order_terms = higher_order_terms;
-    emhd_params.feedback           = feedback;
-    if (closure_type == "constant") { 
+    emhd_params.feedback = feedback;
+    if (closure_type == "constant") {
         emhd_params.type = ClosureType::constant;
     } else if (closure_type == "sound_speed" || closure_type == "soundspeed") {
         emhd_params.type = ClosureType::soundspeed;
@@ -99,40 +102,48 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     } else if (closure_type == "torus") {
         emhd_params.type = ClosureType::torus;
     }
-    emhd_params.tau              = tau;
+    emhd_params.tau = tau;
     emhd_params.conduction_alpha = conduction_alpha;
-    emhd_params.viscosity_alpha  = viscosity_alpha;
-    emhd_params.kappa            = kappa;
-    emhd_params.eta              = eta;
+    emhd_params.viscosity_alpha = viscosity_alpha;
+    emhd_params.kappa = kappa;
+    emhd_params.eta = eta;
     params.Add("emhd_params", emhd_params);
 
-    // Slope reconstruction on faces. Always linear: default to MC unless we're using VL everywhere
+    // Slope reconstruction on faces. Always linear: default to MC unless we're using VL
+    // everywhere
     // TODO NOT USED until we template AddSource
-    if (pin->DoesParameterExist("emhd", "slope_recon") && pin->GetString("emhd", "slope_recon") == "linear_vl") {
-        //|| packages->Get("Fluxes")->Param<KReconstruction::Type>("recon") == KReconstruction::Type::linear_vl) {
+    if (pin->DoesParameterExist("emhd", "slope_recon") &&
+        pin->GetString("emhd", "slope_recon") == "linear_vl") {
+        //|| packages->Get("Fluxes")->Param<KReconstruction::Type>("recon") ==
+        // KReconstruction::Type::linear_vl) {
         params.Add("slope_recon", KReconstruction::Type::linear_vl);
     } else {
         params.Add("slope_recon", KReconstruction::Type::linear_mc);
     }
 
-    // Apply limits on heat flux and pressure anisotropy from velocity space instabilities?
-    // We would want this for the torus runs but not for the test problems. 
+    // Apply limits on heat flux and pressure anisotropy from velocity space
+    // instabilities? We would want this for the torus runs but not for the test problems.
     // For eg: we know that this affects the viscous bondi problem
     bool emhd_limits_default = false;
     if (pin->DoesParameterExist("floors", "emhd_limits"))
         emhd_limits_default = pin->GetBoolean("floors", "emhd_limits");
-    bool enable_emhd_limits = pin->GetOrAddBoolean("emhd", "stability_limits", emhd_limits_default);
+    bool enable_emhd_limits =
+        pin->GetOrAddBoolean("emhd", "stability_limits", emhd_limits_default);
     params.Add("enable_emhd_limits", enable_emhd_limits);
 
     // General options for primitive and conserved scalar variables in ImEx driver
     // EMHD is supported only with imex driver and implicit evolution,
     // synchronizing primitive variables
-    Metadata::AddUserFlag("EMHDVar"); // "EMHD" name now taken by Parthenon for general flag, we want this one specific
-    std::vector<MetadataFlag> emhd_flags = {Metadata::Cell, Metadata::GetUserFlag("Implicit"), Metadata::GetUserFlag("EMHDVar")};
+    Metadata::AddUserFlag("EMHDVar"); // "EMHD" name now taken by Parthenon for general
+                                      // flag, we want this one specific
+    std::vector<MetadataFlag> emhd_flags = {Metadata::Cell,
+        Metadata::GetUserFlag("Implicit"), Metadata::GetUserFlag("EMHDVar")};
 
-    auto flags_prim = packages->Get("Driver")->Param<std::vector<MetadataFlag>>("prim_flags");
+    auto flags_prim =
+        packages->Get("Driver")->Param<std::vector<MetadataFlag>>("prim_flags");
     flags_prim.insert(flags_prim.end(), emhd_flags.begin(), emhd_flags.end());
-    auto flags_cons = packages->Get("Driver")->Param<std::vector<MetadataFlag>>("cons_flags");
+    auto flags_cons =
+        packages->Get("Driver")->Param<std::vector<MetadataFlag>>("cons_flags");
     flags_cons.insert(flags_cons.end(), emhd_flags.begin(), emhd_flags.end());
 
     Metadata m_cons = Metadata(flags_cons);
@@ -149,18 +160,23 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
         pkg->AddField("prims.dP", m_prim);
     }
 
-    // 4vel ucov and temperature Theta are needed as temporaries, but need to be grid-sized anyway.
-    // Allow keeping/saving them.
+    // 4vel ucov and temperature Theta are needed as temporaries, but need to be
+    // grid-sized anyway. Allow keeping/saving them.
     Metadata::AddUserFlag("EMHDTemporary");
-    Metadata m_temp = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::GetUserFlag("EMHDTemporary")});
+    Metadata m_temp = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
+        Metadata::OneCopy, Metadata::GetUserFlag("EMHDTemporary")});
     pkg->AddField("Theta", m_temp);
     std::vector<int> fourv = {GR_DIM};
-    Metadata m_temp_vec = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::GetUserFlag("EMHDTemporary")}, fourv);
+    Metadata m_temp_vec =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy,
+                     Metadata::GetUserFlag("EMHDTemporary")},
+            fourv);
     pkg->AddField("ucov", m_temp_vec);
 
     // This works similarly to the fflag:
     // we register zones where limits on q and dP are hit
-    Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+    Metadata m =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
     pkg->AddField("eflag", m);
 
     // Callbacks
@@ -168,7 +184,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     // UtoP function specifically for boundary sync and output
     pkg->BoundaryUtoP = EMHD::BlockUtoP;
     // If we wanted to apply the domian boundaries to primitive EMHD variables
-    //pkg->DomainBoundaryPtoU = EMHD::BlockPtoU;
+    // pkg->DomainBoundaryPtoU = EMHD::BlockPtoU;
 
     // Add all explicit source terms -- implicit terms are called from Implicit::Step
     pkg->AddSource = EMHD::AddSource;
@@ -181,46 +197,54 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     return pkg;
 }
 
-void MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse)
+void MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
     auto pmb = md->GetBlockData(0)->GetBlockPointer();
 
     // Get only relevant cons, but all prims as we need the Lorentz factor
     PackIndexMap prims_map, cons_map;
-    auto U_E = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("EMHDVar"), Metadata::Conserved}, cons_map);
-    auto P   = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto U_E = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("EMHDVar"), Metadata::Conserved},
+        cons_map);
+    auto P = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
     const VarMap m_p(prims_map, false), m_u(cons_map, true);
 
     const auto& G = pmb->coords;
 
-    auto bounds      = coarse ? pmb->c_cellbounds : pmb->cellbounds;
-    IndexRange ib    = bounds.GetBoundsI(domain);
-    IndexRange jb    = bounds.GetBoundsJ(domain);
-    IndexRange kb    = bounds.GetBoundsK(domain);
-    IndexRange block = IndexRange{0, U_E.GetDim(5)-1};
+    auto bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
+    IndexRange ib = bounds.GetBoundsI(domain);
+    IndexRange jb = bounds.GetBoundsJ(domain);
+    IndexRange kb = bounds.GetBoundsK(domain);
+    IndexRange block = IndexRange{0, U_E.GetDim(5) - 1};
 
     pmb->par_for("UtoP_EMHD", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) { 
-            const Real gamma     = GRMHD::lorentz_calc(G, P(b), m_p, k, j, i, Loci::center);
+                 KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
+            const Real gamma = GRMHD::lorentz_calc(G, P(b), m_p, k, j, i, Loci::center);
             const Real inv_alpha = m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
-            const Real ucon0     = gamma * inv_alpha;
+            const Real ucon0 = gamma * inv_alpha;
 
             // Update the primitive EMHD fields
             if (m_p.Q >= 0)
-                P(b, m_p.Q, k, j, i) = U_E(b, m_u.Q, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
+                P(b, m_p.Q, k, j, i) =
+                    U_E(b, m_u.Q, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
             if (m_p.DP >= 0)
-                P(b, m_p.DP, k, j, i) = U_E(b, m_u.DP, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
-        }
-    );
+                P(b, m_p.DP, k, j, i) =
+                    U_E(b, m_u.DP, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
+        });
 }
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
     // Get only relevant cons, but all prims as we need the Lorentz factor
     PackIndexMap prims_map, cons_map;
-    auto U_E = rc->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("EMHDVar"), Metadata::Conserved}, cons_map);
-    auto P = rc->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto U_E = rc->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("EMHDVar"), Metadata::Conserved},
+        cons_map);
+    auto P = rc->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
     const VarMap m_p(prims_map, false), m_u(cons_map, true);
 
     if (U_E.GetDim(4) == 0) return;
@@ -233,28 +257,31 @@ void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const IndexRange kb = bounds.GetBoundsK(domain);
 
     pmb->par_for("UtoP_EMHD", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             const Real gamma = GRMHD::lorentz_calc(G, P, m_p, k, j, i, Loci::center);
             const Real inv_alpha = m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
             const Real ucon0 = gamma * inv_alpha;
 
             // Update the primitive EMHD fields
             if (m_p.Q >= 0)
-                P(m_p.Q, k, j, i) = U_E(m_u.Q, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
+                P(m_p.Q, k, j, i) =
+                    U_E(m_u.Q, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
             if (m_p.DP >= 0)
-                P(m_p.DP, k, j, i) = U_E(m_u.DP, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
-        }
-    );
+                P(m_p.DP, k, j, i) =
+                    U_E(m_u.DP, k, j, i) / (ucon0 * G.gdet(Loci::center, j, i));
+        });
     Kokkos::fence();
 }
 
-void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void BlockPtoU(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
     // Get only relevant cons, but all prims as we need the Lorentz factor
     PackIndexMap prims_map, cons_map;
-    auto U_E = rc->PackVariables({Metadata::GetUserFlag("EMHDVar"), Metadata::Conserved}, cons_map);
+    auto U_E = rc->PackVariables(
+        {Metadata::GetUserFlag("EMHDVar"), Metadata::Conserved}, cons_map);
     auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive")}, prims_map);
     const VarMap m_p(prims_map, false), m_u(cons_map, true);
 
@@ -266,48 +293,53 @@ void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const IndexRange kb = bounds.GetBoundsK(domain);
 
     pmb->par_for("PtoU_EMHD", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             const Real gamma = GRMHD::lorentz_calc(G, P, m_p, k, j, i, Loci::center);
             const Real inv_alpha = m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
             const Real ucon0 = gamma * inv_alpha;
 
             // Update the conserved EMHD fields
             if (m_p.Q >= 0)
-                U_E(m_u.Q, k, j, i) = P(m_p.Q, k, j, i) * ucon0 * G.gdet(Loci::center, j, i);
+                U_E(m_u.Q, k, j, i) =
+                    P(m_p.Q, k, j, i) * ucon0 * G.gdet(Loci::center, j, i);
             if (m_p.DP >= 0)
-                U_E(m_u.DP, k, j, i) = P(m_p.DP, k, j, i) * ucon0 * G.gdet(Loci::center, j, i);
-        }
-    );
+                U_E(m_u.DP, k, j, i) =
+                    P(m_p.DP, k, j, i) * ucon0 * G.gdet(Loci::center, j, i);
+        });
 }
 
-void InitEMHDVariables(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+void InitEMHDVariables(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     // Do we actually need anything here?
 }
 
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
     // Pointers
     auto pmesh = mdudt->GetMeshPointer();
-    auto pmb0  = mdudt->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = mdudt->GetBlockData(0)->GetBlockPointer();
     // Options: Global
     const auto& gpars = pmb0->packages.Get("GRMHD")->AllParams();
-    const Real gam    = gpars.Get<Real>("gamma");
-    const int ndim    = pmesh->ndim;
+    const Real gam = gpars.Get<Real>("gamma");
+    const int ndim = pmesh->ndim;
     // Options: Local
-    const auto& pars                   = pmb0->packages.Get("EMHD")->AllParams();
+    const auto& pars = pmb0->packages.Get("EMHD")->AllParams();
     const EMHD_parameters& emhd_params = pars.Get<EMHD_parameters>("emhd_params");
 
     // Pack variables
     PackIndexMap prims_map, cons_map, source_map;
-    auto P    = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
-    auto U    = md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
-    auto dUdt = mdudt->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, source_map);
+    auto P = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto U = md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
+    auto dUdt =
+        mdudt->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, source_map);
     const VarMap m_p(prims_map, false), m_u(cons_map, true), m_s(source_map, true);
 
     // Get temporary ucov, Theta for gradients
     PackIndexMap temps_map;
-    auto Temps = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("EMHDTemporary")}, temps_map);
+    auto Temps = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("EMHDTemporary")}, temps_map);
     int m_ucov = temps_map["ucov"].first;
     int m_theta = temps_map["Theta"].first;
 
@@ -317,32 +349,37 @@ TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain doma
     const IndexRange kb = mdudt->GetBoundsK(domain);
     const IndexRange block = IndexRange{0, dUdt.GetDim(5) - 1};
     // 1-zone halo in nontrivial dimensions
-    const IndexRange il = IndexRange{ib.s-1, ib.e+1};
-    const IndexRange jl = (ndim > 1) ? IndexRange{jb.s-1, jb.e+1} : jb;
-    const IndexRange kl = (ndim > 2) ? IndexRange{kb.s-1, kb.e+1} : kb;
+    const IndexRange il = IndexRange{ib.s - 1, ib.e + 1};
+    const IndexRange jl = (ndim > 1) ? IndexRange{jb.s - 1, jb.e + 1} : jb;
+    const IndexRange kl = (ndim > 2) ? IndexRange{kb.s - 1, kb.e + 1} : kb;
 
     // Calculate & apply source terms
-    pmb0->par_for("emhd_sources_pre", block.s, block.e, kl.s, kl.e, jl.s, jl.e, il.s, il.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
-            const auto& G    = dUdt.GetCoords(b);
+    pmb0->par_for("emhd_sources_pre", block.s, block.e, kl.s, kl.e, jl.s, jl.e, il.s,
+        il.e,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
+            const auto& G = dUdt.GetCoords(b);
             // ucon
             Real ucon[GR_DIM], ucov[GR_DIM];
             GRMHD::calc_ucon(G, P(b), m_p, k, j, i, Loci::center, ucon);
             G.lower(ucon, ucov, k, j, i, Loci::center);
-            DLOOP1 Temps(b, m_ucov + mu, k, j, i) = ucov[mu];
+            DLOOP1
+                Temps(b, m_ucov + mu, k, j, i) = ucov[mu];
             // theta
-            Temps(b, m_theta, k, j, i) = m::max((gam - 1) * P(b)(m_p.UU, k, j, i) / P(b)(m_p.RHO, k, j, i), SMALL_NUM);
-        }
-    );
+            Temps(b, m_theta, k, j, i) = m::max(
+                (gam - 1) * P(b)(m_p.UU, k, j, i) / P(b)(m_p.RHO, k, j, i), SMALL_NUM);
+        });
 
     // Calculate & apply source terms
     pmb0->par_for("emhd_sources", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = dUdt.GetCoords(b);
 
             // Get the EGRMHD parameters
             Real tau, chi_e, nu_e;
-            EMHD::set_parameters(G, P(b), m_p, emhd_params, gam, k, j, i, tau, chi_e, nu_e);
+            EMHD::set_parameters(
+                G, P(b), m_p, emhd_params, gam, k, j, i, tau, chi_e, nu_e);
 
             // and the 4-vectors
             FourVectors D;
@@ -352,54 +389,62 @@ TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain doma
             // Compute gradient of ucov and Theta
             Real grad_ucov[GR_DIM][GR_DIM], grad_Theta[GR_DIM];
             // TODO thread the limiter selection through to call
-            EMHD::gradient_calc<KReconstruction::Type::linear_mc>(G, Temps(b), m_ucov, m_theta, b, k, j, i, (ndim > 2), (ndim > 1), grad_ucov, grad_Theta);
+            EMHD::gradient_calc<KReconstruction::Type::linear_mc>(G, Temps(b), m_ucov,
+                m_theta, b, k, j, i, (ndim > 2), (ndim > 1), grad_ucov, grad_Theta);
 
             // Compute div of ucon (all terms but the time-derivative ones are nonzero)
-            Real div_ucon    = 0;
-            DLOOP2 div_ucon += G.gcon(Loci::center, j, i, mu, nu) * grad_ucov[mu][nu];
+            Real div_ucon = 0;
+            DLOOP2
+                div_ucon += G.gcon(Loci::center, j, i, mu, nu) * grad_ucov[mu][nu];
 
             // Compute+add explicit source terms (conduction and viscosity)
             const Real& rho = P(b)(m_p.RHO, k, j, i);
             const Real& Theta = Temps(b)(m_theta, k, j, i);
 
-
             if (m_s.Q >= 0) {
                 const Real& qtilde = P(b)(m_p.Q, k, j, i);
                 const double inv_mag_b = 1. / m::sqrt(bsq);
-                Real q0            = 0;
-                DLOOP1 q0         -= rho * chi_e * (D.bcon[mu] * inv_mag_b) * grad_Theta[mu];
-                DLOOP2 q0         -= rho * chi_e * (D.bcon[mu] * inv_mag_b) * Theta * D.ucon[nu] * grad_ucov[nu][mu];
-                Real q0_tilde      = q0; 
+                Real q0 = 0;
+                DLOOP1
+                    q0 -= rho * chi_e * (D.bcon[mu] * inv_mag_b) * grad_Theta[mu];
+                DLOOP2
+                    q0 -= rho * chi_e * (D.bcon[mu] * inv_mag_b) * Theta * D.ucon[nu] *
+                          grad_ucov[nu][mu];
+                Real q0_tilde = q0;
                 if (emhd_params.higher_order_terms)
-                    q0_tilde *= (chi_e != 0) ? m::sqrt(tau / (chi_e * rho * Theta * Theta)) : 0.0;
+                    q0_tilde *=
+                        (chi_e != 0) ? m::sqrt(tau / (chi_e * rho * Theta * Theta)) : 0.0;
 
-                dUdt(b, m_s.Q, k, j, i)  += G.gdet(Loci::center, j, i) * q0_tilde / tau;
+                dUdt(b, m_s.Q, k, j, i) += G.gdet(Loci::center, j, i) * q0_tilde / tau;
                 if (emhd_params.higher_order_terms)
-                    dUdt(b, m_s.Q, k, j, i)  += G.gdet(Loci::center, j, i) * (qtilde / 2.) * div_ucon;
+                    dUdt(b, m_s.Q, k, j, i) +=
+                        G.gdet(Loci::center, j, i) * (qtilde / 2.) * div_ucon;
             }
 
             if (m_s.DP >= 0) {
                 const Real& dPtilde = P(b)(m_p.DP, k, j, i);
-                Real dP0            = -rho * nu_e * div_ucon;
-                DLOOP2  dP0        += 3. * rho * nu_e * (D.bcon[mu] * D.bcon[nu] / bsq) * grad_ucov[mu][nu];
-                Real dP0_tilde      = dP0;
+                Real dP0 = -rho * nu_e * div_ucon;
+                DLOOP2
+                    dP0 += 3. * rho * nu_e * (D.bcon[mu] * D.bcon[nu] / bsq) *
+                           grad_ucov[mu][nu];
+                Real dP0_tilde = dP0;
                 if (emhd_params.higher_order_terms)
                     dP0_tilde *= (nu_e != 0) ? m::sqrt(tau / (nu_e * rho * Theta)) : 0.0;
 
                 dUdt(b, m_s.DP, k, j, i) += G.gdet(Loci::center, j, i) * dP0_tilde / tau;
                 if (emhd_params.higher_order_terms)
-                    dUdt(b, m_s.DP, k, j, i) += G.gdet(Loci::center, j, i) * (dPtilde / 2.) * div_ucon;
+                    dUdt(b, m_s.DP, k, j, i) +=
+                        G.gdet(Loci::center, j, i) * (dPtilde / 2.) * div_ucon;
             }
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-void ApplyEMHDLimits(MeshBlockData<Real> *mbd, IndexDomain domain)
+void ApplyEMHDLimits(MeshBlockData<Real>* mbd, IndexDomain domain)
 {
-    auto pmb                 = mbd->GetBlockPointer();
-    auto packages            = pmb->packages;
+    auto pmb = mbd->GetBlockPointer();
+    auto packages = pmb->packages;
 
     PackIndexMap prims_map, cons_map;
     auto P = mbd->PackVariables({Metadata::GetUserFlag("Primitive")}, prims_map);
@@ -421,11 +466,12 @@ void ApplyEMHDLimits(MeshBlockData<Real> *mbd, IndexDomain domain)
     const IndexRange jb = mbd->GetBoundsJ(domain);
     const IndexRange kb = mbd->GetBoundsK(domain);
     pmb->par_for("apply_emhd_limits", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             // Apply limits to the Extended MHD variables
-            eflag(k, j, i) = apply_instability_limits(G, P, m_p, gam, emhd_params, k, j, i, U, m_u);
-        }
-    );
+            eflag(k, j, i) =
+                apply_instability_limits(G, P, m_p, gam, emhd_params, k, j, i, U, m_u);
+        });
 }
 
 } // namespace EMHD

--- a/kharma/emhd/emhd.hpp
+++ b/kharma/emhd/emhd.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhd.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,88 +46,89 @@ using namespace parthenon;
 #endif
 
 /**
- * This physics package implements the Extended GRMHD "EGRMHD" scheme of Chandra et al. 2015,
- * First implemented in GRIM, of Chandra et al. 2017.
- * 
- * It adds variables representing viscosity and heat conduction, with a combination of explicit
- * and implicit source terms; thus it requires a semi-implicit scheme for evolution,
- * implemented in KHARMA as ImexDriver.
+ * This physics package implements the Extended GRMHD "EGRMHD" scheme of Chandra et al.
+ * 2015, First implemented in GRIM, of Chandra et al. 2017.
+ *
+ * It adds variables representing viscosity and heat conduction, with a combination of
+ * explicit and implicit source terms; thus it requires a semi-implicit scheme for
+ * evolution, implemented in KHARMA as ImexDriver.
  */
-namespace EMHD {
+namespace EMHD
+{
 
-enum ClosureType{constant=0, soundspeed, kappa_eta, torus};
+enum ClosureType { constant = 0, soundspeed, kappa_eta, torus };
 
-class EMHD_parameters {
-    public:
+class EMHD_parameters
+{
+  public:
+    bool higher_order_terms;
+    bool feedback;
+    ClosureType type;
+    Real tau;
 
-        bool higher_order_terms;
-        bool feedback;
-        ClosureType type;
-        Real tau;
+    Real conduction_alpha;
+    Real viscosity_alpha;
 
-        Real conduction_alpha;
-        Real viscosity_alpha;
+    Real kappa;
+    Real eta;
 
-        Real kappa;
-        Real eta;
-
-        void print() const
-        {
-            printf("EMHD Parameters:\n");
-            printf("higher order: %d feedback: %d \n",
-                    higher_order_terms, feedback);
-            printf("kappa: %g eta: %g tau: %g conduction_a: %g viscosity_a: %g \n",
-                    kappa, eta, tau, conduction_alpha, viscosity_alpha);
-            // TODO closuretype
-        }
-
+    void print() const
+    {
+        printf("EMHD Parameters:\n");
+        printf("higher order: %d feedback: %d \n", higher_order_terms, feedback);
+        printf("kappa: %g eta: %g tau: %g conduction_a: %g viscosity_a: %g \n", kappa,
+            eta, tau, conduction_alpha, viscosity_alpha);
+        // TODO closuretype
+    }
 };
 
 /**
- * Initialization: handle parameters, 
+ * Initialization: handle parameters,
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Add EGRMHD explicit source terms: anything which can be calculated once
  * and added to the general dU/dt term along with e.g. GRMHD source, wind, etc
  */
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 
 /**
  * Set q and dP to sensible starting values if they are not initialized by the problem.
  * Currently a no-op as sensible values are zeros.
  */
-void InitEMHDVariables(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+void InitEMHDVariables(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);
 
 /**
  * Recover primitive qtilde, dPtilde from "conserved" forms {qtilde,dPtilde}*u^0*gdet,
  * and vice versa.
- * These are *not* called in the usual places for explicitly-evolved variables, but instead
- * only on boundaries in order to sync the primitive/conserved variables specifically.
+ * These are *not* called in the usual places for explicitly-evolved variables, but
+ * instead only on boundaries in order to sync the primitive/conserved variables
+ * specifically.
  */
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
-void MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
-void BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse);
+void MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse = false);
+void BlockPtoU(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse);
 
 /**
  * Add EGRMHD explicit source terms: anything which can be calculated once
  * and added to the general dU/dt term along with e.g. GRMHD source, wind, etc
  */
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 
 /**
  * Set q and dP to sensible starting values if they are not initialized by the problem.
  * Currently a no-op as sensible values are zeros.
  */
-void InitEMHDVariables(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+void InitEMHDVariables(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);
 
 /**
  * Apply limits on the Extended MHD variables q & dP based on instabilities.
  *
  * LOCKSTEP: this function respects P and returns consistent P<->U
  */
-void ApplyEMHDLimits(MeshBlockData<Real> *mbd, IndexDomain domain);
+void ApplyEMHDLimits(MeshBlockData<Real>* mbd, IndexDomain domain);
 
 /**
  * Get the EMHD parameters needed on the device side.
@@ -138,7 +139,8 @@ inline EMHD_parameters GetEMHDParameters(Packages_t& packages)
 {
     EMHD::EMHD_parameters emhd_params_tmp = {0};
     if (packages.AllPackages().count("EMHD")) {
-        emhd_params_tmp = packages.Get("EMHD")->Param<EMHD::EMHD_parameters>("emhd_params");
+        emhd_params_tmp =
+            packages.Get("EMHD")->Param<EMHD::EMHD_parameters>("emhd_params");
     }
     return emhd_params_tmp;
 }
@@ -146,41 +148,41 @@ inline EMHD_parameters GetEMHDParameters(Packages_t& packages)
 #if DISABLE_EMHD
 
 template<typename Local>
-KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Local& P, const VarMap& m_p,
-                                           const EMHD_parameters& emhd_params, const Real& gam,
-                                           const int& j, const int& i,
-                                           Real& tau, Real& chi_e, Real& nu_e) {}
+KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Local& P,
+    const VarMap& m_p, const EMHD_parameters& emhd_params, const Real& gam, const int& j,
+    const int& i, Real& tau, Real& chi_e, Real& nu_e)
+{}
 
-KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                           const EMHD_parameters& emhd_params, const Real& gam,
-                                           const int& k, const int& j, const int& i,
-                                           Real& tau, Real& chi_e, Real& nu_e) {}
+KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const EMHD_parameters& emhd_params,
+    const Real& gam, const int& k, const int& j, const int& i, Real& tau, Real& chi_e,
+    Real& nu_e)
+{}
 
-KOKKOS_INLINE_FUNCTION void set_parameters_init(const GRCoordinates& G, const Real& rho, const Real& u,
-                                           const EMHD_parameters& emhd_params, const Real& gam,
-                                           const int& k, const int& j, const int& i,
-                                           Real& tau, Real& chi_e, Real& nu_e) {}
+KOKKOS_INLINE_FUNCTION void set_parameters_init(const GRCoordinates& G, const Real& rho,
+    const Real& u, const EMHD_parameters& emhd_params, const Real& gam, const int& k,
+    const int& j, const int& i, Real& tau, Real& chi_e, Real& nu_e)
+{}
 
 KOKKOS_INLINE_FUNCTION void calc_tensor(const Real& rho, const Real& u, const Real& pgas,
-                                        const EMHD::EMHD_parameters& emhd_params, 
-                                        const Real& q, const Real& dP,
-                                        const FourVectors& D, const int& dir,
-                                        Real emhd[GR_DIM]) {}
+    const EMHD::EMHD_parameters& emhd_params, const Real& q, const Real& dP,
+    const FourVectors& D, const int& dir, Real emhd[GR_DIM])
+{}
 
-KOKKOS_INLINE_FUNCTION void convert_prims_to_q_dP(const Real& q_tilde, const Real& dP_tilde,
-                                        const Real& rho, const Real& Theta, const Real& cs2, 
-                                        const EMHD_parameters& emhd_params, Real& q, Real& dP) {}
+KOKKOS_INLINE_FUNCTION void convert_prims_to_q_dP(const Real& q_tilde,
+    const Real& dP_tilde, const Real& rho, const Real& Theta, const Real& cs2,
+    const EMHD_parameters& emhd_params, Real& q, Real& dP)
+{}
 
 #else
 
 /**
  * Set chi, nu, tau. Problem dependent
  */
-KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Real& rho, const Real& u,
-                                            const Real& qtilde, const Real& dPtilde, const Real& bsq,
-                                            const EMHD_parameters& emhd_params, const Real& gam,
-                                            const int& j, const int& i,
-                                            Real& tau, Real& chi_e, Real& nu_e)
+KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Real& rho,
+    const Real& u, const Real& qtilde, const Real& dPtilde, const Real& bsq,
+    const EMHD_parameters& emhd_params, const Real& gam, const int& j, const int& i,
+    Real& tau, Real& chi_e, Real& nu_e)
 {
     // Formerly chi_e was only set if conduction was present, nu_e only if viscosity
     // Now assumes these will simply be unused if set when these effects are disabled
@@ -197,7 +199,7 @@ KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Real& r
         chi_e = emhd_params.conduction_alpha * cs2 * tau;
         nu_e = emhd_params.viscosity_alpha * cs2 * tau;
 
-    } else if (emhd_params.type == ClosureType::kappa_eta){
+    } else if (emhd_params.type == ClosureType::kappa_eta) {
         // Set tau = const, chi = kappa / rho, nu = eta / rho
         tau = emhd_params.tau;
         chi_e = emhd_params.kappa / m::max(rho, SMALL_NUM);
@@ -209,44 +211,46 @@ KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Real& r
         const GReal r = Xembed[1];
 
         // Compute dynamical time scale
-        const Real tau_dyn = m::sqrt(r*r*r);
+        const Real tau_dyn = m::sqrt(r * r * r);
         tau = tau_dyn;
 
-        const Real pg    = (gam - 1.) * u;
+        const Real pg = (gam - 1.) * u;
         const Real Theta = pg / rho;
         // Compute local sound speed, ensure it is defined and >0
         // Passing NaN disables an upper bound (TODO should we have one?)
-        const Real cs2 = clip(gam * pg / (rho + (gam * u)), SMALL_NUM, 0./0.);
+        const Real cs2 = clip(gam * pg / (rho + (gam * u)), SMALL_NUM, 0. / 0.);
 
         constexpr Real lambda = 0.01;
 
         // Correction due to heat conduction
         {
             const Real q = (emhd_params.higher_order_terms)
-                        ? qtilde * m::sqrt(rho * emhd_params.conduction_alpha * cs2 * Theta * Theta)
-                        : qtilde;
-            const Real q_max   = emhd_params.conduction_alpha * rho * cs2 * m::sqrt(cs2);
+                               ? qtilde * m::sqrt(rho * emhd_params.conduction_alpha *
+                                                  cs2 * Theta * Theta)
+                               : qtilde;
+            const Real q_max = emhd_params.conduction_alpha * rho * cs2 * m::sqrt(cs2);
             const Real q_ratio = m::abs(q) / q_max;
             const Real inv_exp_g = m::exp(-(q_ratio - 1.) / lambda);
-            const Real f_fmin    = inv_exp_g / (inv_exp_g + 1.) + 1.e-5;
+            const Real f_fmin = inv_exp_g / (inv_exp_g + 1.) + 1.e-5;
 
             tau = m::min(tau, f_fmin * tau_dyn);
         }
 
         // Correction due to pressure anisotropy
         {
-            const Real dP = (emhd_params.higher_order_terms)
-                        ? dPtilde * sqrt(rho * emhd_params.viscosity_alpha * cs2 * Theta)
-                        : dPtilde;
-            const Real dP_comp_ratio = m::max(pg - 2./3. * dP, SMALL_NUM) /
-                                       m::max(pg + 1./3. * dP, SMALL_NUM);
+            const Real dP =
+                (emhd_params.higher_order_terms)
+                    ? dPtilde * sqrt(rho * emhd_params.viscosity_alpha * cs2 * Theta)
+                    : dPtilde;
+            const Real dP_comp_ratio = m::max(pg - 2. / 3. * dP, SMALL_NUM) /
+                                       m::max(pg + 1. / 3. * dP, SMALL_NUM);
             const Real dP_max = (dP > 0.)
-                              ? m::min(0.5 * bsq * dP_comp_ratio, 1.49 * pg / 1.07)
-                              : m::max(-bsq, -2.99 * pg / 1.07);
+                                    ? m::min(0.5 * bsq * dP_comp_ratio, 1.49 * pg / 1.07)
+                                    : m::max(-bsq, -2.99 * pg / 1.07);
 
             const Real dP_ratio = m::abs(dP) / (m::abs(dP_max) + SMALL_NUM);
             const Real inv_exp_g = m::exp((1. - dP_ratio) / lambda);
-            const Real f_fmin    = inv_exp_g / (inv_exp_g + 1.) + 1.e-5;
+            const Real f_fmin = inv_exp_g / (inv_exp_g + 1.) + 1.e-5;
 
             tau = m::min(tau, f_fmin * tau_dyn);
         }
@@ -258,61 +262,64 @@ KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Real& r
     }
 }
 template<typename Local>
-KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Local& P, const VarMap& m_p,
-                                           const EMHD_parameters& emhd_params, const Real& gam,
-                                           const int& j, const int& i,
-                                           Real& tau, Real& chi_e, Real& nu_e)
+KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const Local& P,
+    const VarMap& m_p, const EMHD_parameters& emhd_params, const Real& gam, const int& j,
+    const int& i, Real& tau, Real& chi_e, Real& nu_e)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, j, i, Loci::center, Dtmp);
     double bsq = m::max(dot(Dtmp.bcon, Dtmp.bcov), SMALL_NUM);
     Real qtilde = (m_p.Q >= 0) ? P(m_p.Q) : 0.;
     Real dPtilde = (m_p.DP >= 0) ? P(m_p.DP) : 0.;
-    set_parameters(G, P(m_p.RHO), P(m_p.UU), qtilde, dPtilde,
-                    bsq, emhd_params, gam, j, i, tau, chi_e, nu_e);
+    set_parameters(G, P(m_p.RHO), P(m_p.UU), qtilde, dPtilde, bsq, emhd_params, gam, j, i,
+        tau, chi_e, nu_e);
 }
 
-KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                           const EMHD_parameters& emhd_params, const Real& gam,
-                                           const int& k, const int& j, const int& i,
-                                           Real& tau, Real& chi_e, Real& nu_e)
+KOKKOS_INLINE_FUNCTION void set_parameters(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const EMHD_parameters& emhd_params,
+    const Real& gam, const int& k, const int& j, const int& i, Real& tau, Real& chi_e,
+    Real& nu_e)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
     double bsq = m::max(dot(Dtmp.bcon, Dtmp.bcov), SMALL_NUM);
     Real qtilde = (m_p.Q >= 0) ? P(m_p.Q, k, j, i) : 0.;
     Real dPtilde = (m_p.DP >= 0) ? P(m_p.DP, k, j, i) : 0.;
-    set_parameters(G, P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), qtilde, dPtilde,
-                    bsq, emhd_params, gam, j, i, tau, chi_e, nu_e);
+    set_parameters(G, P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), qtilde, dPtilde, bsq,
+        emhd_params, gam, j, i, tau, chi_e, nu_e);
 }
 
 /**
  * Get a row of the EMHD stress-energy tensor with first index up, second index down.
  * A factor of m::sqrt(4 pi) is absorbed into the definition of b.
- * Note this must be passed the full q, dP, not the primitive prims.q, usually denote qtilde
+ * Note this must be passed the full q, dP, not the primitive prims.q, usually denote
+ * qtilde
  *
  * Entirely local!
  */
 KOKKOS_INLINE_FUNCTION void calc_tensor(const Real& rho, const Real& u, const Real& pgas,
-                                        const Real& q, const Real& dP,
-                                        const FourVectors& D, const int& dir,
-                                        Real emhd[GR_DIM])
+    const Real& q, const Real& dP, const FourVectors& D, const int& dir,
+    Real emhd[GR_DIM])
 {
-    const Real bsq  = m::max(dot(D.bcon, D.bcov), SMALL_NUM);
+    const Real bsq = m::max(dot(D.bcon, D.bcov), SMALL_NUM);
     const Real b_mag = m::sqrt(bsq);
-    const Real eta  = pgas + rho + u + bsq;
+    const Real eta = pgas + rho + u + bsq;
     const Real ptot = pgas + 0.5 * bsq;
 
-    DLOOP1 emhd[mu] = eta * D.ucon[dir] * D.ucov[mu] + ptot * (dir == mu) - D.bcon[dir] * D.bcov[mu]
-                    + (q / b_mag) * ((D.ucon[dir] * D.bcov[mu]) + (D.bcon[dir] * D.ucov[mu]))
-                    - dP * ((D.bcon[dir] * D.bcov[mu] / bsq) - (1./3.) * ((dir == mu) + D.ucon[dir] * D.ucov[mu]));
+    DLOOP1
+        emhd[mu] =
+            eta * D.ucon[dir] * D.ucov[mu] + ptot * (dir == mu) -
+            D.bcon[dir] * D.bcov[mu] +
+            (q / b_mag) * ((D.ucon[dir] * D.bcov[mu]) + (D.bcon[dir] * D.ucov[mu])) -
+            dP * ((D.bcon[dir] * D.bcov[mu] / bsq) -
+                     (1. / 3.) * ((dir == mu) + D.ucon[dir] * D.ucov[mu]));
 }
 
 // Convert q_tilde and dP_tilde (which are primitives) to q and dP
 // This is required because the stress-energy tensor depends on q and dP
-KOKKOS_INLINE_FUNCTION void convert_prims_to_q_dP(const Real& q_tilde, const Real& dP_tilde,
-                                        const Real& rho, const Real& Theta, const Real& cs2, 
-                                        const EMHD_parameters& emhd_params, Real& q, Real& dP)
+KOKKOS_INLINE_FUNCTION void convert_prims_to_q_dP(const Real& q_tilde,
+    const Real& dP_tilde, const Real& rho, const Real& Theta, const Real& cs2,
+    const EMHD_parameters& emhd_params, Real& q, Real& dP)
 {
     q = q_tilde;
     if (emhd_params.higher_order_terms) {

--- a/kharma/emhd/emhd_limits.hpp
+++ b/kharma/emhd/emhd_limits.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhd_limits.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -38,40 +38,43 @@
 #include "flux_functions.hpp"
 
 // Flags for the extended MHD limits
-// TODO(BSP) name/list and print like FFlag
-#define HIT_Q_LIMIT      1
+// TODO(CEP) name/list and print like FFlag
+#define HIT_Q_LIMIT 1
 #define HIT_DP_MAX_LIMIT 2
 #define HIT_DP_MIN_LIMIT 4
 
-namespace EMHD {
+namespace EMHD
+{
 
 /**
  * Apply limits on the Extended MHD variables
- * 
- * @return elag, a bitflag indicating whether each particular limit was hit, allowing representation of arbitrary combinations
- * See decs.h for bit names.
- * 
- * The maximum heat flux is limited by the saturated value given by a hot cloud in cold gas.
- * The bounds on the pressure anisotropy as due to the mirror and firehose instability limits.
- * 
- * Although only q, dP are updated here, prim_to_flux updates all conserved. 
- * This shouldn't be an issue though since PtoU in analytic and will result in the same value for the ideal MHD variables.
+ *
+ * @return elag, a bitflag indicating whether each particular limit was hit, allowing
+ * representation of arbitrary combinations See decs.h for bit names.
+ *
+ * The maximum heat flux is limited by the saturated value given by a hot cloud in cold
+ * gas. The bounds on the pressure anisotropy as due to the mirror and firehose
+ * instability limits.
+ *
+ * Although only q, dP are updated here, prim_to_flux updates all conserved.
+ * This shouldn't be an issue though since PtoU in analytic and will result in the same
+ * value for the ideal MHD variables.
  */
-KOKKOS_INLINE_FUNCTION int apply_instability_limits(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                          const Real& gam, const EMHD::EMHD_parameters& emhd_params, 
-                                          const int& k, const int& j, const int& i,
-                                          const VariablePack<Real>& U, const VarMap& m_u, const Loci loc=Loci::center)
+KOKKOS_INLINE_FUNCTION int apply_instability_limits(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const Real& gam,
+    const EMHD::EMHD_parameters& emhd_params, const int& k, const int& j, const int& i,
+    const VariablePack<Real>& U, const VarMap& m_u, const Loci loc = Loci::center)
 {
     int eflag = 0;
 
-    Real rho      = P(m_p.RHO, k, j, i);
-    Real uu       = P(m_p.UU, k, j, i);
-    Real qtilde  = (m_p.Q >= 0) ? P(m_p.Q, k, j, i) : 0.;
+    Real rho = P(m_p.RHO, k, j, i);
+    Real uu = P(m_p.UU, k, j, i);
+    Real qtilde = (m_p.Q >= 0) ? P(m_p.Q, k, j, i) : 0.;
     Real dPtilde = (m_p.DP >= 0) ? P(m_p.DP, k, j, i) : 0.;
 
-    Real pg    = (gam - 1.) * uu;
+    Real pg = (gam - 1.) * uu;
     Real Theta = pg / rho;
-    Real cs    = m::sqrt(gam * pg / (rho + (gam * uu)));
+    Real cs = m::sqrt(gam * pg / (rho + (gam * uu)));
 
     FourVectors D;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, D);
@@ -81,7 +84,7 @@ KOKKOS_INLINE_FUNCTION int apply_instability_limits(const GRCoordinates& G, cons
     EMHD::set_parameters(G, P, m_p, emhd_params, gam, k, j, i, tau, chi_e, nu_e);
 
     Real q, dP;
-    EMHD::convert_prims_to_q_dP(qtilde, dPtilde, rho, Theta, cs*cs, emhd_params, q, dP);
+    EMHD::convert_prims_to_q_dP(qtilde, dPtilde, rho, Theta, cs * cs, emhd_params, q, dP);
 
     // if (i==128 && j==128) {
     //     printf("\n---INSTABILITY LIMITS---\n");
@@ -92,35 +95,34 @@ KOKKOS_INLINE_FUNCTION int apply_instability_limits(const GRCoordinates& G, cons
     // }
 
     if (m_p.Q >= 0) {
-        Real qmax         = 1.07 * rho * cs*cs*cs;
-        Real max_frac     = m::max(m::abs(q) / qmax, 1.);
-        if (m::abs(q) / qmax > 1.)
-            eflag |= HIT_Q_LIMIT;
+        Real qmax = 1.07 * rho * cs * cs * cs;
+        Real max_frac = m::max(m::abs(q) / qmax, 1.);
+        if (m::abs(q) / qmax > 1.) eflag |= HIT_Q_LIMIT;
 
         P(m_p.Q, k, j, i) = P(m_p.Q, k, j, i) / max_frac;
     }
 
     if (m_p.DP >= 0) {
 
-        Real dP_comp_ratio = m::max(pg - 2./3. * dP, SMALL_NUM) / m::max(pg + 1./3. * dP, SMALL_NUM);
-        Real dP_plus       = m::min(1.07 * 0.5 * bsq * dP_comp_ratio, 1.49 * pg);
-        Real dP_minus      = m::max(-1.07 * bsq, -2.99 * pg);
+        Real dP_comp_ratio =
+            m::max(pg - 2. / 3. * dP, SMALL_NUM) / m::max(pg + 1. / 3. * dP, SMALL_NUM);
+        Real dP_plus = m::min(1.07 * 0.5 * bsq * dP_comp_ratio, 1.49 * pg);
+        Real dP_minus = m::max(-1.07 * bsq, -2.99 * pg);
 
         if (dP > 0. && (dP / dP_plus > 1.))
             eflag |= HIT_DP_MAX_LIMIT;
         else if (dP < 0. && (dP / dP_minus > 1.))
             eflag |= HIT_DP_MIN_LIMIT;
-        
+
         if (dP > 0.)
             P(m_p.DP, k, j, i) = P(m_p.DP, k, j, i) * (1. / m::max(dP / dP_plus, 1.));
         else
             P(m_p.DP, k, j, i) = P(m_p.DP, k, j, i) * (1. / m::max(dP / dP_minus, 1.));
-
     }
 
     Flux::p_to_u(G, P, m_p, emhd_params, gam, k, j, i, U, m_u);
 
     return eflag;
-}    
+}
 
 } // EMHD

--- a/kharma/emhd/emhd_sources.hpp
+++ b/kharma/emhd/emhd_sources.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhd_sources.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,22 +44,20 @@
  * Explicit terms are added in emhd.cpp
  */
 
-namespace EMHD {
+namespace EMHD
+{
 
 /**
  * Implicit source terms for EMHD, evaluated during implicit step calculation
  */
 template<typename Global>
-KOKKOS_INLINE_FUNCTION void implicit_sources(const GRCoordinates& G, const Global& P, const VarMap& m_p,
-                                             const Real& gam, const Real& tau,
-                                             const int& k, const int& j, const int& i,
-                                             Real& dUq, Real& dUdP)
+KOKKOS_INLINE_FUNCTION void implicit_sources(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const Real& gam, const Real& tau, const int& k, const int& j,
+    const int& i, Real& dUq, Real& dUdP)
 {
     // These are intentionally the tilde versions!
-    if (m_p.Q >= 0)
-        dUq = -G.gdet(Loci::center, j, i) * (P(m_p.Q, k, j, i) / tau);
-    if (m_p.DP >= 0)
-        dUdP = -G.gdet(Loci::center, j, i) * (P(m_p.DP, k, j, i) / tau);
+    if (m_p.Q >= 0) dUq = -G.gdet(Loci::center, j, i) * (P(m_p.Q, k, j, i) / tau);
+    if (m_p.DP >= 0) dUdP = -G.gdet(Loci::center, j, i) * (P(m_p.DP, k, j, i) / tau);
 }
 
 /**
@@ -67,14 +65,11 @@ KOKKOS_INLINE_FUNCTION void implicit_sources(const GRCoordinates& G, const Globa
  * gamma, j, i,
  */
 template<typename Global>
-KOKKOS_INLINE_FUNCTION void time_derivative_sources(const GRCoordinates& G, const Global& P_new,
-                                                    const Global& P_old, const Global& P,
-                                                    const VarMap& m_p,
-                                                    const Real& tau, const Real& chi_e, const Real& nu_e,
-                                                    const FourVectors &D, const bool& higher_order_terms,
-                                                    const Real& gam, const Real& dt, 
-                                                    const int & k, const int& j, const int& i,
-                                                    Real& dUq, Real& dUdP)
+KOKKOS_INLINE_FUNCTION void time_derivative_sources(const GRCoordinates& G,
+    const Global& P_new, const Global& P_old, const Global& P, const VarMap& m_p,
+    const Real& tau, const Real& chi_e, const Real& nu_e, const FourVectors& D,
+    const bool& higher_order_terms, const Real& gam, const Real& dt, const int& k,
+    const int& j, const int& i, Real& dUq, Real& dUdP)
 {
     double bsq = m::max(dot(D.bcon, D.bcov), SMALL_NUM);
     const double mag_b = m::sqrt(bsq);
@@ -86,38 +81,44 @@ KOKKOS_INLINE_FUNCTION void time_derivative_sources(const GRCoordinates& G, cons
     GRMHD::calc_ucon(G, P_new, m_p, k, j, i, Loci::center, ucon);
     G.lower(ucon, ucov_new, k, j, i, Loci::center);
     Real dt_ucov[GR_DIM];
-    DLOOP1 dt_ucov[mu] = (ucov_new[mu] - ucov_old[mu]) / dt;
+    DLOOP1
+        dt_ucov[mu] = (ucov_new[mu] - ucov_old[mu]) / dt;
 
     // Compute div of ucon (only the temporal part is nonzero)
-    Real div_ucon    = 0;
-    DLOOP1 div_ucon += G.gcon(Loci::center, j, i, 0, mu) * dt_ucov[mu];
+    Real div_ucon = 0;
+    DLOOP1
+        div_ucon += G.gcon(Loci::center, j, i, 0, mu) * dt_ucov[mu];
     // dTheta/dt
-    const Real Theta_new = m::max((gam-1) * P_new(m_p.UU, k, j, i) / P_new(m_p.RHO, k, j, i), SMALL_NUM);
-    const Real Theta_old = m::max((gam-1) * P_old(m_p.UU, k, j, i) / P_old(m_p.RHO, k, j, i), SMALL_NUM);
-    const Real dt_Theta  = (Theta_new - Theta_old) / dt;
+    const Real Theta_new =
+        m::max((gam - 1) * P_new(m_p.UU, k, j, i) / P_new(m_p.RHO, k, j, i), SMALL_NUM);
+    const Real Theta_old =
+        m::max((gam - 1) * P_old(m_p.UU, k, j, i) / P_old(m_p.RHO, k, j, i), SMALL_NUM);
+    const Real dt_Theta = (Theta_new - Theta_old) / dt;
 
     // TEMPORAL SOURCE TERMS
-    const Real& rho     = P(m_p.RHO, k, j, i);
-    const Real& Theta   = (gam-1) * P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
+    const Real& rho = P(m_p.RHO, k, j, i);
+    const Real& Theta = (gam - 1) * P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
 
     if (m_p.Q >= 0) {
-        const Real& qtilde  = P(m_p.Q, k, j, i);
-        Real q0             = -rho * chi_e * (D.bcon[0] / mag_b) * dt_Theta;
-        DLOOP1 q0          -= rho * chi_e * (D.bcon[mu] / mag_b) * Theta * D.ucon[0] * dt_ucov[mu];
-        Real q0_tilde       = q0;
+        const Real& qtilde = P(m_p.Q, k, j, i);
+        Real q0 = -rho * chi_e * (D.bcon[0] / mag_b) * dt_Theta;
+        DLOOP1
+            q0 -= rho * chi_e * (D.bcon[mu] / mag_b) * Theta * D.ucon[0] * dt_ucov[mu];
+        Real q0_tilde = q0;
         if (higher_order_terms)
             q0_tilde *= (chi_e != 0) ? m::sqrt(tau / (chi_e * rho * Theta * Theta)) : 0.0;
 
-        dUq  = G.gdet(Loci::center, j, i) * (q0_tilde / tau);
+        dUq = G.gdet(Loci::center, j, i) * (q0_tilde / tau);
         if (higher_order_terms)
             dUq += G.gdet(Loci::center, j, i) * (qtilde / 2.) * div_ucon;
     }
 
     if (m_p.DP >= 0) {
         const Real& dPtilde = P(m_p.DP, k, j, i);
-        Real dP0            = -rho * nu_e * div_ucon;
-        DLOOP1 dP0         += 3. * rho * nu_e * (D.bcon[0] * D.bcon[mu] / bsq) * dt_ucov[mu];
-        Real dP0_tilde      = dP0;
+        Real dP0 = -rho * nu_e * div_ucon;
+        DLOOP1
+            dP0 += 3. * rho * nu_e * (D.bcon[0] * D.bcon[mu] / bsq) * dt_ucov[mu];
+        Real dP0_tilde = dP0;
         if (higher_order_terms)
             dP0_tilde *= (nu_e != 0) ? m::sqrt(tau / (nu_e * rho * Theta)) : 0.0;
 

--- a/kharma/emhd/emhd_utils.hpp
+++ b/kharma/emhd/emhd_utils.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhd.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,40 +42,46 @@ using KReconstruction::slope_calc;
 /**
  * Utilities for the EMHD source terms, things we might conceivably use somewhere else,
  * or use *from* somewhere else instead of here.
- * 
+ *
  * 1. Slopes at faces using various linear reconstructions.  Since this is unrelated to
- *    reconstructing all prims, and only called zone-wise, the "same" recon algos are reimplemented here
- * 2. Calculate gradient of each component of ucov & 
+ *    reconstructing all prims, and only called zone-wise, the "same" recon algos are
+ * reimplemented here
+ * 2. Calculate gradient of each component of ucov &
  */
 
-namespace EMHD {
+namespace EMHD
+{
 
 // Compute gradient of four velocities and temperature
 // Called by emhd_explicit_sources
 template<KReconstruction::Type recon>
-KOKKOS_INLINE_FUNCTION void gradient_calc(const GRCoordinates& G, const VariablePack<Real>& Temps,
-                                          const int& uvec_index, const int& theta_index,
-                                          const int& b, const int& k, const int& j, const int& i, 
-                                          const bool& do_3d, const bool& do_2d,
-                                          Real grad_ucov[GR_DIM][GR_DIM], Real grad_Theta[GR_DIM])
+KOKKOS_INLINE_FUNCTION void gradient_calc(const GRCoordinates& G,
+    const VariablePack<Real>& Temps, const int& uvec_index, const int& theta_index,
+    const int& b, const int& k, const int& j, const int& i, const bool& do_3d,
+    const bool& do_2d, Real grad_ucov[GR_DIM][GR_DIM], Real grad_Theta[GR_DIM])
 {
     // Compute gradient of ucov
     DLOOP1 {
         grad_ucov[0][mu] = 0;
         // slope in direction nu of component mu
         grad_ucov[1][mu] = slope_calc<recon, X1DIR>(G, Temps, uvec_index + mu, k, j, i);
-        grad_ucov[2][mu] = (do_2d) ? slope_calc<recon, X2DIR>(G, Temps, uvec_index + mu, k, j, i) : 0.;
-        grad_ucov[3][mu] = (do_3d) ? slope_calc<recon, X3DIR>(G, Temps, uvec_index + mu, k, j, i) : 0.;
+        grad_ucov[2][mu] =
+            (do_2d) ? slope_calc<recon, X2DIR>(G, Temps, uvec_index + mu, k, j, i) : 0.;
+        grad_ucov[3][mu] =
+            (do_3d) ? slope_calc<recon, X3DIR>(G, Temps, uvec_index + mu, k, j, i) : 0.;
     }
     // TODO skip this if flat space?
-    DLOOP3 grad_ucov[mu][nu] -= G.conn(j, i, lam, mu, nu) * Temps(uvec_index + lam, k, j, i);
+    DLOOP3
+        grad_ucov[mu][nu] -= G.conn(j, i, lam, mu, nu) * Temps(uvec_index + lam, k, j, i);
 
     // Compute temperature gradient
     // Time derivative component is computed in time_derivative_sources
     grad_Theta[0] = 0;
     grad_Theta[1] = slope_calc<recon, X1DIR>(G, Temps, theta_index, k, j, i);
-    grad_Theta[2] = (do_2d) ? slope_calc<recon, X2DIR>(G, Temps, theta_index, k, j, i) : 0.;
-    grad_Theta[3] = (do_3d) ? slope_calc<recon, X3DIR>(G, Temps, theta_index, k, j, i) : 0.;
+    grad_Theta[2] =
+        (do_2d) ? slope_calc<recon, X2DIR>(G, Temps, theta_index, k, j, i) : 0.;
+    grad_Theta[3] =
+        (do_3d) ? slope_calc<recon, X3DIR>(G, Temps, theta_index, k, j, i) : 0.;
 }
 
 } // namespace EMHD

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: floors.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,15 +43,17 @@
 
 // Floors.  Apply limits to fluid values to maintain integrable state
 
-int Floors::CountFFlags(MeshData<Real> *md)
+int Floors::CountFFlags(MeshData<Real>* md)
 {
-    return Reductions::CountFlags(md, "fflag", FFlag::flag_names, IndexDomain::interior, true)[0];
+    return Reductions::CountFlags(
+        md, "fflag", FFlag::flag_names, IndexDomain::interior, true)[0];
 }
 
-std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Floors::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Floors");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Parse all the particular floor values into a nice struct we can pass device-side
     params.Add("prescription", MakePrescription(pin));
@@ -60,12 +62,14 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // the option exists to use the fluid frame exclusively 'fluid' or outside a
     // certain radius 'mixed'. This option adds fluid at speed, making results
     // less reliable but velocity reconstructions potentially more robust.
-    // Drift frame floors are now available and preferred when using 
+    // Drift frame floors are now available and preferred when using
     // the implicit solver to avoid UtoP calls.
-    // TODO(BSP) automate/standardize parsing enums like this: classes w/tables like the flags?
-    std::vector<std::string> allowed_floor_frames = {"normal", "fluid", "mixed",
-                                                     "mixed_fluid_normal", "mixed_normal_drift", "drift"};
-    std::string frame_s = pin->GetOrAddString("floors", "frame", "normal", allowed_floor_frames);
+    // TODO(CEP) automate/standardize parsing enums like this: classes w/tables like the
+    // flags?
+    std::vector<std::string> allowed_floor_frames = {
+        "normal", "fluid", "mixed", "mixed_fluid_normal", "mixed_normal_drift", "drift"};
+    std::string frame_s =
+        pin->GetOrAddString("floors", "frame", "normal", allowed_floor_frames);
     InjectionFrame frame;
     if (frame_s == "normal") {
         if (pin->DoesBlockExist("inverter") &&
@@ -86,15 +90,20 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     }
     params.Add("frame", frame);
 
-    // New inverter w/recovery only supports normal frame floors. Yell about it, but allow overriding
+    // New inverter w/recovery only supports normal frame floors. Yell about it, but allow
+    // overriding
     if (pin->DoesBlockExist("inverter") &&
         pin->GetString("inverter", "type") == "kastaun" &&
         frame != InjectionFrame::normal_kastaun) {
         if (!pin->GetOrAddBoolean("floors", "allow_unsafe", false)) {
-            std::cout << "With version 2025.10, KHARMA dramatically changed how floors are applied.\n"
-                      << "The resulting algorithm is much more stable, but requires that floors be applied in the normal observer frame.\n"
-                      << "Consider using the <floors> parameters from pars/tori_3d/mad.par.\n"
-                      << "If you know what you're doing, set floors/allow_unsafe=true";
+            std::cout
+                << "With version 2025.10, KHARMA dramatically changed how floors are "
+                   "applied.\n"
+                << "The resulting algorithm is much more stable, but requires that "
+                   "floors "
+                   "be applied in the normal observer frame.\n"
+                << "Consider using the <floors> parameters from pars/tori_3d/mad.par.\n"
+                << "If you know what you're doing, set floors/allow_unsafe=true";
             throw std::runtime_error("Unsafe floors requested without override");
         }
     }
@@ -116,33 +125,38 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // the values will simply be the same if radius-dependent floors are not enabled.
     // Avoids a bunch of if (radius_dependent_floors) else while determining floors.
     if (pin->DoesBlockExist("floors_inner"))
-        params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
+        params.Add(
+            "prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)));
     else
-        params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)), "floors");
+        params.Add("prescription_inner",
+            MakePrescriptionInner(pin, MakePrescription(pin)), "floors");
 
     // Sometimes we want the floors package, but don't want to apply anything, for tests
     bool disable_call = pin->GetOrAddBoolean("floors", "disable_call", false);
     params.Add("disable_call", disable_call);
 
-    // These preserve floor values between the "mark" pass and the actual floor application
-    // We need them even if floors are disabled, to apply initial values based on some prescription
-    // as a part of problem setup
-    Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+    // These preserve floor values between the "mark" pass and the actual floor
+    // application We need them even if floors are disabled, to apply initial values based
+    // on some prescription as a part of problem setup
+    Metadata m =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
     pkg->AddField("Floors.rho_floor", m);
     pkg->AddField("Floors.u_floor", m);
 
     // Flag for which floor conditions were violated.  Used for diagnostics
-    // TODO(BSP) Should switch these to "Integer" fields when Parthenon supports it
+    // TODO(CEP) Should switch these to "Integer" fields when Parthenon supports it
     pkg->AddField("fflag", m);
-    // When not using UtoP, we still need a "dummy" copy of pflag to write the post-flooring flag to
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Overridable});
+    // When not using UtoP, we still need a "dummy" copy of pflag to write the
+    // post-flooring flag to
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy,
+        Metadata::Overridable});
     pkg->AddField("pflag", m);
 
     // Don't actually call the usual floor function if we're using normal frame w/Kastaun,
     // floors will be applied during the inversion call.
     // Also allow manually disabling the call, for testing
     if (!disable_call && frame != InjectionFrame::normal_kastaun) {
-        // TODO(BSP) THIS IS THE ONLY MeshApplyFloors.  Any others will NOT BE CALLED.
+        // TODO(CEP) THIS IS THE ONLY MeshApplyFloors.  Any others will NOT BE CALLED.
         // Use BlockApplyFloors in your packages or fix Packages::MeshApplyFloors
         pkg->MeshApplyFloors = Floors::ApplyGRMHDFloors;
     }
@@ -151,24 +165,29 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
     // Count total floors as a history item
-    hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, CountFFlags, "FFlags"));
+    hst_vars.emplace_back(
+        parthenon::HistoryOutputVar(UserHistoryOperation::sum, CountFFlags, "FFlags"));
     // TODO Domain::entire version?
     // TODO entries for each individual flag?
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     return pkg;
 }
 
-TaskStatus Floors::ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *mbd, IndexDomain domain)
+TaskStatus Floors::ApplyInitialFloors(
+    ParameterInput* pin, MeshBlockData<Real>* mbd, IndexDomain domain)
 {
     Flag("ApplyInitialFloors");
 
     auto pmb = mbd->GetBlockPointer();
 
     PackIndexMap prims_map, cons_map;
-    auto P = mbd->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    auto U = mbd->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    auto P = mbd->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+    auto U = mbd->PackVariables(
+        std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
     const auto& G = pmb->coords;
@@ -179,25 +198,26 @@ TaskStatus Floors::ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *
     // Otherwise stick to specified/default geometric floors
     Floors::Prescription floors_tmp;
     if (pmb->packages.AllPackages().count("Floors")) {
-        floors_tmp = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+        floors_tmp =
+            pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
     } else {
         // JUST rho & u geometric
         floors_tmp.rho_min_geom = pin->GetOrAddReal("floors", "rho_min_geom", 1e-6);
-        floors_tmp.u_min_geom   = pin->GetOrAddReal("floors", "u_min_geom", 1e-8);
+        floors_tmp.u_min_geom = pin->GetOrAddReal("floors", "u_min_geom", 1e-8);
         floors_tmp.rho_min_const = pin->GetOrAddReal("floors", "rho_min_const", 1e-20);
-        floors_tmp.u_min_const   = pin->GetOrAddReal("floors", "u_min_const", 1e-20);
+        floors_tmp.u_min_const = pin->GetOrAddReal("floors", "u_min_const", 1e-20);
 
         // Disable everything else, even if it's specified
         floors_tmp.bsq_over_rho_max = 1e20;
-        floors_tmp.bsq_over_u_max   = 1e20;
-        floors_tmp.u_over_rho_max   = 1e20;
-        floors_tmp.ktot_max         = 1e20;
-        floors_tmp.gamma_max        = 1e20;
+        floors_tmp.bsq_over_u_max = 1e20;
+        floors_tmp.u_over_rho_max = 1e20;
+        floors_tmp.ktot_max = 1e20;
+        floors_tmp.gamma_max = 1e20;
 
-        floors_tmp.use_r_char    = false;
-        floors_tmp.r_char        = 0.; //unused
+        floors_tmp.use_r_char = false;
+        floors_tmp.r_char = 0.; // unused
         floors_tmp.temp_adjust_u = false;
-        floors_tmp.adjust_k      = false;
+        floors_tmp.adjust_k = false;
     }
     const Floors::Prescription floors = floors_tmp;
 
@@ -205,37 +225,43 @@ TaskStatus Floors::ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *
 
     const IndexRange3 b = KDomain::GetRange(mbd, domain);
     pmb->par_for("apply_initial_floors", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real rhoflr_max, uflr_max;
-            // Initial floors, so the radius-dependence of floors don't matter that much. 
-            int fflag = determine_floors(G, P, m_p, gam, k, j, i, floors, floors, rhoflr_max, uflr_max);
+            // Initial floors, so the radius-dependence of floors don't matter
+            // that much.
+            int fflag = determine_floors(
+                G, P, m_p, gam, k, j, i, floors, floors, rhoflr_max, uflr_max);
             if (fflag) {
-                apply_floors<InjectionFrame::fluid>(G, P, m_p, gam, k, j, i, rhoflr_max, uflr_max, U, m_u);
+                apply_floors<InjectionFrame::fluid>(
+                    G, P, m_p, gam, k, j, i, rhoflr_max, uflr_max, U, m_u);
                 apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors, U, m_u);
                 // P->U for any modified zones
-                Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, j, i, U, m_u, Loci::center);
+                Flux::p_to_u_mhd(
+                    G, P, m_p, emhd_params, gam, k, j, i, U, m_u, Loci::center);
             }
-        }
-    );
+        });
 
     EndFlag();
     return TaskStatus::complete;
 }
 
-TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
+TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real>* md, IndexDomain domain,
     const Floors::Prescription& floors, const Floors::Prescription& floors_inner)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
     // Packs of prims and cons
     PackIndexMap prims_map;
-    auto& P = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto& P = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
     const VarMap m_p(prims_map, false);
 
     auto fflag = md->PackVariables(std::vector<std::string>{"fflag"});
     auto pflag = md->PackVariables(std::vector<std::string>{"pflag"});
     PackIndexMap floors_map;
-    auto floor_vals = md->PackVariables(std::vector<std::string>{"Floors.rho_floor", "Floors.u_floor"}, floors_map);
+    auto floor_vals = md->PackVariables(
+        std::vector<std::string>{"Floors.rho_floor", "Floors.u_floor"}, floors_map);
     const int rhofi = floors_map["Floors.rho_floor"].first;
     const int ufi = floors_map["Floors.u_floor"].first;
 
@@ -243,30 +269,35 @@ TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
 
     const IndexRange3 b = KDomain::GetRange(md, domain);
     const IndexRange block = IndexRange{0, P.GetDim(5) - 1};
-    pmb0->par_for("determine_floors", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("determine_floors", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is,
+        b.ie,
+                  KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = P.GetCoords(b);
-            // The inverter might have set some floor flags, so we add to that non-destructively
-            fflag(b, 0, k, j, i) = static_cast<int>(fflag(b, 0, k, j, i)) |
-                                    determine_floors(G, P(b), m_p, gam, k, j, i, floors, floors_inner,
-                                                     floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i));
-        }
-    );
+            // The inverter might have set some floor flags, so we add to that
+            // non-destructively
+            fflag(b, 0, k, j, i) =
+                static_cast<int>(fflag(b, 0, k, j, i)) |
+                determine_floors(G, P(b), m_p, gam, k, j, i, floors, floors_inner,
+                    floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i));
+        });
 
-    // TODO(BSP) if we can somehow guarantee one call/rank we can start the reduction here
-    //Reductions::StartFlagReduce(md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
+    // TODO(CEP) if we can somehow guarantee one call/rank we can start the reduction here
+    // Reductions::StartFlagReduce(md, "fflag", FFlag::flag_names, IndexDomain::interior,
+    // true, 0);
 
     return TaskStatus::complete;
 }
 
-TaskStatus Floors::ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain)
+TaskStatus Floors::ApplyGRMHDFloors(MeshData<Real>* md, IndexDomain domain)
 {
     auto pmesh = md->GetMeshPointer();
     const auto& pars = pmesh->packages.Get("Floors")->AllParams();
 
     // Determine floors
     const Floors::Prescription floors = pars.Get<Floors::Prescription>("prescription");
-    const Floors::Prescription floors_inner = pars.Get<Floors::Prescription>("prescription_inner");
+    const Floors::Prescription floors_inner =
+        pars.Get<Floors::Prescription>("prescription_inner");
     DetermineGRMHDFloors(md, domain, floors, floors_inner);
 
     if (pars.Get<InjectionFrame>("frame") == InjectionFrame::normal_kastaun) {
@@ -286,7 +317,7 @@ TaskStatus Floors::ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain)
     }
 }
 
-TaskStatus Floors::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+TaskStatus Floors::PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -296,9 +327,11 @@ TaskStatus Floors::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
 
     // Debugging/diagnostic info about floor flags
     if (flag_verbose > 0) {
-        Reductions::StartFlagReduce(md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
+        Reductions::StartFlagReduce(
+            md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
         // Debugging/diagnostic info about floor and inversion flags
-        Reductions::CheckFlagReduceAndPrintHits(md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
+        Reductions::CheckFlagReduceAndPrintHits(
+            md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
     }
 
     // Anything else (energy conservation? Added material stats?)

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: floors.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,18 +37,20 @@
 #include "types.hpp"
 
 #include "b_flux_ct.hpp"
+#include "emhd.hpp"
 #include "flux_functions.hpp"
 #include "grmhd_functions.hpp"
-#include "emhd.hpp"
 #include "reductions.hpp"
 
-namespace Floors {
+namespace Floors
+{
 
-namespace FFlag {
+namespace FFlag
+{
 // Floor codes are non-exclusive, so it makes little sense to use an enum
-// Instead, we use bitflags, starting high enough that we can stick the pflag in the bottom 5 bits
-// See floors.hpp for explanations of the flags
-// This is the namespaced, typed equivalent of #define
+// Instead, we use bitflags, starting high enough that we can stick the pflag in the
+// bottom 5 bits See floors.hpp for explanations of the flags This is the namespaced,
+// typed equivalent of #define
 static constexpr int GEOM_RHO = 32;
 static constexpr int GEOM_U = 64;
 static constexpr int B_RHO = 128;
@@ -73,51 +75,51 @@ static constexpr int MINIMUM = GEOM_RHO;
 // TODO
 // 1. prettier names?
 // 2. What deep majicks would allow this to be constexpr?
-static const std::map<int, std::string> flag_names = {
-    {GEOM_RHO, "GEOM_RHO"},
-    {GEOM_U, "GEOM_U"},
-    {B_RHO, "B_RHO"},
-    {B_U, "B_U"},
-    {GAMMA, "GAMMA"},
-    {TEMP, "TEMPERATURE"},
-    {KTOT, "ENTROPY"},
-    {GEOM_RHO_FLUX, "GEOM_RHO_ON_RECON"},
-    {GEOM_U_FLUX, "GEOM_U_ON_RECON"},
-    {INVERTER_RHO, "GEOM_RHO_ON_INVERT"},
-    {INVERTER_U, "GEOM_U_ON_INVERT"},
-    {INVERTER_GAMMA, "GAMMA_ON_INVERT"},
-    {INVERTER_U_MAX, "U_MAX_ON_INVERT"}
-};
+static const std::map<int, std::string> flag_names = {{GEOM_RHO, "GEOM_RHO"},
+    {GEOM_U, "GEOM_U"}, {B_RHO, "B_RHO"}, {B_U, "B_U"}, {GAMMA, "GAMMA"},
+    {TEMP, "TEMPERATURE"}, {KTOT, "ENTROPY"}, {GEOM_RHO_FLUX, "GEOM_RHO_ON_RECON"},
+    {GEOM_U_FLUX, "GEOM_U_ON_RECON"}, {INVERTER_RHO, "GEOM_RHO_ON_INVERT"},
+    {INVERTER_U, "GEOM_U_ON_INVERT"}, {INVERTER_GAMMA, "GAMMA_ON_INVERT"},
+    {INVERTER_U_MAX, "U_MAX_ON_INVERT"}};
 }
 
-enum class InjectionFrame{fluid=0, normal_onedw, normal_kastaun, mixed_fluid_normal, mixed_normal_drift, drift};
+enum class InjectionFrame {
+    fluid = 0,
+    normal_onedw,
+    normal_kastaun,
+    mixed_fluid_normal,
+    mixed_normal_drift,
+    drift
+};
 
 /**
  * Struct to hold floor values without cumbersome dictionary/string logistics.
  * Hopefully faster than dragging the full Params object device side,
  * similar reasoning to VarMap.
  */
-class Prescription {
-    public:
-        // Constant sanity limits
-        Real rho_min_const, u_min_const;
-        // Purely geometric limits
-        Real rho_min_geom, u_min_geom, r_char, floors_switch_r;
-        // Dynamic limits on magnetization/temperature
-        Real bsq_over_rho_max, bsq_over_u_max, u_over_rho_max;
-        // Limit entropy
-        Real ktot_max;
-        // Limit fluid Lorentz factor
-        Real gamma_max;
-        // Floor options (frame was MOVED to templating)
-        bool use_r_char, temp_adjust_u, adjust_k;
-        // Radius dependent floors?
-        bool radius_dependent_floors;
-        // Add density to respect the gamma ceiling?
-        bool use_rho_to_slow;
+class Prescription
+{
+  public:
+    // Constant sanity limits
+    Real rho_min_const, u_min_const;
+    // Purely geometric limits
+    Real rho_min_geom, u_min_geom, r_char, floors_switch_r;
+    // Dynamic limits on magnetization/temperature
+    Real bsq_over_rho_max, bsq_over_u_max, u_over_rho_max;
+    // Limit entropy
+    Real ktot_max;
+    // Limit fluid Lorentz factor
+    Real gamma_max;
+    // Floor options (frame was MOVED to templating)
+    bool use_r_char, temp_adjust_u, adjust_k;
+    // Radius dependent floors?
+    bool radius_dependent_floors;
+    // Add density to respect the gamma ceiling?
+    bool use_rho_to_slow;
 };
 
-inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string block="floors")
+inline Prescription MakePrescription(
+    parthenon::ParameterInput* pin, std::string block = "floors")
 {
     Prescription p;
     // Floor parameters
@@ -130,11 +132,14 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
         p.u_min_const = pin->GetOrAddReal(block, "u_min_const", 1.e-20);
     } else { // TODO spherical cart will also have both
         // Accept old names
-        Real rho_min_const_default = pin->DoesParameterExist(block, "rho_min_geom") ?
-                                        pin->GetReal(block, "rho_min_geom") : 1.e-8;
-        Real u_min_const_default = pin->DoesParameterExist(block, "u_min_geom") ?
-                                    pin->GetReal(block, "u_min_geom") : 1.e-10;
-        p.rho_min_const = pin->GetOrAddReal(block, "rho_min_const", rho_min_const_default);
+        Real rho_min_const_default = pin->DoesParameterExist(block, "rho_min_geom")
+                                         ? pin->GetReal(block, "rho_min_geom")
+                                         : 1.e-8;
+        Real u_min_const_default = pin->DoesParameterExist(block, "u_min_geom")
+                                       ? pin->GetReal(block, "u_min_geom")
+                                       : 1.e-10;
+        p.rho_min_const =
+            pin->GetOrAddReal(block, "rho_min_const", rho_min_const_default);
         p.u_min_const = pin->GetOrAddReal(block, "u_min_const", u_min_const_default);
     }
 
@@ -161,7 +166,8 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
     // Limit the fluid Lorentz factor gamma
     p.gamma_max = pin->GetOrAddReal(block, "gamma_max", 50.);
 
-    p.radius_dependent_floors = pin->GetOrAddBoolean("floors", "radius_dependent_floors", false); 
+    p.radius_dependent_floors =
+        pin->GetOrAddBoolean("floors", "radius_dependent_floors", false);
     p.floors_switch_r = pin->GetOrAddReal("floors", "floors_switch_r", 50.);
 
     p.use_rho_to_slow = pin->GetOrAddBoolean("floors", "use_rho_to_slow", false);
@@ -170,48 +176,62 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
 }
 
 /**
- * Set prescription struct for inner domain (r < floor_switch_r) if 'radius_dependent_floors' is enabled.
- * Sets values provided in the 'floors_inner' block in input par file if provided,
- * else sets it equal to the values in the whole/outer domain.
+ * Set prescription struct for inner domain (r < floor_switch_r) if
+ * 'radius_dependent_floors' is enabled. Sets values provided in the 'floors_inner' block
+ * in input par file if provided, else sets it equal to the values in the whole/outer
+ * domain.
  */
-inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescription p_outer, std::string block="floors_inner")
+inline Prescription MakePrescriptionInner(parthenon::ParameterInput* pin,
+    Prescription p_outer, std::string block = "floors_inner")
 {
-    // TODO(BSP) I wonder if there's an easier way to "set if parameter exists" from pin, that would be broadly useful
+    // TODO(CEP) I wonder if there's an easier way to "set if parameter exists" from pin,
+    // that would be broadly useful
     Prescription p_inner;
 
     // Floor parameters
     if (pin->GetBoolean("coordinates", "spherical")) {
         // In spherical systems, floors drop as r^2, so set them higher by default
-        p_inner.rho_min_geom = pin->GetOrAddReal(block, "rho_min_geom", p_outer.rho_min_geom);
-        p_inner.u_min_geom   = pin->GetOrAddReal(block, "u_min_geom", p_outer.u_min_geom);
+        p_inner.rho_min_geom =
+            pin->GetOrAddReal(block, "rho_min_geom", p_outer.rho_min_geom);
+        p_inner.u_min_geom = pin->GetOrAddReal(block, "u_min_geom", p_outer.u_min_geom);
         // Some constant for large distances. New, out of the way by default
-        p_inner.rho_min_const = pin->GetOrAddReal(block, "rho_min_const", p_outer.rho_min_const);
-        p_inner.u_min_const   = pin->GetOrAddReal(block, "u_min_const", p_outer.u_min_const);
+        p_inner.rho_min_const =
+            pin->GetOrAddReal(block, "rho_min_const", p_outer.rho_min_const);
+        p_inner.u_min_const =
+            pin->GetOrAddReal(block, "u_min_const", p_outer.u_min_const);
     } else { // TODO spherical cart will also have both
         // Accept old names
-        Real rho_min_const_default = pin->DoesParameterExist(block, "rho_min_geom") ?
-                                        pin->GetReal(block, "rho_min_geom") : p_outer.rho_min_geom;
-        Real u_min_const_default   = pin->DoesParameterExist(block, "u_min_geom") ?
-                                        pin->GetReal(block, "u_min_geom") : p_outer.u_min_geom;
-        p_inner.rho_min_const = pin->GetOrAddReal(block, "rho_min_const", rho_min_const_default);
-        p_inner.u_min_const   = pin->GetOrAddReal(block, "u_min_const", u_min_const_default);
+        Real rho_min_const_default = pin->DoesParameterExist(block, "rho_min_geom")
+                                         ? pin->GetReal(block, "rho_min_geom")
+                                         : p_outer.rho_min_geom;
+        Real u_min_const_default = pin->DoesParameterExist(block, "u_min_geom")
+                                       ? pin->GetReal(block, "u_min_geom")
+                                       : p_outer.u_min_geom;
+        p_inner.rho_min_const =
+            pin->GetOrAddReal(block, "rho_min_const", rho_min_const_default);
+        p_inner.u_min_const =
+            pin->GetOrAddReal(block, "u_min_const", u_min_const_default);
     }
 
     p_inner.use_r_char = pin->GetOrAddBoolean(block, "use_r_char", p_outer.use_r_char);
-    p_inner.r_char     = pin->GetOrAddReal(block, "r_char", p_outer.r_char);
+    p_inner.r_char = pin->GetOrAddReal(block, "r_char", p_outer.r_char);
 
-    p_inner.bsq_over_rho_max = pin->GetOrAddReal(block, "bsq_over_rho_max", p_outer.bsq_over_rho_max);
-    p_inner.bsq_over_u_max = pin->GetOrAddReal(block, "bsq_over_u_max", p_outer.bsq_over_u_max);
+    p_inner.bsq_over_rho_max =
+        pin->GetOrAddReal(block, "bsq_over_rho_max", p_outer.bsq_over_rho_max);
+    p_inner.bsq_over_u_max =
+        pin->GetOrAddReal(block, "bsq_over_u_max", p_outer.bsq_over_u_max);
 
-    p_inner.u_over_rho_max = pin->GetOrAddReal(block, "u_over_rho_max", p_outer.u_over_rho_max);
+    p_inner.u_over_rho_max =
+        pin->GetOrAddReal(block, "u_over_rho_max", p_outer.u_over_rho_max);
     p_inner.ktot_max = pin->GetOrAddReal(block, "ktot_max", p_outer.ktot_max);
-    p_inner.temp_adjust_u = pin->GetOrAddBoolean(block, "temp_adjust_u", p_outer.temp_adjust_u);
+    p_inner.temp_adjust_u =
+        pin->GetOrAddBoolean(block, "temp_adjust_u", p_outer.temp_adjust_u);
     p_inner.adjust_k = pin->GetOrAddBoolean(block, "adjust_k", p_outer.adjust_k);
 
     p_inner.gamma_max = pin->GetOrAddReal(block, "gamma_max", p_outer.gamma_max);
 
     // Always grab these from p_outer, they should never differ between outer/inner floors
-    p_inner.radius_dependent_floors = p_outer.radius_dependent_floors; 
+    p_inner.radius_dependent_floors = p_outer.radius_dependent_floors;
     p_inner.floors_switch_r = p_outer.floors_switch_r;
 
     return p_inner;
@@ -220,17 +240,18 @@ inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescr
 /**
  * Initialization.  Set parameters.
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Apply density and internal energy floors and ceilings
- * 
+ *
  * This function definitely applies floors over the stated domain.
  * If "Floors" package is not loaded, it is not registered.
- * 
+ *
  * LOCKSTEP: this function respects P and returns consistent P<->U
  */
-TaskStatus ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain);
+TaskStatus ApplyGRMHDFloors(MeshData<Real>* md, IndexDomain domain);
 
 /**
  * Determine just the floor values and flags for the current state, i.e.
@@ -238,7 +259,7 @@ TaskStatus ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain);
  * 2. fflag, which floors were hit by the current state
  * This is what ApplyFloors uses to determine the floor values/locations
  */
-TaskStatus DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
+TaskStatus DetermineGRMHDFloors(MeshData<Real>* md, IndexDomain domain,
     const Floors::Prescription& floors, const Floors::Prescription& floors_inner);
 
 /**
@@ -247,19 +268,20 @@ TaskStatus DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
  * 2. Don't record results to 'fflag' or 'pflag'
  * Used for problems where some part of the domain is initialized to
  * "whatever the floor value is."
- * *This function can be called even if the Floors package is not initialized, and ignores "floors/on=false"*
+ * *This function can be called even if the Floors package is not initialized, and ignores
+ * "floors/on=false"*
  */
-TaskStatus ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *mbd, IndexDomain domain);
+TaskStatus ApplyInitialFloors(
+    ParameterInput* pin, MeshBlockData<Real>* mbd, IndexDomain domain);
 
 /**
  * Count up all nonzero FFlags on md.  Used for history file reductions.
  */
-int CountFFlags(MeshData<Real> *md);
+int CountFFlags(MeshData<Real>* md);
 
 /**
  * Print a summary of floors which were hit
  */
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md);
-
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md);
 
 } // namespace Floors

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: floors_functions.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,72 +41,87 @@
 /**
  * Device-side functions for applying GRMHD floors
  */
-namespace Floors {
+namespace Floors
+{
 
 /**
- * Apply all ceilings together, currently at most one on velocity and two on internal energy
- * TODO REALLY need to take fflag here and only compute existing values if we know the floor was hit
- * 
+ * Apply all ceilings together, currently at most one on velocity and two on internal
+ * energy
+ * TODO REALLY need to take fflag here and only compute existing values if we know the
+ * floor was hit
+ *
  * LOCKSTEP: this function respects P and returns consistent P<->U
  */
-KOKKOS_INLINE_FUNCTION void apply_ceilings(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                          const Real& gam, const int& k, const int& j, const int& i,
-                                          const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
-                                          const VariablePack<Real>& U, const VarMap& m_u, const Loci loc=Loci::center)
+KOKKOS_INLINE_FUNCTION void apply_ceilings(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const Real& gam, const int& k,
+    const int& j, const int& i, const Floors::Prescription& floors,
+    const Floors::Prescription& floors_inner, const VariablePack<Real>& U,
+    const VarMap& m_u, const Loci loc = Loci::center)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
-                                            && G.r(k, j, i) < floors.floors_switch_r) ? floors_inner : floors;
+    const Floors::Prescription& myfloors =
+        (floors.radius_dependent_floors && G.r(k, j, i) < floors.floors_switch_r)
+            ? floors_inner
+            : floors;
 
     // Compute max values for ceilings
-    Real gamma      = GRMHD::lorentz_calc(G, P, m_p, k, j, i, loc);
-    Real ktot       = (gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam);
+    Real gamma = GRMHD::lorentz_calc(G, P, m_p, k, j, i, loc);
+    Real ktot = (gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam);
     Real u_over_rho = P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
 
     // 1. Limit gamma with respect to normal observer
     if (gamma > myfloors.gamma_max) {
         Real f = m::sqrt((SQR(myfloors.gamma_max) - 1.) / (SQR(gamma) - 1.));
-        VLOOP P(m_p.U1+v, k, j, i) *= f;
+        VLOOP
+            P(m_p.U1 + v, k, j, i) *= f;
     }
 
     // 2. Limit the entropy by controlling u, to avoid anomalous cooling from funnel wall
-    // Note this technically applies the condition *one step sooner* than legacy, since it operates on
-    // the entropy as calculated from current conditions, rather than the value kept from the previous
-    // step for calculating dissipation.
+    // Note this technically applies the condition *one step sooner* than legacy, since it
+    // operates on the entropy as calculated from current conditions, rather than the
+    // value kept from the previous step for calculating dissipation.
     if (ktot > myfloors.ktot_max) {
         P(m_p.UU, k, j, i) = myfloors.ktot_max / ktot * P(m_p.UU, k, j, i);
     }
 
-    // 3. Limit the temperature by controlling u.  Can optionally add density instead, implemented in apply_floors
-    if (myfloors.temp_adjust_u && P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > myfloors.u_over_rho_max) {
+    // 3. Limit the temperature by controlling u.  Can optionally add density instead,
+    // implemented in apply_floors
+    if (myfloors.temp_adjust_u &&
+        P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > myfloors.u_over_rho_max) {
         P(m_p.UU, k, j, i) = myfloors.u_over_rho_max * P(m_p.RHO, k, j, i);
     }
 }
 
-KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                                        const Real& gam, const int& k, const int& j, const int& i, const Floors::Prescription& floors,
-                                        const Floors::Prescription& floors_inner, Real& rhoflr_max, Real& uflr_max)
+KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const Real& gam, const int& k,
+    const int& j, const int& i, const Floors::Prescription& floors,
+    const Floors::Prescription& floors_inner, Real& rhoflr_max, Real& uflr_max)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
-                                            && G.r(k, j, i) < floors.floors_switch_r) ? floors_inner : floors;
+    const Floors::Prescription& myfloors =
+        (floors.radius_dependent_floors && G.r(k, j, i) < floors.floors_switch_r)
+            ? floors_inner
+            : floors;
 
     // Calculate the different floor values in play:
     // 1. Geometric hard floors, not based on fluid relationships
-    // TODO(BSP) can this be cached if it's slow?
+    // TODO(CEP) can this be cached if it's slow?
     Real rhoflr_geom, uflr_geom;
-    if(G.coords.is_spherical()) {
+    if (G.coords.is_spherical()) {
         const GReal r = G.r(k, j, i);
         // r_char sets more aggressive floor close to EH but backs off
-        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r*r) * (1 + r / myfloors.r_char)) : 1. / m::sqrt(r*r*r);
+        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r * r) * (1 + r / myfloors.r_char))
+                                             : 1. / m::sqrt(r * r * r);
         rhoflr_geom = m::max(myfloors.rho_min_geom * rhoscal, myfloors.rho_min_const);
-        uflr_geom   = m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
+        uflr_geom =
+            m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
     } else {
         rhoflr_geom = myfloors.rho_min_const;
-        uflr_geom   = myfloors.u_min_const;
+        uflr_geom = myfloors.u_min_const;
     }
 
-    // 2. Magnetization ceilings: impose maximum magnetization sigma = bsq/rho, and inverse beta prop. to bsq/U
+    // 2. Magnetization ceilings: impose maximum magnetization sigma = bsq/rho, and
+    // inverse beta prop. to bsq/U
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
     Real rhoflr_b, uflr_b;
@@ -114,7 +129,7 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
     // Used with spherical coordinate system, i.e., G.r(k,j,i) exist
     Real bsq = dot(Dtmp.bcon, Dtmp.bcov);
     rhoflr_b = bsq / myfloors.bsq_over_rho_max;
-    uflr_b   = bsq / myfloors.bsq_over_u_max;
+    uflr_b = bsq / myfloors.bsq_over_u_max;
 
     // Evaluate max U floor, needed for temp ceiling below
     uflr_max = m::max(uflr_geom, uflr_b);
@@ -152,24 +167,30 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
     if (GRMHD::lorentz_calc(G, P, m_p, k, j, i, Loci::center) > myfloors.gamma_max)
         fflag |= FFlag::GAMMA;
 
-    if ((gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam) > myfloors.ktot_max)
+    if ((gam - 1.) * P(m_p.UU, k, j, i) / m::pow(P(m_p.RHO, k, j, i), gam) >
+        myfloors.ktot_max)
         fflag |= FFlag::KTOT;
 
-    if (myfloors.temp_adjust_u && (P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > myfloors.u_over_rho_max))
+    if (myfloors.temp_adjust_u &&
+        (P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i) > myfloors.u_over_rho_max))
         fflag |= FFlag::TEMP;
 
     return fflag;
 }
 
-#define FLOOR_ONE_ARGS const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p, const Real& gam, \
-                        const int& k, const int& j, const int& i, const Real& rhoflr_max, const Real& uflr_max, \
-                        const VariablePack<Real>& U, const VarMap& m_u
+#define FLOOR_ONE_ARGS                                                                   \
+    const GRCoordinates &G, const VariablePack<Real>&P, const VarMap &m_p,               \
+        const Real &gam, const int &k, const int &j, const int &i,                       \
+        const Real &rhoflr_max, const Real &uflr_max, const VariablePack<Real>&U,        \
+        const VarMap &m_u
 
 /**
- * Apply floors of several types in determining how to add mass and internal energy to preserve stability.
- * All floors which might apply are recorded separately, then mass/energy are added *in normal observer frame*
- * 
- * @return pflag: in NOF, a number <32 representing any failure of the U->P solve.  Otherwise 0.
+ * Apply floors of several types in determining how to add mass and internal energy to
+ * preserve stability. All floors which might apply are recorded separately, then
+ * mass/energy are added *in normal observer frame*
+ *
+ * @return pflag: in NOF, a number <32 representing any failure of the U->P solve.
+ * Otherwise 0.
  */
 template<InjectionFrame frame>
 KOKKOS_INLINE_FUNCTION int apply_floors(FLOOR_ONE_ARGS);
@@ -178,24 +199,25 @@ template<>
 KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::fluid>(FLOOR_ONE_ARGS)
 {
     P(m_p.RHO, k, j, i) += m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
-    P(m_p.UU, k, j, i)  += m::max(0., uflr_max - P(m_p.UU, k, j, i));
+    P(m_p.UU, k, j, i) += m::max(0., uflr_max - P(m_p.UU, k, j, i));
     return 0;
 }
 
 template<>
 KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::drift>(FLOOR_ONE_ARGS)
 {
-    // Drift frame floors. Refer to Appendix B3 in https://doi.org/10.1093/mnras/stx364 (hereafter R17)
-    const Real lapse2    = 1. / (-G.gcon(Loci::center, j, i, 0, 0));
+    // Drift frame floors. Refer to Appendix B3 in https://doi.org/10.1093/mnras/stx364
+    // (hereafter R17)
+    const Real lapse2 = 1. / (-G.gcon(Loci::center, j, i, 0, 0));
     double beta[GR_DIM] = {0};
     beta[1] = lapse2 * G.gcon(Loci::center, j, i, 0, 1);
     beta[2] = lapse2 * G.gcon(Loci::center, j, i, 0, 2);
     beta[3] = lapse2 * G.gcon(Loci::center, j, i, 0, 3);
 
     // Fluid quantities (four velocities have been computed above)
-    const Real rho   = P(m_p.RHO, k, j, i);
-    const Real uu    = P(m_p.UU, k, j, i);
-    const Real pg    = (gam - 1.) * uu;
+    const Real rho = P(m_p.RHO, k, j, i);
+    const Real uu = P(m_p.UU, k, j, i);
+    const Real pg = (gam - 1.) * uu;
     const Real w_old = m::max(rho + uu + pg, SMALL_NUM);
 
     // Normal observer magnetic field
@@ -207,8 +229,9 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::drift>(FLOOR_ONE_ARGS)
         Bcon[2] = P(m_p.B2, k, j, i);
         Bcon[3] = P(m_p.B3, k, j, i);
     }
-    DLOOP2 Bcov[mu] += G.gcov(Loci::center, j, i, mu, nu) * Bcon[nu];
-    const Real Bsq   = m::max(dot(Bcon, Bcov), SMALL_NUM);
+    DLOOP2
+        Bcov[mu] += G.gcov(Loci::center, j, i, mu, nu) * Bcon[nu];
+    const Real Bsq = m::max(dot(Bcon, Bcov), SMALL_NUM);
     const Real B_mag = m::sqrt(Bsq);
 
     // Get four-vectors again
@@ -226,27 +249,31 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::drift>(FLOOR_ONE_ARGS)
     double QdotB = dot(Bcon, Qcov);
 
     // Initial parallel velocity (refer R17 Eqn B10)
-    Real vpar = QdotB / (B_mag * w_old * Dtmp.ucon[0]*Dtmp.ucon[0]);
+    Real vpar = QdotB / (B_mag * w_old * Dtmp.ucon[0] * Dtmp.ucon[0]);
 
     Real ucon_dr[GR_DIM] = {0};
     // t-component of drift velocity (refer R17 Eqn B13)
-    ucon_dr[0] = 1. / m::sqrt(1. / (Dtmp.ucon[0]*Dtmp.ucon[0]) + vpar*vpar);
+    ucon_dr[0] = 1. / m::sqrt(1. / (Dtmp.ucon[0] * Dtmp.ucon[0]) + vpar * vpar);
     // spatial components of drift velocity (refer R17 Eqn B11)
-    VLOOP ucon_dr[1 + v] = Dtmp.ucon[1 + v] * (ucon_dr[0] / Dtmp.ucon[0]) - (vpar * Bcon[1 + v] * ucon_dr[0] / B_mag);
+    VLOOP
+        ucon_dr[1 + v] = Dtmp.ucon[1 + v] * (ucon_dr[0] / Dtmp.ucon[0]) -
+                         (vpar * Bcon[1 + v] * ucon_dr[0] / B_mag);
 
     // Update rho, uu and compute new enthalpy
     P(m_p.RHO, k, j, i) = m::max(rho, rhoflr_max);
-    P(m_p.UU, k, j, i)  = m::max(uu, uflr_max);
-    const Real pg_new   = (gam - 1.) * P(m_p.UU, k, j, i);
-    const Real w_new    = P(m_p.RHO, k, j, i) + P(m_p.UU, k, j, i) + pg_new;
+    P(m_p.UU, k, j, i) = m::max(uu, uflr_max);
+    const Real pg_new = (gam - 1.) * P(m_p.UU, k, j, i);
+    const Real w_new = P(m_p.RHO, k, j, i) + P(m_p.UU, k, j, i) + pg_new;
 
     // New parallel velocity (refer R17 Eqn B14)
     const Real x = (2. * QdotB) / (B_mag * w_new * ucon_dr[0]);
-    vpar = x / (1 + m::sqrt(1 + x*x)) * (1. / ucon_dr[0]);
+    vpar = x / (1 + m::sqrt(1 + x * x)) * (1. / ucon_dr[0]);
 
     // New fluid four velocity (refer R17 Eqns B13 and B11)
-    Dtmp.ucon[0] = 1. / m::sqrt(1/(ucon_dr[0]*ucon_dr[0]) - vpar*vpar);
-    VLOOP Dtmp.ucon[1 + v] = ucon_dr[1 + v] * (Dtmp.ucon[0] / ucon_dr[0]) + (vpar * Bcon[1 + v] * Dtmp.ucon[0] / B_mag);
+    Dtmp.ucon[0] = 1. / m::sqrt(1 / (ucon_dr[0] * ucon_dr[0]) - vpar * vpar);
+    VLOOP
+        Dtmp.ucon[1 + v] = ucon_dr[1 + v] * (Dtmp.ucon[0] / ucon_dr[0]) +
+                           (vpar * Bcon[1 + v] * Dtmp.ucon[0] / B_mag);
     G.lower(Dtmp.ucon, Dtmp.ucov, k, j, i, Loci::center);
 
     // New velocity primitives
@@ -266,26 +293,28 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_onedw>(FLOOR_ONE_
     // By using the existing velocities for the rho*u^0 and T^0_0 contributions,
     // We produce a guaranteed overestimate (since NOF floors will slow the material,
     // reducing the Lorentz factor)
-    const Real rho_add    = m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
-    const Real u_add      = m::max(0., uflr_max - P(m_p.UU, k, j, i));
-    //const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
+    const Real rho_add = m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
+    const Real u_add = m::max(0., uflr_max - P(m_p.UU, k, j, i));
+    // const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j,
+    // i)};
     const Real uvec[NVEC] = {0.};
     const Real B[NVEC] = {0.};
 
-    // 2. Calculate the increase in conserved mass/energy corresponding to the new material.
+    // 2. Calculate the increase in conserved mass/energy corresponding to the new
+    // material.
     Real rho_ut, T[GR_DIM];
     GRMHD::p_to_u_mhd(G, rho_add, u_add, uvec, B, gam, k, j, i, rho_ut, T, Loci::center);
 
     // 3. Add new conserved mass/energy to the current "conserved" state.
     U(m_u.RHO, k, j, i) += rho_ut;
-    U(m_u.UU, k, j, i)  += T[0];  // Actually T^0_0 + rho u^t
+    U(m_u.UU, k, j, i) += T[0]; // Actually T^0_0 + rho u^t
     // Also add to the local primitives to produce a better guess
     P(m_p.RHO, k, j, i) += rho_add;
-    P(m_p.UU, k, j, i)  += u_add;
+    P(m_p.UU, k, j, i) += u_add;
 
     // Recover primitive variables from conserved versions
-    return Inverter::u_to_p<Inverter::Type::onedw>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                    8, 1e-8, false);
+    return Inverter::u_to_p<Inverter::Type::onedw>(
+        G, U, m_u, gam, k, j, i, P, m_p, Loci::center, 8, 1e-8, false);
 }
 
 template<>
@@ -293,66 +322,83 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_kastaun>(FLOOR_ON
 {
     // Add the material in the normal observer frame.
     // 1. Calculate how much material we're adding.
-    const Real rho_add    = m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
-    const Real u_add      = m::max(0., uflr_max - P(m_p.UU, k, j, i));
-    // We compute rho u^0 and T^00 using the existing velocities to determine Lorentz factor.
-    // This is a guaranteed overestimate of the fluid contributions to these quantities
+    const Real rho_add = m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
+    const Real u_add = m::max(0., uflr_max - P(m_p.UU, k, j, i));
+    // We compute rho u^0 and T^00 using the existing velocities to determine Lorentz
+    // factor. This is a guaranteed overestimate of the fluid contributions to these
+    // quantities
     const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
     // Alternatively, add less than will produce our floored values
-    //const Real uvec[NVEC] = {0.};
+    // const Real uvec[NVEC] = {0.};
     const Real B[NVEC] = {0.};
 
-    // 2. Calculate the increase in conserved mass/energy corresponding to the new material.
+    // 2. Calculate the increase in conserved mass/energy corresponding to the new
+    // material.
     Real rho_ut, T[GR_DIM];
     GRMHD::p_to_u_mhd(G, rho_add, u_add, uvec, B, gam, k, j, i, rho_ut, T, Loci::center);
 
     // 3. Add new conserved mass/energy to the current "conserved" state.
     // (no need to modify the guess for Kastaun, esp once we sync mu)
     U(m_u.RHO, k, j, i) += rho_ut;
-    U(m_u.UU, k, j, i)  += T[0]; // Actually T^0_0 + rho u^t
+    U(m_u.UU, k, j, i) += T[0]; // Actually T^0_0 + rho u^t
 
-    // Recover new primitive variables.  Use Kastaun with safe parameters so we don't fail often
-    return Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                     25, 1e-12, true);
+    // Recover new primitive variables.  Use Kastaun with safe parameters so we don't fail
+    // often
+    return Inverter::u_to_p<Inverter::Type::kastaun>(
+        G, U, m_u, gam, k, j, i, P, m_p, Loci::center, 25, 1e-12, true);
 }
 
 // These are implemented as special cases in the kernel in floors_impl.hpp
 // We define them here as no-ops so they resolve in the general template call-through
 template<>
-KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::mixed_fluid_normal>(FLOOR_ONE_ARGS) { return 0; }
+KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::mixed_fluid_normal>(
+    FLOOR_ONE_ARGS)
+{
+    return 0;
+}
 template<>
-KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::mixed_normal_drift>(FLOOR_ONE_ARGS) { return 0; }
+KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::mixed_normal_drift>(
+    FLOOR_ONE_ARGS)
+{
+    return 0;
+}
 
 /**
  * Apply just the geometric floors to a set of local primitives.
  * Specifically called after reconstruction when using non-TVD schemes, e.g. WENO5.
- * Reimplemented to be fast and fit the general prim_to_flux calling convention, including geometry locations
- * 
- * @return fflag: since no inversion is performed, this just returns a flag representing which geometric floors were hit
- * 
+ * Reimplemented to be fast and fit the general prim_to_flux calling convention, including
+ * geometry locations
+ *
+ * @return fflag: since no inversion is performed, this just returns a flag representing
+ * which geometric floors were hit
+ *
  * NOT LOCKSTEP: Operates on and respects primitives *only*
  */
 template<typename Local>
-KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Local& P, const VarMap& m,
-                                            const Real& gam, const int& j, const int& i,
-                                            const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
-                                            const Loci loc=Loci::center)
+KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Local& P,
+    const VarMap& m, const Real& gam, const int& j, const int& i,
+    const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
+    const Loci loc = Loci::center)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
-                                            && G.r(0, j, i) < floors.floors_switch_r) ? floors_inner : floors;
+    const Floors::Prescription& myfloors =
+        (floors.radius_dependent_floors && G.r(0, j, i) < floors.floors_switch_r)
+            ? floors_inner
+            : floors;
 
     // Apply only the geometric floors
     Real rhoflr_geom, uflr_geom;
-    if(G.coords.is_spherical()) {
+    if (G.coords.is_spherical()) {
         const GReal r = G.r(0, j, i);
         // r_char sets more aggressive floor close to EH but backs off
-        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r*r) * (1 + r / myfloors.r_char)) : 1. / m::sqrt(r*r*r);
+        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r * r) * (1 + r / myfloors.r_char))
+                                             : 1. / m::sqrt(r * r * r);
         rhoflr_geom = m::max(myfloors.rho_min_geom * rhoscal, myfloors.rho_min_const);
-        uflr_geom   = m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
+        uflr_geom =
+            m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
     } else {
         rhoflr_geom = myfloors.rho_min_const;
-        uflr_geom   = myfloors.u_min_const;
+        uflr_geom = myfloors.u_min_const;
     }
 
     int fflag = 0;
@@ -361,32 +407,36 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Local& P, co
     fflag |= (uflr_geom > P(m.UU)) * FFlag::GEOM_U_FLUX;
 
     P(m.RHO) += m::max(0., rhoflr_geom - P(m.RHO));
-    P(m.UU)  += m::max(0., uflr_geom - P(m.UU));
+    P(m.UU) += m::max(0., uflr_geom - P(m.UU));
 
     return fflag;
 }
 
 template<typename Global>
-KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, const VarMap& m,
-                                            const Real& gam, const int& k, const int& j, const int& i,
-                                            const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
-                                            const Loci loc=Loci::center)
+KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P,
+    const VarMap& m, const Real& gam, const int& k, const int& j, const int& i,
+    const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
+    const Loci loc = Loci::center)
 {
     // Choose our floor scheme
-    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
-                                            && G.r(0, j, i) < floors.floors_switch_r) ? floors_inner : floors;
+    const Floors::Prescription& myfloors =
+        (floors.radius_dependent_floors && G.r(0, j, i) < floors.floors_switch_r)
+            ? floors_inner
+            : floors;
 
     // Apply only the geometric floors
     Real rhoflr_geom, uflr_geom;
-    if(G.coords.is_spherical()) {
+    if (G.coords.is_spherical()) {
         const GReal r = G.r(0, j, i);
         // r_char sets more aggressive floor close to EH but backs off
-        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r*r) * (1 + r / myfloors.r_char)) : 1. / m::sqrt(r*r*r);
+        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r * r) * (1 + r / myfloors.r_char))
+                                             : 1. / m::sqrt(r * r * r);
         rhoflr_geom = m::max(myfloors.rho_min_geom * rhoscal, myfloors.rho_min_const);
-        uflr_geom   = m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
+        uflr_geom =
+            m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
     } else {
         rhoflr_geom = myfloors.rho_min_const;
-        uflr_geom   = myfloors.u_min_const;
+        uflr_geom = myfloors.u_min_const;
     }
 
     int fflag = 0;
@@ -396,7 +446,7 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, c
     fflag |= (uflr_geom > P(m.UU, k, j, i)) * FFlag::GEOM_U_FLUX;
 
     P(m.RHO, k, j, i) += m::max(0., rhoflr_geom - P(m.RHO, k, j, i));
-    P(m.UU, k, j, i)  += m::max(0., uflr_geom - P(m.UU, k, j, i));
+    P(m.UU, k, j, i) += m::max(0., uflr_geom - P(m.UU, k, j, i));
 
     return fflag;
 }

--- a/kharma/floors/floors_impl.hpp
+++ b/kharma/floors/floors_impl.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: floors_impl.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,91 +37,107 @@
 
 #include "domain.hpp"
 
-namespace Floors {
+namespace Floors
+{
 
 /**
  * Template to call through to templated apply_floors
  */
 template<InjectionFrame frame>
-TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
+TaskStatus ApplyFloorsInFrame(MeshData<Real>* md, IndexDomain domain)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
     PackIndexMap prims_map, cons_map;
-    auto P = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto P = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
     auto U = md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
     auto fflag = md->PackVariables(std::vector<std::string>{"fflag"});
     auto pflag = md->PackVariables(std::vector<std::string>{"pflag"});
     PackIndexMap floors_map;
-    auto floor_vals = md->PackVariables(std::vector<std::string>{"Floors.rho_floor", "Floors.u_floor"}, floors_map);
+    auto floor_vals = md->PackVariables(
+        std::vector<std::string>{"Floors.rho_floor", "Floors.u_floor"}, floors_map);
     const int rhofi = floors_map["Floors.rho_floor"].first;
     const int ufi = floors_map["Floors.u_floor"].first;
 
     const Real gam = pmb0->packages.Get("GRMHD")->Param<Real>("gamma");
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb0->packages);
-    const Real switch_r = (frame == InjectionFrame::mixed_fluid_normal) ?
-                            pmb0->packages.Get("Floors")->Param<Real>("frame_switch_r") : 0;
-    const Real switch_beta = (frame == InjectionFrame::mixed_normal_drift) ?
-                            pmb0->packages.Get("Floors")->Param<Real>("frame_switch_beta") : 0;
+    const Real switch_r =
+        (frame == InjectionFrame::mixed_fluid_normal)
+            ? pmb0->packages.Get("Floors")->Param<Real>("frame_switch_r")
+            : 0;
+    const Real switch_beta =
+        (frame == InjectionFrame::mixed_normal_drift)
+            ? pmb0->packages.Get("Floors")->Param<Real>("frame_switch_beta")
+            : 0;
     // Still needed for ceilings and determining floors
-    const Floors::Prescription floors = pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
-    const Floors::Prescription floors_inner = pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
+    const Floors::Prescription floors =
+        pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+    const Floors::Prescription floors_inner =
+        pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
 
     const IndexRange3 b = KDomain::GetRange(md, domain);
     const IndexRange block = IndexRange{0, P.GetDim(5) - 1};
     pmb0->par_for("apply_floors", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             if (static_cast<int>(fflag(b, 0, k, j, i))) {
                 const auto& G = P.GetCoords(b);
-                // apply_floors can involve another U_to_P call.  Hide the pflag in bottom 5 bits and retrieve both
+                // apply_floors can involve another U_to_P call.  Hide the pflag in bottom
+                // 5 bits and retrieve both
                 int pflag_l = 0;
-                // These would be constexpr except Nvidia doesn't like lambda-capture in constexpr ifs
+                // These would be constexpr except Nvidia doesn't like lambda-capture in
+                // constexpr ifs
                 if (frame == InjectionFrame::mixed_fluid_normal) {
                     if (G.r(k, j, i) > switch_r) {
-                        pflag_l = apply_floors<InjectionFrame::fluid>(G, P(b), m_p, gam, k, j, i,
-                                            floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                        pflag_l = apply_floors<InjectionFrame::fluid>(G, P(b), m_p, gam,
+                            k, j, i, floor_vals(b, rhofi, k, j, i),
+                            floor_vals(b, ufi, k, j, i), U(b), m_u);
                     } else {
                         // TODO should mixed frames respect Kastaun vs 1Dw?
-                        // Since no prior simulations use mixed frames thus requiring back-compat, I said no
-                        pflag_l = apply_floors<InjectionFrame::normal_kastaun>(G, P(b), m_p, gam, k, j, i,
-                                            floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                        // Since no prior simulations use mixed frames thus requiring
+                        // back-compat, I said no
+                        pflag_l = apply_floors<InjectionFrame::normal_kastaun>(G, P(b),
+                            m_p, gam, k, j, i, floor_vals(b, rhofi, k, j, i),
+                            floor_vals(b, ufi, k, j, i), U(b), m_u);
                     }
                 } else if (frame == InjectionFrame::mixed_normal_drift) {
                     FourVectors Dtmp;
                     GRMHD::calc_4vecs(G, P(b), m_p, k, j, i, Loci::center, Dtmp);
-                    Real mag_switch = m::min(P(b, m_p.RHO, k, j, i), P(b, m_p.UU, k, j, i)) /
-                                        dot(Dtmp.bcon, Dtmp.bcov);
+                    Real mag_switch =
+                        m::min(P(b, m_p.RHO, k, j, i), P(b, m_p.UU, k, j, i)) /
+                        dot(Dtmp.bcon, Dtmp.bcov);
                     if (mag_switch < switch_beta) {
-                        pflag_l = apply_floors<InjectionFrame::drift>(G, P(b), m_p, gam, k, j, i,
-                                            floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                        pflag_l = apply_floors<InjectionFrame::drift>(G, P(b), m_p, gam,
+                            k, j, i, floor_vals(b, rhofi, k, j, i),
+                            floor_vals(b, ufi, k, j, i), U(b), m_u);
                     } else {
-                        pflag_l = apply_floors<InjectionFrame::normal_kastaun>(G, P(b), m_p, gam, k, j, i,
-                                            floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                            U(b), m_u);
+                        pflag_l = apply_floors<InjectionFrame::normal_kastaun>(G, P(b),
+                            m_p, gam, k, j, i, floor_vals(b, rhofi, k, j, i),
+                            floor_vals(b, ufi, k, j, i), U(b), m_u);
                     }
                 } else {
                     pflag_l = apply_floors<frame>(G, P(b), m_p, gam, k, j, i,
-                                        floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i),
-                                        U(b), m_u);
+                        floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i), U(b),
+                        m_u);
                 }
 
-                // Record the pflag if nonzero, that is, if *either* the initial inversion or
-                // post-floor inversion failed.
+                // Record the pflag if nonzero, that is, if *either* the initial inversion
+                // or post-floor inversion failed.
                 if (pflag_l) pflag(b, 0, k, j, i) = pflag_l;
 
-                // Apply ceilings *after* floors, to make the temperature ceiling better-behaved
-                apply_ceilings(G, P(b), m_p, gam, k, j, i, floors, floors_inner, U(b), m_u);
+                // Apply ceilings *after* floors, to make the temperature ceiling
+                // better-behaved
+                apply_ceilings(
+                    G, P(b), m_p, gam, k, j, i, floors, floors_inner, U(b), m_u);
 
                 // P->U for any modified zones
-                Flux::p_to_u_mhd(G, P(b), m_p, emhd_params, gam, k, j, i, U(b), m_u, Loci::center);
+                Flux::p_to_u_mhd(
+                    G, P(b), m_p, emhd_params, gam, k, j, i, U(b), m_u, Loci::center);
             }
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: flux.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,19 +42,22 @@
 
 using namespace parthenon;
 
-// GetFlux is in the header file get_flux.hpp, as it is templated on reconstruction scheme and flux direction
+// GetFlux is in the header file get_flux.hpp, as it is templated on reconstruction scheme
+// and flux direction
 
-int Flux::CountFOFCFlags(MeshData<Real> *md)
+int Flux::CountFOFCFlags(MeshData<Real>* md)
 {
-    return Reductions::CountFlags(md, "fofcflag", std::map<int, std::string>{{1, "Flux-corrected"}}, IndexDomain::interior, true)[0];
+    return Reductions::CountFlags(md, "fofcflag",
+        std::map<int, std::string>{{1, "Flux-corrected"}}, IndexDomain::interior,
+        true)[0];
 }
 
-
-std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Flux::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     Flag("Initializing Flux");
     auto pkg = std::make_shared<KHARMAPackage>("Fluxes");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Don't even error on this. Use LLF unless the user is very clear otherwise.
     std::string default_flux_s = "llf";
@@ -62,7 +65,8 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         default_flux_s = pin->GetString("driver", "flux");
     }
     std::vector<std::string> flux_allowed_vals = {"llf", "hlle"};
-    std::string flux = pin->GetOrAddString("flux", "type", default_flux_s, flux_allowed_vals);
+    std::string flux =
+        pin->GetOrAddString("flux", "type", default_flux_s, flux_allowed_vals);
     params.Add("use_hlle", (flux == "hlle"));
 
     // Reconstruction scheme
@@ -73,15 +77,18 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     } else if (pin->DoesParameterExist("GRMHD", "reconstruction")) {
         default_recon_s = pin->GetString("GRMHD", "reconstruction");
     }
-    std::vector<std::string> recon_allowed_vals = {"donor_cell", "donor_cell_c", "linear_vl", "linear_mc",
-                                             "weno5", "weno5_linear", "ppm", "ppmx", "mp5"};
-    std::string recon = pin->GetOrAddString("flux", "reconstruction", default_recon_s, recon_allowed_vals);
+    std::vector<std::string> recon_allowed_vals = {"donor_cell", "donor_cell_c",
+        "linear_vl", "linear_mc", "weno5", "weno5_linear", "ppm", "ppmx", "mp5"};
+    std::string recon = pin->GetOrAddString(
+        "flux", "reconstruction", default_recon_s, recon_allowed_vals);
     bool lower_edges = pin->GetOrAddBoolean("flux", "low_order_edges", false);
     bool lower_poles = pin->GetOrAddBoolean("flux", "low_order_poles", false);
     if (lower_edges && lower_poles)
-        throw std::runtime_error("Cannot enable lowered reconstruction on edges and poles!");
+        throw std::runtime_error(
+            "Cannot enable lowered reconstruction on edges and poles!");
     if ((lower_edges || lower_poles) && recon != "weno5")
-        throw std::runtime_error("Lowered reconstructions can only be enabled with weno5!");
+        throw std::runtime_error(
+            "Lowered reconstructions can only be enabled with weno5!");
 
     int stencil = 0;
     if (recon == "donor_cell") {
@@ -114,24 +121,29 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     } else if (recon == "ppmx") {
         params.Add("recon", KReconstruction::Type::ppmx);
         stencil = 5;
-        std::cout << "KHARMA WARNING: PPMX reconstruction implemention has known bugs." << std::endl
+        std::cout << "KHARMA WARNING: PPMX reconstruction implemention has known bugs."
+                  << std::endl
                   << "Use at your own risk!" << std::endl;
     } else if (recon == "mp5") {
         params.Add("recon", KReconstruction::Type::mp5);
         stencil = 5;
-    }  // we only allow these options
+    } // we only allow these options
     // Warn if using less than 3 ghost zones w/WENO etc, 2 w/Linear, etc.
     // SMR/AMR independently requires an even number of zones, so we usually use 4
-    if (Globals::nghost < (stencil/2 + 1)) {
+    if (Globals::nghost < (stencil / 2 + 1)) {
         throw std::runtime_error("Not enough ghost zones for specified reconstruction!");
     }
 
-    // Fallback to TVD reconstruction when these algorithms reconstruct something outside the floors
-    bool default_recon_fallback = (recon == "weno5" || recon == "weno5_linear" || recon == "mp5");
-    bool reconstruction_fallback = pin->GetOrAddBoolean("flux", "reconstruction_fallback", default_recon_fallback);
+    // Fallback to TVD reconstruction when these algorithms reconstruct something outside
+    // the floors
+    bool default_recon_fallback =
+        (recon == "weno5" || recon == "weno5_linear" || recon == "mp5");
+    bool reconstruction_fallback =
+        pin->GetOrAddBoolean("flux", "reconstruction_fallback", default_recon_fallback);
     params.Add("reconstruction_fallback", reconstruction_fallback);
     // Alternatively just apply the geometric floors in fluid frame like a heathen
-    bool reconstruction_floors = pin->GetOrAddBoolean("flux", "reconstruction_floors", false);
+    bool reconstruction_floors =
+        pin->GetOrAddBoolean("flux", "reconstruction_floors", false);
     params.Add("reconstruction_floors", reconstruction_floors);
 
     // When calculating the fluxes, replace perpendicular fields (e.g. B2 at F2) with
@@ -143,18 +155,23 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         if (pin->DoesParameterExist("b_field", "consistent_face_b")) {
             default_consistent_b = pin->GetBoolean("b_field", "consistent_face_b");
         }
-        consistent_face_b = pin->GetOrAddBoolean("flux", "consistent_face_b", default_consistent_b);
+        consistent_face_b =
+            pin->GetOrAddBoolean("flux", "consistent_face_b", default_consistent_b);
         params.Add("consistent_face_b", consistent_face_b);
     }
 
     // We can't just use GetVariables or something since there's no mesh yet.
     // That's what this function is for.
-    int nvar = StateDescriptor::CreateResolvedStateDescriptor(*packages)->GetPackDimension(Metadata::WithFluxes);
+    int nvar =
+        StateDescriptor::CreateResolvedStateDescriptor(*packages)->GetPackDimension(
+            Metadata::WithFluxes);
     std::vector<int> s_flux({nvar});
     if (packages->Get("Globals")->Param<int>("verbose") > 2)
         std::cout << "Allocating fluxes for " << nvar << " variables" << std::endl;
-    // TODO optionally move all these to faces? Not important yet, & faces have no output, more memory
-    std::vector<MetadataFlag> flags_flux = {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
+    // TODO optionally move all these to faces? Not important yet, & faces have no output,
+    // more memory
+    std::vector<MetadataFlag> flags_flux = {
+        Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
     Metadata m = Metadata(flags_flux, s_flux);
     pkg->AddField("Flux.Pr", m);
     pkg->AddField("Flux.Pl", m);
@@ -164,7 +181,8 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     pkg->AddField("Flux.Fl", m);
 
     std::vector<int> s_vector({NVEC});
-    std::vector<MetadataFlag> flags_speed = {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
+    std::vector<MetadataFlag> flags_speed = {
+        Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy};
     m = Metadata(flags_speed, s_vector);
     pkg->AddField("Flux.cmax", m);
     pkg->AddField("Flux.cmin", m);
@@ -182,7 +200,8 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
 
     if (use_fofc) {
         if (!packages->AllPackages().count("Floors"))
-            throw std::runtime_error("First-order Flux Corrections cannot be used without floors!");
+            throw std::runtime_error(
+                "First-order Flux Corrections cannot be used without floors!");
 
         // FOFC-specific options
         bool use_glf = pin->GetOrAddBoolean("fofc", "use_glf", false);
@@ -195,7 +214,8 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         params.Add("fofc_polar_cells", fofc_polar_cells);
         // Usually we use LLF everywhere and this fallback is optional.
         // If we use HLLE outside EH, we need to fall back to LLF/donor-cell inside.
-        const bool use_eh_buffer = pin->GetOrAddBoolean("fofc", "use_eh_buffer", (flux != "llf"));
+        const bool use_eh_buffer =
+            pin->GetOrAddBoolean("fofc", "use_eh_buffer", (flux != "llf"));
         params.Add("fofc_use_eh_buffer", use_eh_buffer);
         if (use_eh_buffer) {
             const GReal eh_buffer = pin->GetOrAddReal("fofc", "eh_buffer", 0.1);
@@ -205,38 +225,49 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
         if (packages->AllPackages().count("B_CT")) {
             // Use consistent B for FOFC (see above)
             // It is mildly inadvisable to disable this
-            bool fofc_consistent_face_b = pin->GetOrAddBoolean("fofc", "consistent_face_b", consistent_face_b);
+            bool fofc_consistent_face_b =
+                pin->GetOrAddBoolean("fofc", "consistent_face_b", consistent_face_b);
             params.Add("fofc_consistent_face_b", fofc_consistent_face_b);
         }
 
-        // Use a custom block for fofc floors.  We now do the same for Kastaun, where we can *also* have floors
+        // Use a custom block for fofc floors.  We now do the same for Kastaun, where we
+        // can *also* have floors
         // TODO even post-reconstruction/reconstruction fallback?
         if (!pin->DoesBlockExist("fofc_floors")) {
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "floors"));
             if (pin->DoesBlockExist("floors_inner"))
-                params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+                params.Add("fofc_prescription_inner",
+                    Floors::MakePrescriptionInner(
+                        pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
             else
-                params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
+                params.Add("fofc_prescription_inner",
+                    Floors::MakePrescriptionInner(
+                        pin, Floors::MakePrescription(pin, "floors"), "floors"));
         } else {
             // Override inner and outer floors with `fofc_floors` block
             params.Add("fofc_prescription", Floors::MakePrescription(pin, "fofc_floors"));
-            params.Add("fofc_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "fofc_floors"), "fofc_floors"));
+            params.Add("fofc_prescription_inner",
+                Floors::MakePrescriptionInner(
+                    pin, Floors::MakePrescription(pin, "fofc_floors"), "fofc_floors"));
         }
 
         // Flag for whether FOFC was applied, for diagnostics
         // This could be another bitflag in fflag, but that would be really confusing...
-        Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::FillGhost});
+        Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
+            Metadata::OneCopy, Metadata::FillGhost});
         pkg->AddField("fofcflag", m);
 
-        // List (vector) of HistoryOutputVars that will all be enrolled as output variables
+        // List (vector) of HistoryOutputVars that will all be enrolled as output
+        // variables
         parthenon::HstVar_list hst_vars = {};
         // Count total floors as a history item
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::max, CountFOFCFlags, "FOFCFlags"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(
+            UserHistoryOperation::max, CountFOFCFlags, "FOFCFlags"));
         // TODO Domain::entire version?
         // TODO entries for each individual flag?
-        // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+        // add callbacks for HST output to the Params struct, identified by the
+        // `hist_param_key`
         pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
-
     }
 
     // We register the geometric (\Gamma*T) source here
@@ -249,7 +280,7 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     return pkg;
 }
 
-TaskStatus Flux::BlockPtoUMHD(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+TaskStatus Flux::BlockPtoUMHD(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     // Pointers
     auto pmb = rc->GetBlockPointer();
@@ -273,15 +304,15 @@ TaskStatus Flux::BlockPtoUMHD(MeshBlockData<Real> *rc, IndexDomain domain, bool 
     const auto& G = pmb->coords;
 
     pmb->par_for("p_to_u_mhd", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, j, i, U, m_u);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus Flux::BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+TaskStatus Flux::BlockPtoU(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     // Pointers
     auto pmb = rc->GetBlockPointer();
@@ -292,8 +323,7 @@ TaskStatus Flux::BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coa
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
     // Make sure we don't step on face CT: unnecessary so far, might fix ordering mistakes
-    if (pmb->packages.AllPackages().count("B_CT"))
-        B_CT::BlockUtoP(rc, domain, coarse);
+    if (pmb->packages.AllPackages().count("B_CT")) B_CT::BlockUtoP(rc, domain, coarse);
 
     // Pack variables
     PackIndexMap prims_map, cons_map;
@@ -314,22 +344,22 @@ TaskStatus Flux::BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coa
     const auto& G = pmb->coords;
 
     pmb->par_for("p_to_u", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Flux::p_to_u(G, P, m_p, emhd_params, gam, k, j, i, U, m_u);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-TaskStatus Flux::MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse)
+TaskStatus Flux::MeshPtoU(MeshData<Real>* md, IndexDomain domain, bool coarse)
 {
-    for (int i=0; i < md->NumBlocks(); ++i)
+    for (int i = 0; i < md->NumBlocks(); ++i)
         Flux::BlockPtoU(md->GetBlockData(i).get(), domain, coarse);
     return TaskStatus::complete;
 }
 
-TaskStatus Flux::BlockPtoU_Send(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+TaskStatus Flux::BlockPtoU_Send(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     // Pointers
     auto pmb = rc->GetBlockPointer();
@@ -342,11 +372,14 @@ TaskStatus Flux::BlockPtoU_Send(MeshBlockData<Real> *rc, IndexDomain domain, boo
 
     // Pack variables. We never want to run this on the B field
     using FC = Metadata::FlagCollection;
-    auto cons_flags = FC(Metadata::Conserved, Metadata::Cell, Metadata::GetUserFlag("HD"));
+    auto cons_flags =
+        FC(Metadata::Conserved, Metadata::Cell, Metadata::GetUserFlag("HD"));
     if (pmb->packages.AllPackages().count("EMHD"))
-        cons_flags = cons_flags + FC(Metadata::Conserved, Metadata::Cell, Metadata::GetUserFlag("EMHDVar"));
+        cons_flags = cons_flags + FC(Metadata::Conserved, Metadata::Cell,
+                                      Metadata::GetUserFlag("EMHDVar"));
     PackIndexMap prims_map, cons_map;
-    const auto& P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+    const auto& P = rc->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
     const auto& U = rc->PackVariables(cons_flags, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
@@ -387,28 +420,28 @@ TaskStatus Flux::BlockPtoU_Send(MeshBlockData<Real> *rc, IndexDomain domain, boo
         if (ndim < 3) return TaskStatus::complete;
         kb.s -= ng;
         kb.e -= ng;
-    } // TODO(BSP) error?
+    } // TODO(CEP) error?
 
     const auto& G = pmb->coords;
 
     pmb->par_for("p_to_u_send", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Flux::p_to_u(G, P, m_p, emhd_params, gam, k, j, i, U, m_u);
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
 
-void Flux::AddGeoSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+void Flux::AddGeoSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
     // Pointers
     auto pmesh = md->GetMeshPointer();
-    auto pmb0  = md->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     auto pkgs = pmb0->packages;
     // Options
     const auto& pars = pkgs.Get("GRMHD")->AllParams();
-    const Real gam   = pars.Get<Real>("gamma");
+    const Real gam = pars.Get<Real>("gamma");
 
     // All connection coefficients are zero in Cartesian Minkowski space
     // TODO do we know this fully in init?
@@ -416,49 +449,57 @@ void Flux::AddGeoSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain d
 
     // Pack variables
     PackIndexMap prims_map, cons_map;
-    auto P    = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
-    auto dUdt = mdudt->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
+    auto P = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto dUdt =
+        mdudt->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
     const VarMap m_p(prims_map, false), m_u(cons_map, true);
 
     // EMHD params
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb0->packages);
-    
+
     // Get sizes
     IndexRange3 bd = KDomain::GetRange(md, domain);
-    auto block = IndexRange{0, P.GetDim(5)-1};
+    auto block = IndexRange{0, P.GetDim(5) - 1};
 
-    pmb0->par_for("tmunu_source", block.s, block.e, bd.ks, bd.ke, bd.js, bd.je, bd.is, bd.ie,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+    pmb0->par_for("tmunu_source", block.s, block.e, bd.ks, bd.ke, bd.js, bd.je, bd.is,
+        bd.ie,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = dUdt.GetCoords(b);
             FourVectors D;
             GRMHD::calc_4vecs(G, P(b), m_p, k, j, i, Loci::center, D);
-            // Call Flux::calc_tensor which will in turn call the right calc_tensor based on the number of primitives
-            Real Tmu[GR_DIM]    = {0};
+            // Call Flux::calc_tensor which will in turn call the right
+            // calc_tensor based on the number of primitives
+            Real Tmu[GR_DIM] = {0};
             Real new_du[GR_DIM] = {0};
             for (int mu = 0; mu < GR_DIM; ++mu) {
                 Flux::calc_tensor(P(b), m_p, D, emhd_params, gam, k, j, i, mu, Tmu);
                 for (int nu = 0; nu < GR_DIM; ++nu) {
-                    // Contract mhd stress tensor with connection, and multiply by metric determinant
+                    // Contract mhd stress tensor with connection, and multiply
+                    // by metric determinant
                     for (int lam = 0; lam < GR_DIM; ++lam) {
                         new_du[lam] += Tmu[nu] * G.gdet_conn(j, i, nu, lam, mu);
                     }
                 }
             }
 
-            dUdt(b, m_u.UU, k, j, i)           += new_du[0];
-            VLOOP dUdt(b, m_u.U1 + v, k, j, i) += new_du[1 + v];
-        }
-    );
+            dUdt(b, m_u.UU, k, j, i) += new_du[0];
+            VLOOP
+                dUdt(b, m_u.U1 + v, k, j, i) += new_du[1 + v];
+        });
 }
 
-TaskStatus Flux::CheckCtop(MeshData<Real> *md)
+TaskStatus Flux::CheckCtop(MeshData<Real>* md)
 {
-    Reductions::DomainReduction<Reductions::Var::nan_ctop, UserHistoryOperation::sum, int>(md, 0);
-    Reductions::DomainReduction<Reductions::Var::zero_ctop, UserHistoryOperation::sum, int>(md, 1);
+    Reductions::DomainReduction<Reductions::Var::nan_ctop, UserHistoryOperation::sum,
+        int>(md, 0);
+    Reductions::DomainReduction<Reductions::Var::zero_ctop, UserHistoryOperation::sum,
+        int>(md, 1);
     return TaskStatus::complete;
 }
 
-TaskStatus Flux::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+TaskStatus Flux::PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     // Options
@@ -471,9 +512,11 @@ TaskStatus Flux::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
     // Debugging/diagnostic info about FOFC hits
     if (use_fofc && flag_verbose > 0) {
         std::map<int, std::string> fofc_label = {{1, "Flux-corrected"}};
-        Reductions::StartFlagReduce(md, "fofcflag", fofc_label, IndexDomain::interior, false, 10);
+        Reductions::StartFlagReduce(
+            md, "fofcflag", fofc_label, IndexDomain::interior, false, 10);
         // Debugging/diagnostic info about floor and inversion flags
-        Reductions::CheckFlagReduceAndPrintHits(md, "fofcflag", fofc_label, IndexDomain::interior, false, 10);
+        Reductions::CheckFlagReduceAndPrintHits(
+            md, "fofcflag", fofc_label, IndexDomain::interior, false, 10);
     }
 
     // Check for a soundspeed (ctop) of 0 or NaN
@@ -485,10 +528,10 @@ TaskStatus Flux::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
 
         if (MPIRank0() && (nzero > 0 || nnan > 0)) {
             // TODO string formatting in C++ that doesn't suck
-            fprintf(stderr, "Max signal speed ctop of 0 or NaN (%d zero, %d NaN)", nzero, nnan);
+            fprintf(stderr, "Max signal speed ctop of 0 or NaN (%d zero, %d NaN)", nzero,
+                nnan);
             throw std::runtime_error("Bad ctop!");
         }
-
     }
 
     return TaskStatus::complete;

--- a/kharma/flux/flux.hpp
+++ b/kharma/flux/flux.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: flux.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,81 +43,85 @@
 #include "reconstruction.hpp"
 #include "types.hpp"
 
-namespace Flux {
+namespace Flux
+{
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
-TaskStatus CheckCtop(MeshData<Real> *md);
+TaskStatus CheckCtop(MeshData<Real>* md);
 
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md);
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md);
 
-TaskStatus MarkFOFC(MeshData<Real> *md);
+TaskStatus MarkFOFC(MeshData<Real>* md);
 
 /**
  * Given a "guess" in which the fflag reflects zones which would fail with current fluxes,
  * replace fluxes surrounding flagged zones with donor-cell/first-order versions
  */
-TaskStatus FOFC(MeshData<Real> *md, MeshData<Real> *guess);
+TaskStatus FOFC(MeshData<Real>* md, MeshData<Real>* guess);
 
 /**
- * Add the geometric source term present in the covariant derivative of the stress-energy tensor,
- * S_nu = sqrt(-g) T^kap_lam Gamma^lam_nu_kap
- * This is defined in Flux:: rather than GRMHD:: because the stress-energy tensor may contain
- * (E)GR(R)(M)HD terms.
+ * Add the geometric source term present in the covariant derivative of the stress-energy
+ * tensor, S_nu = sqrt(-g) T^kap_lam Gamma^lam_nu_kap This is defined in Flux:: rather
+ * than GRMHD:: because the stress-energy tensor may contain (E)GR(R)(M)HD terms.
  */
-void AddGeoSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+void AddGeoSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 // Version returning TaskStatus, for calling alone in FOFC "update"
-// TODO(BSP) switch KHARMAPackage (and Parthenon packages?) to expect all TaskStatus
-inline TaskStatus AddGeoSourceTask(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+// TODO(CEP) switch KHARMAPackage (and Parthenon packages?) to expect all TaskStatus
+inline TaskStatus AddGeoSourceTask(
+    MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
     AddGeoSource(md, mdudt, domain);
     return TaskStatus::complete;
 }
 
 /**
- * Likewise, the conversion P->U, even for just the GRMHD variables, requires (consists of)
- * the stress-energy tensor.
+ * Likewise, the conversion P->U, even for just the GRMHD variables, requires (consists
+ * of) the stress-energy tensor.
  */
-TaskStatus BlockPtoUMHD(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse=false);
+TaskStatus BlockPtoUMHD(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse = false);
 
 /**
- * When calculating fluxes, we use Flux::prim_to_flux, which must generate conserved variables
- * and fluxes for all loaded packages correctly.
- * These calls just run that function over the grid.
+ * When calculating fluxes, we use Flux::prim_to_flux, which must generate conserved
+ * variables and fluxes for all loaded packages correctly. These calls just run that
+ * function over the grid.
  */
-TaskStatus BlockPtoU(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse=false);
-TaskStatus MeshPtoU(MeshData<Real> *md, IndexDomain domain, bool coarse=false);
+TaskStatus BlockPtoU(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse = false);
+TaskStatus MeshPtoU(MeshData<Real>* md, IndexDomain domain, bool coarse = false);
 
 /**
  * As above, except that IndexDomains of ghost cells are taken to cover
  * cells *sent* (that is, part of the domain) rather than received
- * 
+ *
  * UNUSED
  */
-TaskStatus BlockPtoU_Send(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+TaskStatus BlockPtoU_Send(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse);
 
 /**
  * Count how many zones forced first-order fluxes (*not* the number of fluxes reduced)
  */
-int CountFOFCFlags(MeshData<Real> *md);
+int CountFOFCFlags(MeshData<Real>* md);
 
 // Fluxes a.k.a. "Approximate Riemann Solvers"
 // More complex solvers require speed estimates not calculable completely from
 // invariants, necessitating frame transformations and related madness.
-// These have identical signatures, so that we could runtime relink w/variant like coordinate_embedding
+// These have identical signatures, so that we could runtime relink w/variant like
+// coordinate_embedding
 
 // Local Lax-Friedrichs flux (usual, more stable)
-KOKKOS_INLINE_FUNCTION Real llf(const Real& fluxL, const Real& fluxR, const Real& cmax, 
-                                const Real& cmin, const Real& Ul, const Real& Ur)
+KOKKOS_INLINE_FUNCTION Real llf(const Real& fluxL, const Real& fluxR, const Real& cmax,
+    const Real& cmin, const Real& Ul, const Real& Ur)
 {
     Real ctop = m::max(cmax, cmin);
     return 0.5 * (fluxL + fluxR - ctop * (Ur - Ul));
 }
-// Harten, Lax, van Leer, & Einfeldt flux (early problems but not extensively studied since)
+// Harten, Lax, van Leer, & Einfeldt flux (early problems but not extensively studied
+// since)
 KOKKOS_INLINE_FUNCTION Real hlle(const Real& fluxL, const Real& fluxR, const Real& cmax,
-                                const Real& cmin, const Real& Ul, const Real& Ur)
+    const Real& cmin, const Real& Ul, const Real& Ur)
 {
-    return (cmax*fluxL + cmin*fluxR - cmax*cmin*(Ur - Ul)) / (cmax + cmin);
+    return (cmax * fluxL + cmin * fluxR - cmax * cmin * (Ur - Ul)) / (cmax + cmin);
 }
 
 }

--- a/kharma/flux/flux_functions.hpp
+++ b/kharma/flux/flux_functions.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: flux_functions.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -51,21 +51,20 @@ namespace Flux
 
 // TODO Q > 0 != emhd_enabled.  Store enablement in emhd_params since we need it anyway
 template<typename Local>
-KOKKOS_FORCEINLINE_FUNCTION void calc_tensor(const Local& P, const VarMap& m_p, const FourVectors D,
-                                        const EMHD::EMHD_parameters& emhd_params, const Real& gam, const int& dir,
-                                        Real T[GR_DIM])
+KOKKOS_FORCEINLINE_FUNCTION void calc_tensor(const Local& P, const VarMap& m_p,
+    const FourVectors D, const EMHD::EMHD_parameters& emhd_params, const Real& gam,
+    const int& dir, Real T[GR_DIM])
 {
     if ((m_p.Q >= 0 || m_p.DP >= 0) && emhd_params.feedback) {
         // Apply higher-order terms conversion if necessary
         Real qtilde = 0., dPtilde = 0.;
-        if (m_p.Q >= 0)
-            qtilde = P(m_p.Q);
-        if (m_p.DP >= 0)
-            dPtilde = P(m_p.DP);
+        if (m_p.Q >= 0) qtilde = P(m_p.Q);
+        if (m_p.DP >= 0) dPtilde = P(m_p.DP);
         const Real Theta = (gam - 1) * P(m_p.UU) / P(m_p.RHO);
-        const Real cs2   = gam * (gam - 1) * P(m_p.UU) / (P(m_p.RHO) + gam * P(m_p.UU));
+        const Real cs2 = gam * (gam - 1) * P(m_p.UU) / (P(m_p.RHO) + gam * P(m_p.UU));
         Real q, dP;
-        EMHD::convert_prims_to_q_dP(qtilde, dPtilde, P(m_p.RHO), Theta, cs2, emhd_params, q, dP);
+        EMHD::convert_prims_to_q_dP(
+            qtilde, dPtilde, P(m_p.RHO), Theta, cs2, emhd_params, q, dP);
 
         // Then calculate the tensor
         EMHD::calc_tensor(P(m_p.RHO), P(m_p.UU), (gam - 1) * P(m_p.UU), q, dP, D, dir, T);
@@ -79,31 +78,33 @@ KOKKOS_FORCEINLINE_FUNCTION void calc_tensor(const Local& P, const VarMap& m_p, 
 }
 
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void calc_tensor(const Global& P, const VarMap& m_p, const FourVectors D,
-                                        const EMHD::EMHD_parameters& emhd_params, const Real& gam, 
-                                        const int& k, const int& j, const int& i, const int& dir,
-                                        Real T[GR_DIM])
+KOKKOS_FORCEINLINE_FUNCTION void calc_tensor(const Global& P, const VarMap& m_p,
+    const FourVectors D, const EMHD::EMHD_parameters& emhd_params, const Real& gam,
+    const int& k, const int& j, const int& i, const int& dir, Real T[GR_DIM])
 {
     if ((m_p.Q >= 0 || m_p.DP >= 0) && emhd_params.feedback) {
         // Apply higher-order terms conversion if necessary
         Real qtilde = 0., dPtilde = 0.;
-        if (m_p.Q >= 0)
-            qtilde = P(m_p.Q, k, j, i);
-        if (m_p.DP >= 0)
-            dPtilde = P(m_p.DP, k, j, i);
+        if (m_p.Q >= 0) qtilde = P(m_p.Q, k, j, i);
+        if (m_p.DP >= 0) dPtilde = P(m_p.DP, k, j, i);
         const Real Theta = (gam - 1) * P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
-        const Real cs2   = gam * (gam - 1) * P(m_p.UU, k, j, i) / (P(m_p.RHO, k, j, i) + gam * P(m_p.UU, k, j, i));
+        const Real cs2 = gam * (gam - 1) * P(m_p.UU, k, j, i) /
+                         (P(m_p.RHO, k, j, i) + gam * P(m_p.UU, k, j, i));
         Real q, dP;
-        EMHD::convert_prims_to_q_dP(qtilde, dPtilde, P(m_p.RHO, k, j, i), Theta, cs2, emhd_params, q, dP);
+        EMHD::convert_prims_to_q_dP(
+            qtilde, dPtilde, P(m_p.RHO, k, j, i), Theta, cs2, emhd_params, q, dP);
 
         // Then calculate the tensor
-        EMHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), (gam - 1) * P(m_p.UU, k, j, i), q, dP, D, dir, T);
+        EMHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+            (gam - 1) * P(m_p.UU, k, j, i), q, dP, D, dir, T);
     } else if (m_p.B1 >= 0) {
         // GRMHD stress-energy tensor w/ first index up, second index down
-        GRMHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), (gam - 1) * P(m_p.UU, k, j, i), D, dir, T);
+        GRMHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+            (gam - 1) * P(m_p.UU, k, j, i), D, dir, T);
     } else {
         // GRHD stress-energy tensor w/ first index up, second index down
-        GRHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), (gam - 1) * P(m_p.UU, k, j, i), D, dir, T);
+        GRHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+            (gam - 1) * P(m_p.UU, k, j, i), D, dir, T);
     }
 }
 
@@ -114,9 +115,10 @@ KOKKOS_FORCEINLINE_FUNCTION void calc_tensor(const Global& P, const VarMap& m_p,
  * Keep in mind loc should usually correspond to dir for perpendicuar fluxes
  */
 template<typename Local>
-KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Local& P, const VarMap& m_p, const FourVectors D,
-                                         const EMHD::EMHD_parameters& emhd_params, const Real& gam, const int& j, const int& i, const int& dir,
-                                         const Local& flux, const VarMap& m_u, const Loci loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Local& P,
+    const VarMap& m_p, const FourVectors D, const EMHD::EMHD_parameters& emhd_params,
+    const Real& gam, const int& j, const int& i, const int& dir, const Local& flux,
+    const VarMap& m_u, const Loci loc = Loci::center)
 {
     Real gdet = G.gdet(loc, j, i);
     // Particle number flux
@@ -134,54 +136,52 @@ KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Loca
     if (m_u.B1 >= 0) {
         // Magnetic field
         if (dir == 0) {
-            VLOOP flux(m_u.B1 + v) = P(m_p.B1 + v) * gdet;
+            VLOOP
+                flux(m_u.B1 + v) = P(m_p.B1 + v) * gdet;
         } else {
             // Constraint damping w/Dedner may add also P(m_p.psi) * gdet,
             // but for us this is in the source term
-            VLOOP flux(m_u.B1 + v) = (D.bcon[v+1] * D.ucon[dir] - D.bcon[dir] * D.ucon[v+1]) * gdet;
+            VLOOP
+                flux(m_u.B1 + v) =
+                    (D.bcon[v + 1] * D.ucon[dir] - D.bcon[dir] * D.ucon[v + 1]) * gdet;
         }
         // Extra scalar psi for constraint damping, see B_CD
         if (m_u.PSI >= 0) {
             if (dir == 0) {
                 flux(m_u.PSI) = P(m_p.PSI) * gdet;
             } else {
-                // Psi field update as in Mosta et al (IllinoisGRMHD), alternate explanation Jesse et al (2020)
-                //Real alpha = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
-                //Real beta_dir = G.gcon(Loci::center, j, i, 0, dir) * alpha * alpha;
-                flux(m_u.PSI) = (D.bcon[dir] - G.gcon(Loci::center, j, i, 0, dir) * P(m_p.PSI)) * gdet;
+                // Psi field update as in Mosta et al (IllinoisGRMHD), alternate
+                // explanation Jesse et al (2020)
+                // Real alpha = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
+                // Real beta_dir = G.gcon(Loci::center, j, i, 0, dir) * alpha * alpha;
+                flux(m_u.PSI) =
+                    (D.bcon[dir] - G.gcon(Loci::center, j, i, 0, dir) * P(m_p.PSI)) *
+                    gdet;
             }
         }
     }
 
     // EMHD Variables: advect like rho
-    if (m_u.Q >= 0)
-        flux(m_u.Q) = P(m_p.Q) * D.ucon[dir] * gdet;
-    if (m_u.DP >= 0)
-        flux(m_u.DP) = P(m_p.DP) * D.ucon[dir] * gdet;
+    if (m_u.Q >= 0) flux(m_u.Q) = P(m_p.Q) * D.ucon[dir] * gdet;
+    if (m_u.DP >= 0) flux(m_u.DP) = P(m_p.DP) * D.ucon[dir] * gdet;
 
     // Electrons: normalized by density
     if (m_u.KTOT >= 0) {
         flux(m_u.KTOT) = flux(m_u.RHO) * P(m_p.KTOT);
-        if (m_u.K_CONSTANT >= 0)
-            flux(m_u.K_CONSTANT) = flux(m_u.RHO) * P(m_p.K_CONSTANT);
-        if (m_u.K_HOWES >= 0)
-            flux(m_u.K_HOWES) = flux(m_u.RHO) * P(m_p.K_HOWES);
-        if (m_u.K_KAWAZURA >= 0)
-            flux(m_u.K_KAWAZURA) = flux(m_u.RHO) * P(m_p.K_KAWAZURA);
-        if (m_u.K_WERNER >= 0)
-            flux(m_u.K_WERNER) = flux(m_u.RHO) * P(m_p.K_WERNER);
-        if (m_u.K_ROWAN >= 0)
-            flux(m_u.K_ROWAN) = flux(m_u.RHO) * P(m_p.K_ROWAN);
-        if (m_u.K_SHARMA >= 0)
-            flux(m_u.K_SHARMA) = flux(m_u.RHO) * P(m_p.K_SHARMA);
+        if (m_u.K_CONSTANT >= 0) flux(m_u.K_CONSTANT) = flux(m_u.RHO) * P(m_p.K_CONSTANT);
+        if (m_u.K_HOWES >= 0) flux(m_u.K_HOWES) = flux(m_u.RHO) * P(m_p.K_HOWES);
+        if (m_u.K_KAWAZURA >= 0) flux(m_u.K_KAWAZURA) = flux(m_u.RHO) * P(m_p.K_KAWAZURA);
+        if (m_u.K_WERNER >= 0) flux(m_u.K_WERNER) = flux(m_u.RHO) * P(m_p.K_WERNER);
+        if (m_u.K_ROWAN >= 0) flux(m_u.K_ROWAN) = flux(m_u.RHO) * P(m_p.K_ROWAN);
+        if (m_u.K_SHARMA >= 0) flux(m_u.K_SHARMA) = flux(m_u.RHO) * P(m_p.K_SHARMA);
     }
 }
 
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Global& P, const VarMap& m_p, const FourVectors D,
-                                         const EMHD::EMHD_parameters& emhd_params, const Real& gam,
-                                         const int& k, const int& j, const int& i, const int& dir,
-                                         Real flux[MAX_VARS], const VarMap& m_u, const Loci loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const FourVectors D, const EMHD::EMHD_parameters& emhd_params,
+    const Real& gam, const int& k, const int& j, const int& i, const int& dir,
+    Real flux[MAX_VARS], const VarMap& m_u, const Loci loc = Loci::center)
 {
     Real gdet = G.gdet(loc, j, i);
     // Particle number flux
@@ -199,54 +199,56 @@ KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Glob
     if (m_u.B1 >= 0) {
         // Magnetic field
         if (dir == 0) {
-            VLOOP flux[m_u.B1 + v] = P(m_p.B1 + v, k, j, i) * gdet;
+            VLOOP
+                flux[m_u.B1 + v] = P(m_p.B1 + v, k, j, i) * gdet;
         } else {
             // Constraint damping w/Dedner may add also P(m_p.psi) * gdet,
             // but for us this is in the source term
-            VLOOP flux[m_u.B1 + v] = (D.bcon[v+1] * D.ucon[dir] - D.bcon[dir] * D.ucon[v+1]) * gdet;
+            VLOOP
+                flux[m_u.B1 + v] =
+                    (D.bcon[v + 1] * D.ucon[dir] - D.bcon[dir] * D.ucon[v + 1]) * gdet;
         }
         // Extra scalar psi for constraint damping, see B_CD
         if (m_u.PSI >= 0) {
             if (dir == 0) {
                 flux[m_u.PSI] = P(m_p.PSI, k, j, i) * gdet;
             } else {
-                // Psi field update as in Mosta et al (IllinoisGRMHD), alternate explanation Jesse et al (2020)
-                //Real alpha = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
-                //Real beta_dir = G.gcon(Loci::center, j, i, 0, dir) * alpha * alpha;
-                flux[m_u.PSI] = (D.bcon[dir] - G.gcon(Loci::center, j, i, 0, dir) * P(m_p.PSI, k, j, i)) * gdet;
+                // Psi field update as in Mosta et al (IllinoisGRMHD), alternate
+                // explanation Jesse et al (2020)
+                // Real alpha = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
+                // Real beta_dir = G.gcon(Loci::center, j, i, 0, dir) * alpha * alpha;
+                flux[m_u.PSI] = (D.bcon[dir] - G.gcon(Loci::center, j, i, 0, dir) *
+                                                   P(m_p.PSI, k, j, i)) *
+                                gdet;
             }
         }
     }
 
     // EMHD Variables: advect like rho
-    if (m_u.Q >= 0)
-        flux[m_u.Q] = P(m_p.Q, k, j, i) * D.ucon[dir] * gdet;
-    if (m_u.DP >= 0)
-        flux[m_u.DP] = P(m_p.DP, k, j, i) * D.ucon[dir] * gdet;
+    if (m_u.Q >= 0) flux[m_u.Q] = P(m_p.Q, k, j, i) * D.ucon[dir] * gdet;
+    if (m_u.DP >= 0) flux[m_u.DP] = P(m_p.DP, k, j, i) * D.ucon[dir] * gdet;
 
     // Electrons: normalized by density
     if (m_u.KTOT >= 0) {
         flux[m_u.KTOT] = flux[m_u.RHO] * P(m_p.KTOT, k, j, i);
         if (m_u.K_CONSTANT >= 0)
             flux[m_u.K_CONSTANT] = flux[m_u.RHO] * P(m_p.K_CONSTANT, k, j, i);
-        if (m_u.K_HOWES >= 0)
-            flux[m_u.K_HOWES] = flux[m_u.RHO] * P(m_p.K_HOWES, k, j, i);
+        if (m_u.K_HOWES >= 0) flux[m_u.K_HOWES] = flux[m_u.RHO] * P(m_p.K_HOWES, k, j, i);
         if (m_u.K_KAWAZURA >= 0)
             flux[m_u.K_KAWAZURA] = flux[m_u.RHO] * P(m_p.K_KAWAZURA, k, j, i);
         if (m_u.K_WERNER >= 0)
             flux[m_u.K_WERNER] = flux[m_u.RHO] * P(m_p.K_WERNER, k, j, i);
-        if (m_u.K_ROWAN >= 0)
-            flux[m_u.K_ROWAN] = flux[m_u.RHO] * P(m_p.K_ROWAN, k, j, i);
+        if (m_u.K_ROWAN >= 0) flux[m_u.K_ROWAN] = flux[m_u.RHO] * P(m_p.K_ROWAN, k, j, i);
         if (m_u.K_SHARMA >= 0)
             flux[m_u.K_SHARMA] = flux[m_u.RHO] * P(m_p.K_SHARMA, k, j, i);
     }
 }
 
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Global& P, const VarMap& m_p, const FourVectors D,
-                                         const EMHD::EMHD_parameters& emhd_params, const Real& gam, 
-                                         const int& k, const int& j, const int& i, const int dir,
-                                         const Global& flux, const VarMap& m_u, const Loci loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const FourVectors D, const EMHD::EMHD_parameters& emhd_params,
+    const Real& gam, const int& k, const int& j, const int& i, const int dir,
+    const Global& flux, const VarMap& m_u, const Loci loc = Loci::center)
 {
     const Real gdet = G.gdet(loc, j, i);
     // Particle number flux
@@ -263,57 +265,67 @@ KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux(const GRCoordinates& G, const Glob
     if (m_u.B1 >= 0) {
         // Magnetic field
         if (dir == 0) {
-            VLOOP flux(m_u.B1 + v, k, j, i) = P(m_p.B1 + v, k, j, i) * gdet;
+            VLOOP
+                flux(m_u.B1 + v, k, j, i) = P(m_p.B1 + v, k, j, i) * gdet;
         } else {
             // Constraint damping w/Dedner may add also P(m_p.psi) * gdet,
             // but for us this is in the source term
-            VLOOP flux(m_u.B1 + v, k, j, i) = (D.bcon[v+1] * D.ucon[dir] - D.bcon[dir] * D.ucon[v+1]) * gdet;
+            VLOOP
+                flux(m_u.B1 + v, k, j, i) =
+                    (D.bcon[v + 1] * D.ucon[dir] - D.bcon[dir] * D.ucon[v + 1]) * gdet;
         }
         // Extra scalar psi for constraint damping, see B_CD
         if (m_u.PSI >= 0) {
             if (dir == 0) {
                 flux(m_u.PSI, k, j, i) = P(m_p.PSI, k, j, i) * gdet;
             } else {
-                // Psi field update as in Mosta et al (IllinoisGRMHD), alternate explanation Jesse et al (2020)
-                //Real alpha = 1. / sqrt(-G.gcon(Loci::center, j, i, 0, 0));
-                //Real beta_dir = G.gcon(Loci::center, j, i, 0, dir) * alpha * alpha;
-                flux(m_u.PSI, k, j, i) = (D.bcon[dir] - G.gcon(Loci::center, j, i, 0, dir) * P(m_p.PSI, k, j, i)) * gdet;
+                // Psi field update as in Mosta et al (IllinoisGRMHD), alternate
+                // explanation Jesse et al (2020)
+                // Real alpha = 1. / sqrt(-G.gcon(Loci::center, j, i, 0, 0));
+                // Real beta_dir = G.gcon(Loci::center, j, i, 0, dir) * alpha * alpha;
+                flux(m_u.PSI, k, j, i) =
+                    (D.bcon[dir] -
+                        G.gcon(Loci::center, j, i, 0, dir) * P(m_p.PSI, k, j, i)) *
+                    gdet;
             }
         }
     }
 
     // EMHD Variables: advect like rho
-    if (m_u.Q >= 0)
-        flux(m_u.Q, k, j, i)  = P(m_p.Q, k, j, i) * D.ucon[dir] * gdet;
-    if (m_u.DP >= 0)
-        flux(m_u.DP, k, j, i) = P(m_p.DP, k, j, i) * D.ucon[dir] * gdet;
+    if (m_u.Q >= 0) flux(m_u.Q, k, j, i) = P(m_p.Q, k, j, i) * D.ucon[dir] * gdet;
+    if (m_u.DP >= 0) flux(m_u.DP, k, j, i) = P(m_p.DP, k, j, i) * D.ucon[dir] * gdet;
 
     // Electrons: normalized by density
     if (m_u.KTOT >= 0) {
-        flux(m_u.KTOT, k, j, i)  = flux(m_u.RHO, k, j, i) * P(m_p.KTOT, k, j, i);
+        flux(m_u.KTOT, k, j, i) = flux(m_u.RHO, k, j, i) * P(m_p.KTOT, k, j, i);
         if (m_u.K_CONSTANT >= 0)
-            flux(m_u.K_CONSTANT, k, j, i) = flux(m_u.RHO, k, j, i) * P(m_p.K_CONSTANT, k, j, i);
+            flux(m_u.K_CONSTANT, k, j, i) =
+                flux(m_u.RHO, k, j, i) * P(m_p.K_CONSTANT, k, j, i);
         if (m_u.K_HOWES >= 0)
-            flux(m_u.K_HOWES, k, j, i)    = flux(m_u.RHO, k, j, i) * P(m_p.K_HOWES, k, j, i);
+            flux(m_u.K_HOWES, k, j, i) = flux(m_u.RHO, k, j, i) * P(m_p.K_HOWES, k, j, i);
         if (m_u.K_KAWAZURA >= 0)
-            flux(m_u.K_KAWAZURA, k, j, i) = flux(m_u.RHO, k, j, i) * P(m_p.K_KAWAZURA, k, j, i);
+            flux(m_u.K_KAWAZURA, k, j, i) =
+                flux(m_u.RHO, k, j, i) * P(m_p.K_KAWAZURA, k, j, i);
         if (m_u.K_WERNER >= 0)
-            flux(m_u.K_WERNER, k, j, i)   = flux(m_u.RHO, k, j, i) * P(m_p.K_WERNER, k, j, i);
+            flux(m_u.K_WERNER, k, j, i) =
+                flux(m_u.RHO, k, j, i) * P(m_p.K_WERNER, k, j, i);
         if (m_u.K_ROWAN >= 0)
-            flux(m_u.K_ROWAN, k, j, i)    = flux(m_u.RHO, k, j, i) * P(m_p.K_ROWAN, k, j, i);
+            flux(m_u.K_ROWAN, k, j, i) = flux(m_u.RHO, k, j, i) * P(m_p.K_ROWAN, k, j, i);
         if (m_u.K_SHARMA >= 0)
-            flux(m_u.K_SHARMA, k, j, i)   = flux(m_u.RHO, k, j, i) * P(m_p.K_SHARMA, k, j, i);
+            flux(m_u.K_SHARMA, k, j, i) =
+                flux(m_u.RHO, k, j, i) * P(m_p.K_SHARMA, k, j, i);
     }
 }
 
 /**
- * P->U for just the GRMHD variables, but using the full tensor.  Needed with floors and in a few places
+ * P->U for just the GRMHD variables, but using the full tensor.  Needed with floors and
+ * in a few places
  */
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux_mhd(const GRCoordinates& G, const Global& P, const VarMap& m_p, const FourVectors D,
-                                         const EMHD::EMHD_parameters& emhd_params, const Real& gam, 
-                                         const int& k, const int& j, const int& i, const int dir,
-                                         const Global& flux, const VarMap& m_u, const Loci loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux_mhd(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const FourVectors D, const EMHD::EMHD_parameters& emhd_params,
+    const Real& gam, const int& k, const int& j, const int& i, const int dir,
+    const Global& flux, const VarMap& m_u, const Loci loc = Loci::center)
 {
     const Real& gdet = G.gdet(loc, j, i);
     // Particle number flux
@@ -328,12 +340,14 @@ KOKKOS_FORCEINLINE_FUNCTION void prim_to_flux_mhd(const GRCoordinates& G, const 
 }
 
 /**
- * Get the conserved (E)GRMHD variables corresponding to primitives in a zone. Equivalent to prim_to_flux with dir==0
+ * Get the conserved (E)GRMHD variables corresponding to primitives in a zone. Equivalent
+ * to prim_to_flux with dir==0
  */
 template<typename Local>
-KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P, const VarMap& m_p,
-                                   const EMHD::EMHD_parameters& emhd_params, const Real& gam, const int& j, const int& i,
-                                   const Local& U, const VarMap& m_u, const Loci& loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P,
+    const VarMap& m_p, const EMHD::EMHD_parameters& emhd_params, const Real& gam,
+    const int& j, const int& i, const Local& U, const VarMap& m_u,
+    const Loci& loc = Loci::center)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, j, i, loc, Dtmp);
@@ -341,10 +355,10 @@ KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P, 
 }
 
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P, const VarMap& m_p,
-                                   const EMHD::EMHD_parameters& emhd_params, const Real& gam, 
-                                   const int& k, const int& j, const int& i,
-                                   const Global& U, const VarMap& m_u, const Loci& loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const EMHD::EMHD_parameters& emhd_params, const Real& gam,
+    const int& k, const int& j, const int& i, const Global& U, const VarMap& m_u,
+    const Loci& loc = Loci::center)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
@@ -352,10 +366,10 @@ KOKKOS_FORCEINLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P,
 }
 
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void p_to_u_mhd(const GRCoordinates& G, const Global& P, const VarMap& m_p,
-                                   const EMHD::EMHD_parameters& emhd_params, const Real& gam, 
-                                   const int& k, const int& j, const int& i,
-                                   const Global& U, const VarMap& m_u, const Loci& loc=Loci::center)
+KOKKOS_FORCEINLINE_FUNCTION void p_to_u_mhd(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const EMHD::EMHD_parameters& emhd_params, const Real& gam,
+    const int& k, const int& j, const int& i, const Global& U, const VarMap& m_u,
+    const Loci& loc = Loci::center)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
@@ -366,35 +380,35 @@ KOKKOS_FORCEINLINE_FUNCTION void p_to_u_mhd(const GRCoordinates& G, const Global
  * Calculate components of magnetosonic velocity from primitive variables
  */
 template<typename Local>
-KOKKOS_FORCEINLINE_FUNCTION void vchar(const GRCoordinates& G, const Local& P, const VarMap& m, const FourVectors& D,
-                                  const Real& gam, const EMHD::EMHD_parameters& emhd_params, 
-                                  const int& k, const int& j, const int& i, const Loci& loc, const int& dir,
-                                  Real& cmax, Real& cmin)
+KOKKOS_FORCEINLINE_FUNCTION void vchar(const GRCoordinates& G, const Local& P,
+    const VarMap& m, const FourVectors& D, const Real& gam,
+    const EMHD::EMHD_parameters& emhd_params, const int& k, const int& j, const int& i,
+    const Loci& loc, const int& dir, Real& cmax, Real& cmin)
 {
     // Find sound speed
-    const Real ef  = P(m.RHO) + gam * P(m.UU);
+    const Real ef = P(m.RHO) + gam * P(m.UU);
     // The fluid sound speed should be at most sqrt(gam-1) for a relativistic fluid
     const Real cs2 = clip(gam * (gam - 1) * P(m.UU) / ef, 0., gam - 1.);
     Real cms2;
     if (m.Q >= 0 || m.DP >= 0) {
-         // Get the EGRMHD parameters
+        // Get the EGRMHD parameters
         Real tau, chi_e, nu_e;
         EMHD::set_parameters(G, P, m, emhd_params, gam, j, i, tau, chi_e, nu_e);
-        
+
         // Find fast magnetosonic speed
         const Real bsq = dot(D.bcon, D.bcov);
         const Real va2 = bsq / (bsq + ef);
 
-        const Real ccond2 = (m.Q >= 0)
-            ? (gam - 1.) * emhd_params.conduction_alpha * cs2
-            : 0.0;
-        const Real cvis2 = (m.DP >= 0)
-            ? (4./3.) / (P(m.RHO) + (gam * P(m.UU)) ) * P(m.RHO) * emhd_params.viscosity_alpha * cs2
-            : 0.0;
+        const Real ccond2 =
+            (m.Q >= 0) ? (gam - 1.) * emhd_params.conduction_alpha * cs2 : 0.0;
+        const Real cvis2 = (m.DP >= 0) ? (4. / 3.) / (P(m.RHO) + (gam * P(m.UU))) *
+                                             P(m.RHO) * emhd_params.viscosity_alpha * cs2
+                                       : 0.0;
 
-        const Real cs2_emhd = 0.5*(cs2 + ccond2 + m::sqrt(cs2*cs2 + ccond2*ccond2)) + cvis2;
+        const Real cs2_emhd =
+            0.5 * (cs2 + ccond2 + m::sqrt(cs2 * cs2 + ccond2 * ccond2)) + cvis2;
 
-        cms2 = cs2_emhd + va2 - cs2_emhd*va2;
+        cms2 = cs2_emhd + va2 - cs2_emhd * va2;
     } else if (m.B1 >= 0) {
         // Find fast magnetosonic speed
         const Real bsq = dot(D.bcon, D.bcov);
@@ -411,21 +425,22 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar(const GRCoordinates& G, const Local& P, c
     Real A, B, C;
     {
         Real Bcov[GR_DIM] = {1., 0., 0., 0.};
-        Real Acov[GR_DIM] = {0}; Acov[dir] = 1.;
+        Real Acov[GR_DIM] = {0};
+        Acov[dir] = 1.;
 
         Real Acon[GR_DIM], Bcon[GR_DIM];
         G.raise(Acov, Acon, k, j, i, loc);
         G.raise(Bcov, Bcon, k, j, i, loc);
 
-        const Real Asq  = dot(Acon, Acov);
-        const Real Bsq  = dot(Bcon, Bcov);
-        const Real Au   = dot(Acov, D.ucon);
-        const Real Bu   = dot(Bcov, D.ucon);
-        const Real AB   = dot(Acon, Bcov);
+        const Real Asq = dot(Acon, Acov);
+        const Real Bsq = dot(Bcon, Bcov);
+        const Real Au = dot(Acov, D.ucon);
+        const Real Bu = dot(Bcov, D.ucon);
+        const Real AB = dot(Acon, Bcov);
 
-        A = Bu*Bu - (Bsq + Bu*Bu) * cms2;
-        B = 2. * (Au*Bu - (AB + Au*Bu) * cms2);
-        C = Au*Au - (Asq + Au*Au) * cms2;
+        A = Bu * Bu - (Bsq + Bu * Bu) * cms2;
+        B = 2. * (Au * Bu - (AB + Au * Bu) * cms2);
+        C = Au * Au - (Asq + Au * Au) * cms2;
     }
 
     Real discr = m::sqrt(m::max(B * B - 4. * A * C, 0.));
@@ -438,37 +453,39 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar(const GRCoordinates& G, const Local& P, c
 }
 
 // This is expressly for updating cmin/max for FOFC zones
-// It's named differently because it already took k,j,i so we can't pull the overloading w/different signatures trick
+// It's named differently because it already took k,j,i so we can't pull the overloading
+// w/different signatures trick
 template<typename Global>
-KOKKOS_FORCEINLINE_FUNCTION void vchar_global(const GRCoordinates& G, const Global& P, const VarMap& m, const FourVectors& D,
-                                  const Real& gam, const EMHD::EMHD_parameters& emhd_params, 
-                                  const int& k, const int& j, const int& i, const Loci& loc, const int& dir,
-                                  Real& cmax, Real& cmin)
+KOKKOS_FORCEINLINE_FUNCTION void vchar_global(const GRCoordinates& G, const Global& P,
+    const VarMap& m, const FourVectors& D, const Real& gam,
+    const EMHD::EMHD_parameters& emhd_params, const int& k, const int& j, const int& i,
+    const Loci& loc, const int& dir, Real& cmax, Real& cmin)
 {
     // Find sound speed
-    const Real ef  = P(m.RHO, k, j, i) + gam * P(m.UU, k, j, i);
+    const Real ef = P(m.RHO, k, j, i) + gam * P(m.UU, k, j, i);
     // The fluid sound speed should be at most sqrt(gam-1) for a relativistic fluid
     const Real cs2 = clip(gam * (gam - 1) * P(m.UU, k, j, i) / ef, 0., gam - 1.);
     Real cms2;
     if (m.Q >= 0 || m.DP >= 0) {
-         // Get the EGRMHD parameters
+        // Get the EGRMHD parameters
         Real tau, chi_e, nu_e;
         EMHD::set_parameters(G, P, m, emhd_params, gam, k, j, i, tau, chi_e, nu_e);
-        
+
         // Find fast magnetosonic speed
         const Real bsq = dot(D.bcon, D.bcov);
         const Real va2 = bsq / (bsq + ef);
 
-        const Real ccond2 = (m.Q >= 0)
-            ? (gam - 1.) * emhd_params.conduction_alpha * cs2
-            : 0.0;
-        const Real cvis2 = (m.DP >= 0)
-            ? (4./3.) / (P(m.RHO, k, j, i) + (gam * P(m.UU, k, j, i)) ) * P(m.RHO, k, j, i) * emhd_params.viscosity_alpha * cs2
-            : 0.0;
+        const Real ccond2 =
+            (m.Q >= 0) ? (gam - 1.) * emhd_params.conduction_alpha * cs2 : 0.0;
+        const Real cvis2 =
+            (m.DP >= 0) ? (4. / 3.) / (P(m.RHO, k, j, i) + (gam * P(m.UU, k, j, i))) *
+                              P(m.RHO, k, j, i) * emhd_params.viscosity_alpha * cs2
+                        : 0.0;
 
-        const Real cs2_emhd = 0.5*(cs2 + ccond2 + m::sqrt(cs2*cs2 + ccond2*ccond2)) + cvis2;
+        const Real cs2_emhd =
+            0.5 * (cs2 + ccond2 + m::sqrt(cs2 * cs2 + ccond2 * ccond2)) + cvis2;
 
-        cms2 = cs2_emhd + va2 - cs2_emhd*va2;
+        cms2 = cs2_emhd + va2 - cs2_emhd * va2;
     } else if (m.B1 >= 0) {
         // Find fast magnetosonic speed
         const Real bsq = dot(D.bcon, D.bcov);
@@ -485,21 +502,22 @@ KOKKOS_FORCEINLINE_FUNCTION void vchar_global(const GRCoordinates& G, const Glob
     Real A, B, C;
     {
         Real Bcov[GR_DIM] = {1., 0., 0., 0.};
-        Real Acov[GR_DIM] = {0}; Acov[dir] = 1.;
+        Real Acov[GR_DIM] = {0};
+        Acov[dir] = 1.;
 
         Real Acon[GR_DIM], Bcon[GR_DIM];
         G.raise(Acov, Acon, k, j, i, loc);
         G.raise(Bcov, Bcon, k, j, i, loc);
 
-        const Real Asq  = dot(Acon, Acov);
-        const Real Bsq  = dot(Bcon, Bcov);
-        const Real Au   = dot(Acov, D.ucon);
-        const Real Bu   = dot(Bcov, D.ucon);
-        const Real AB   = dot(Acon, Bcov);
+        const Real Asq = dot(Acon, Acov);
+        const Real Bsq = dot(Bcon, Bcov);
+        const Real Au = dot(Acov, D.ucon);
+        const Real Bu = dot(Bcov, D.ucon);
+        const Real AB = dot(Acon, Bcov);
 
-        A = Bu*Bu - (Bsq + Bu*Bu) * cms2;
-        B = 2. * (Au*Bu - (AB + Au*Bu) * cms2);
-        C = Au*Au - (Asq + Au*Au) * cms2;
+        A = Bu * Bu - (Bsq + Bu * Bu) * cms2;
+        B = 2. * (Au * Bu - (AB + Au * Bu) * cms2);
+        C = Au * Au - (Asq + Au * Au) * cms2;
     }
 
     Real discr = m::sqrt(m::max(B * B - 4. * A * C, 0.));

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: fofc.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,9 +40,9 @@
 using namespace parthenon;
 
 // Very bad definition. TODO get rid of this eventually
-#define PLOOP for(int ip=0; ip < nvar; ++ip)
+#define PLOOP for (int ip = 0; ip < nvar; ++ip)
 
-TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
+TaskStatus Flux::MarkFOFC(MeshData<Real>* guess)
 {
     auto pmb0 = guess->GetBlockData(0)->GetBlockPointer();
 
@@ -57,56 +57,62 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
     const bool spherical = pmb0->coords.coords.is_spherical();
     const int polar_cells = pars.Get<int>("fofc_polar_cells");
     const GReal r_eh = pmb0->coords.coords.get_horizon();
-    const GReal fofc_radius = pars.Get<bool>("fofc_use_eh_buffer") ?
-                                r_eh + pars.Get<GReal>("fofc_eh_buffer") :
-                                0.;
+    const GReal fofc_radius = pars.Get<bool>("fofc_use_eh_buffer")
+                                  ? r_eh + pars.Get<GReal>("fofc_eh_buffer")
+                                  : 0.;
 
     // Pre-mark cells which will need fluxes reduced.
     // This avoids a race condition marking them multiple times when iterating faces,
-    // and isolates the potentially slow/weird integer conversion stuff so we can measure the kernel time
+    // and isolates the potentially slow/weird integer conversion stuff so we can measure
+    // the kernel time
     const IndexRange3 b = KDomain::GetRange(guess, IndexDomain::entire);
     const IndexRange block = IndexRange{0, fofcflag.GetDim(5) - 1};
     pmb0->par_for("fofc_mark", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = fofcflag.GetCoords(b);
             // if cell failed to invert or would call floors...
             // TODO preserve cause in the fofcflag
-            if (static_cast<int>(fflag(b, 0, k, j, i)) || //Inverter::failed(pflag(b, 0, k, j, i)) ||
+            if (static_cast<int>(
+                    fflag(b, 0, k, j, i)) || // Inverter::failed(pflag(b, 0, k, j, i)) ||
                 (spherical && G.r(k, j, i) < fofc_radius)) {
                 fofcflag(b, 0, k, j, i) = 1;
             } else {
                 fofcflag(b, 0, k, j, i) = 0;
             }
-        }
-    );
+        });
 
     if (spherical && polar_cells > 0) {
         for (int i_block = 0; i_block < guess->NumBlocks(); i_block++) {
-            auto &rc = guess->GetBlockData(i_block);
+            auto& rc = guess->GetBlockData(i_block);
             auto pmb = rc->GetBlockPointer();
-            const bool is_inner_x2 = KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2);
-            const bool is_outer_x2 = KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2);
+            const bool is_inner_x2 =
+                KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2);
+            const bool is_outer_x2 =
+                KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2);
             if (is_inner_x2 || is_outer_x2) {
                 auto lfofcflag = rc->PackVariables(std::vector<std::string>{"fofcflag"});
                 if (is_inner_x2) {
                     const IndexRange3 b = KDomain::GetRange(guess, IndexDomain::inner_x2);
                     int jstart = b.je + 1;
                     int jend = jstart + polar_cells - 1;
-                    pmb0->par_for("fofc_mark_inner_x2", b.ks, b.ke, jstart, jend, b.is, b.ie,
-                        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                    pmb0->par_for("fofc_mark_inner_x2", b.ks, b.ke, jstart, jend, b.is,
+                        b.ie,
+                                  KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                        {
                             lfofcflag(0, k, j, i) = 1;
-                        }
-                    );
+                        });
                 }
                 if (is_outer_x2) {
                     const IndexRange3 b = KDomain::GetRange(guess, IndexDomain::outer_x2);
                     int jend = b.js - 1;
                     int jstart = jend - polar_cells + 1;
-                    pmb0->par_for("fofc_mark_outer_x2", b.ks, b.ke, jstart, jend, b.is, b.ie,
-                        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                    pmb0->par_for("fofc_mark_outer_x2", b.ks, b.ke, jstart, jend, b.is,
+                        b.ie,
+                                  KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                        {
                             lfofcflag(0, k, j, i) = 1;
-                        }
-                    );
+                        });
                 }
             }
         }
@@ -115,7 +121,7 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
     return TaskStatus::complete;
 }
 
-TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
+TaskStatus Flux::FOFC(MeshData<Real>* md, MeshData<Real>* guess)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     auto& packages = pmb0->packages;
@@ -133,13 +139,14 @@ TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
     const auto& Fl_all = md->PackVariables(std::vector<std::string>{"Flux.Fl"});
     const auto& Fr_all = md->PackVariables(std::vector<std::string>{"Flux.Fr"});
     // I assume we should update cmax/cmin. Else we should use the old ones, so
-    const auto& cmax  = md->PackVariables(std::vector<std::string>{"Flux.cmax"});
-    const auto& cmin  = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
+    const auto& cmax = md->PackVariables(std::vector<std::string>{"Flux.cmax"});
+    const auto& cmin = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
     // TODO this does NOT necessarily leave Flux.xyz vars in a matching state with GetFlux
     // It will be filled according to m_u/cons_map, which does not contain B
     PackIndexMap cons_map, prims_map;
-    std::vector<MetadataFlag> prims_flags = {Metadata::GetUserFlag("Primitive"), Metadata::Cell};
+    std::vector<MetadataFlag> prims_flags = {
+        Metadata::GetUserFlag("Primitive"), Metadata::Cell};
     std::vector<MetadataFlag> cons_flags = {Metadata::Conserved, Metadata::Cell};
     const auto& P_all = md->PackVariables(prims_flags, prims_map);
     const auto& U_all = md->PackVariablesAndFluxes(cons_flags, cons_map);
@@ -156,73 +163,91 @@ TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
     // Only fix faces if they exist
     const bool face_b = (Bf.GetDim(4) > 0 && pars.Get<bool>("fofc_consistent_face_b"));
 
-    for (int dir=1; dir <= ndim; dir++) { // TODO if(trivial_direction) etc
+    for (int dir = 1; dir <= ndim; dir++) { // TODO if(trivial_direction) etc
         const TE el = FaceOf(dir);
         const Loci loc = loc_of(dir);
         const IndexRange3 b = KDomain::GetRange(md, IndexDomain::interior, el, -1, 1);
         const IndexRange block = IndexRange{0, P_all.GetDim(5) - 1};
-        pmb0->par_for("fofc_replacement", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
+        pmb0->par_for("fofc_replacement", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is,
+            b.ie,
+            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+            {
                 const auto& G = P_all.GetCoords(b);
 
-                // Face i,j,k borders cell with same index and 1 left with index:
+                // Face i,j,k borders cell with same index and 1 left with
+                // index:
                 int kk = (dir == 3) ? k - 1 : k;
                 int jj = (dir == 2) ? j - 1 : j;
                 int ii = (dir == 1) ? i - 1 : i;
                 // If either bordering cell is marked
                 if (static_cast<int>(fofcflag(b, 0, k, j, i)) ||
-                    static_cast<int>(fofcflag(b, 0, kk, jj, ii))) { // TODO allow customizing
+                    static_cast<int>(
+                        fofcflag(b, 0, kk, jj, ii))) { // TODO allow customizing
 
-                    // "Reconstruct" left & right of this face: left is left cell, right is shared-index
-                    PLOOP Pl_all(b, ip, k, j, i) = P_all(b, ip, kk, jj, ii);
-                    PLOOP Pr_all(b, ip, k, j, i) = P_all(b, ip, k, j, i);
+                    // "Reconstruct" left & right of this face: left is left
+                    // cell, right is shared-index
+                    PLOOP
+                        Pl_all(b, ip, k, j, i) = P_all(b, ip, kk, jj, ii);
+                    PLOOP
+                        Pr_all(b, ip, k, j, i) = P_all(b, ip, k, j, i);
                     // Preserve the existing field at the face
                     if (face_b) {
-                        Pl_all(b, m_p.B1+dir-1, k, j, i) = Bf(b, el, 0, k, j, i) / G.gdet(loc, j, i);
-                        Pr_all(b, m_p.B1+dir-1, k, j, i) = Bf(b, el, 0, k, j, i) / G.gdet(loc, j, i);
+                        Pl_all(b, m_p.B1 + dir - 1, k, j, i) =
+                            Bf(b, el, 0, k, j, i) / G.gdet(loc, j, i);
+                        Pr_all(b, m_p.B1 + dir - 1, k, j, i) =
+                            Bf(b, el, 0, k, j, i) / G.gdet(loc, j, i);
                     }
 
                     FourVectors Dtmp;
                     // Left
                     GRMHD::calc_4vecs(G, Pl_all(b), m_p, k, j, i, loc, Dtmp);
-                    Flux::prim_to_flux(G, Pl_all(b), m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ul_all(b), m_u, loc);
-                    Flux::prim_to_flux(G, Pl_all(b), m_p, Dtmp, emhd_params, gam, k, j, i, dir, Fl_all(b), m_u, loc);
+                    Flux::prim_to_flux(G, Pl_all(b), m_p, Dtmp, emhd_params, gam, k, j, i,
+                        0, Ul_all(b), m_u, loc);
+                    Flux::prim_to_flux(G, Pl_all(b), m_p, Dtmp, emhd_params, gam, k, j, i,
+                        dir, Fl_all(b), m_u, loc);
                     // Magnetosonic speeds
                     Real cmaxL, cminL;
-                    Flux::vchar_global(G, Pl_all(b), m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxL, cminL);
+                    Flux::vchar_global(G, Pl_all(b), m_p, Dtmp, gam, emhd_params, k, j, i,
+                        loc, dir, cmaxL, cminL);
                     // Record speeds
-                    cmax(b, dir-1, k, j, i) = m::max(0., cmaxL);
-                    cmin(b, dir-1, k, j, i) = m::min(0., cminL);
+                    cmax(b, dir - 1, k, j, i) = m::max(0., cmaxL);
+                    cmin(b, dir - 1, k, j, i) = m::min(0., cminL);
 
                     // Right
                     GRMHD::calc_4vecs(G, Pr_all(b), m_p, k, j, i, loc, Dtmp);
-                    Flux::prim_to_flux(G, Pr_all(b), m_p, Dtmp, emhd_params, gam, k, j, i, 0, Ur_all(b), m_u, loc);
-                    Flux::prim_to_flux(G, Pr_all(b), m_p, Dtmp, emhd_params, gam, k, j, i, dir, Fr_all(b), m_u, loc);
+                    Flux::prim_to_flux(G, Pr_all(b), m_p, Dtmp, emhd_params, gam, k, j, i,
+                        0, Ur_all(b), m_u, loc);
+                    Flux::prim_to_flux(G, Pr_all(b), m_p, Dtmp, emhd_params, gam, k, j, i,
+                        dir, Fr_all(b), m_u, loc);
                     // Magnetosonic speeds
                     Real cmaxR, cminR;
-                    Flux::vchar_global(G, Pr_all(b), m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxR, cminR);
+                    Flux::vchar_global(G, Pr_all(b), m_p, Dtmp, gam, emhd_params, k, j, i,
+                        loc, dir, cmaxR, cminR);
                     // Calculate cmax/min based on comparison with cached values
                     if (!use_global) {
-                        cmax(b, dir-1, k, j, i) =  m::max(cmax(b, dir-1, k, j, i), cmaxR);
-                        cmin(b, dir-1, k, j, i) = -m::min(cmin(b, dir-1, k, j, i), cminR);
+                        cmax(b, dir - 1, k, j, i) =
+                            m::max(cmax(b, dir - 1, k, j, i), cmaxR);
+                        cmin(b, dir - 1, k, j, i) =
+                            -m::min(cmin(b, dir - 1, k, j, i), cminR);
                     } else {
-                        // This conveniently also reduces the timestep if necessary
-                        // Though, you should almost certainly set use_dt_light w/this
-                        cmax(b, dir-1, k, j, i) = 1.;
-                        cmin(b, dir-1, k, j, i) = 1.;
+                        // This conveniently also reduces the timestep if
+                        // necessary -- though, you should almost certainly set
+                        // use_dt_light w/this
+                        cmax(b, dir - 1, k, j, i) = 1.;
+                        cmin(b, dir - 1, k, j, i) = 1.;
                     }
 
-                    // Use LLF flux. Note we replace fluxes of all variables (including B!)
-                    // This is for a consistent scheme, i.e. all cells FOFC == using DC+LLF
+                    // Use LLF flux. Note we replace fluxes of all variables
+                    // (including B!) This is for a consistent scheme, i.e. all
+                    // cells FOFC == using DC+LLF
                     PLOOP
-                        U_all(b).flux(dir, ip, k, j, i) = llf(Fl_all(b, ip, k, j, i), Fr_all(b, ip, k, j, i),
-                                                            cmax(b, dir-1, k, j, i), cmin(b, dir-1, k, j, i),
-                                                            Ul_all(b, ip, k, j, i), Ur_all(b, ip, k, j, i));
+                        U_all(b).flux(dir, ip, k, j, i) =
+                            llf(Fl_all(b, ip, k, j, i), Fr_all(b, ip, k, j, i),
+                                cmax(b, dir - 1, k, j, i), cmin(b, dir - 1, k, j, i),
+                                Ul_all(b, ip, k, j, i), Ur_all(b, ip, k, j, i));
                 }
-            }
-        );
+            });
     }
 
     return TaskStatus::complete;
-
 }

--- a/kharma/flux/get_flux.hpp
+++ b/kharma/flux/get_flux.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: get_flux.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -38,44 +38,45 @@
 #include "domain.hpp"
 #include "floors_functions.hpp"
 
-namespace Flux {
+namespace Flux
+{
 
 /**
- * @brief Reconstruct the values of primitive variables at left and right of each zone face,
- * find the corresponding conserved variables and their fluxes through the face
+ * @brief Reconstruct the values of primitive variables at left and right of each zone
+ * face, find the corresponding conserved variables and their fluxes through the face
  *
  * @param md the current stage MeshData container, holding pointers to all variable data
  *
- * Memory-wise, this fills the fluxes stored with the "conserved" fields.  These will be used
- * over the course of the step to calculate an update to the zone-centered values.
+ * Memory-wise, this fills the fluxes stored with the "conserved" fields.  These will be
+ * used over the course of the step to calculate an update to the zone-centered values.
  * This function also fills the "Flux.cmax" & "Flux.cmin" vectors with the signal speeds,
  * and potentially the "Flux.vl" and "Flux.vr" vectors with the fluid velocities
- * 
- * This function is defined in the header because it is templated on the reconstruction scheme and
- * direction.  Since there are only a few reconstruction schemes supported, and we will only ever
- * need fluxes in three directions, we can recompile the function for every combination.
- * This allows some extra optimization from knowing that dir != 0 in parcticular, and inlining
- * the particular reconstruction call we need.
+ *
+ * This function is defined in the header because it is templated on the reconstruction
+ * scheme and direction.  Since there are only a few reconstruction schemes supported, and
+ * we will only ever need fluxes in three directions, we can recompile the function for
+ * every combination. This allows some extra optimization from knowing that dir != 0 in
+ * parcticular, and inlining the particular reconstruction call we need.
  */
-template <KReconstruction::Type Recon, int dir>
-inline TaskStatus GetFlux(MeshData<Real> *md)
+template<KReconstruction::Type Recon, int dir>
+inline TaskStatus GetFlux(MeshData<Real>* md)
 {
     // Pointers
     auto pmesh = md->GetMeshPointer();
-    auto pmb0  = md->GetBlockData(0)->GetBlockPointer();
+    auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     auto& packages = pmb0->packages;
     // Exit on trivial operations
     const int ndim = pmesh->ndim;
     if (ndim < 3 && dir == X3DIR) return TaskStatus::complete;
     if (ndim < 2 && dir == X2DIR) return TaskStatus::complete;
 
-    Flag("GetFlux_"+std::to_string(dir));
+    Flag("GetFlux_" + std::to_string(dir));
 
     // Options
-    const auto& pars       = packages.Get("Fluxes")->AllParams();
-    const auto& mhd_pars   = packages.Get("GRMHD")->AllParams();
-    const auto& globals    = packages.Get("Globals")->AllParams();
-    const bool use_hlle    = pars.Get<bool>("use_hlle");
+    const auto& pars = packages.Get("Fluxes")->AllParams();
+    const auto& mhd_pars = packages.Get("GRMHD")->AllParams();
+    const auto& globals = packages.Get("Globals")->AllParams();
+    const bool use_hlle = pars.Get<bool>("use_hlle");
 
     const bool reconstruction_floors = pars.Get<bool>("reconstruction_floors");
     Floors::Prescription floors_temp;
@@ -84,8 +85,9 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
         // Apply post-reconstruction floors.
         // Only enabled for WENO since it is not TVD, and only when other
         // floors are enabled.
-        floors_temp       = packages.Get("Floors")->Param<Floors::Prescription>("prescription");
-        floors_inner_temp = packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
+        floors_temp = packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+        floors_inner_temp =
+            packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner");
     }
     const Floors::Prescription& floors = floors_temp;
     const Floors::Prescription& floors_inner = floors_inner_temp;
@@ -97,10 +99,12 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
     // Check whether we're using constraint-damping
     // (which requires that a variable be propagated at ctop_max)
     const bool use_b_cd = packages.AllPackages().count("B_CD");
-    const double ctop_max = (use_b_cd) ? packages.Get("B_CD")->Param<Real>("ctop_max_last") : 0.0;
+    const double ctop_max =
+        (use_b_cd) ? packages.Get("B_CD")->Param<Real>("ctop_max_last") : 0.0;
 
     const bool use_ismr = packages.AllPackages().count("ISMR");
-    const int ng_plus_nlevels = use_ismr ? packages.Get("ISMR")->Param<uint>("nlevels") + Globals::nghost : 0;
+    const int ng_plus_nlevels =
+        use_ismr ? packages.Get("ISMR")->Param<uint>("nlevels") + Globals::nghost : 0;
 
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(packages);
 
@@ -108,11 +112,14 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
 
     // Pack variables.  Keep ctop separate
     PackIndexMap prims_map, cons_map;
-    const auto& cmax  = md->PackVariables(std::vector<std::string>{"Flux.cmax"});
-    const auto& cmin  = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
+    const auto& cmax = md->PackVariables(std::vector<std::string>{"Flux.cmax"});
+    const auto& cmin = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
-    const auto& P_all = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    const auto& U_all = md->PackVariablesAndFluxes(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    const auto& P_all = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::Cell},
+        prims_map);
+    const auto& U_all = md->PackVariablesAndFluxes(
+        std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
     const auto& Pl_all = md->PackVariables(std::vector<std::string>{"Flux.Pl"});
@@ -123,17 +130,20 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
     const auto& Fr_all = md->PackVariables(std::vector<std::string>{"Flux.Fr"});
 
     // Get the domain size
-    // We need fluxes outside the domain for flux-CT and FOFC: one extra zone update on each side
-    const IndexRange3 b = KDomain::GetRange(md, IndexDomain::interior, FaceOf(dir), -1, 1);
+    // We need fluxes outside the domain for flux-CT and FOFC: one extra zone update on
+    // each side
+    const IndexRange3 b =
+        KDomain::GetRange(md, IndexDomain::interior, FaceOf(dir), -1, 1);
     // Get other sizes we need
     const int n1 = pmb0->cellbounds.ncellsi(IndexDomain::entire);
     const IndexRange block = IndexRange{0, cmax.GetDim(5) - 1};
     const int nvar = U_all.GetDim(4);
 
     if (globals.Get<int>("verbose") > 2) {
-        std::cout << "Calculating fluxes for " << cmax.GetDim(5) << " blocks, "
-                << nvar << " variables (" << P_all.GetDim(4) << " primitives)" << std::endl;
-        m_u.print(); m_p.print();
+        std::cout << "Calculating fluxes for " << cmax.GetDim(5) << " blocks, " << nvar
+                  << " variables (" << P_all.GetDim(4) << " primitives)" << std::endl;
+        m_u.print();
+        m_p.print();
         emhd_params.print();
     }
 
@@ -142,19 +152,26 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
     const size_t var_size_in_bytes = parthenon::ScratchPad2D<Real>::shmem_size(nvar, n1);
     const size_t line_size_in_bytes = parthenon::ScratchPad1D<int>::shmem_size(n1);
     // Allocate enough to cache prims, conserved, and fluxes, for left and right faces,
-    // plus temporaries inside reconstruction (most use none, donor_cell uses one, linear_vl uses a bunch)
+    // plus temporaries inside reconstruction (most use none, donor_cell uses one,
+    // linear_vl uses a bunch)
     using RType = KReconstruction::Type;
-    const size_t recon_scratch_bytes = (4 + 1*(Recon == RType::donor_cell) +
-                                            5*(Recon == RType::linear_vl)) * var_size_in_bytes +
-                                        line_size_in_bytes;
+    const size_t recon_scratch_bytes =
+        (4 + 1 * (Recon == RType::donor_cell) + 5 * (Recon == RType::linear_vl)) *
+            var_size_in_bytes +
+        line_size_in_bytes;
     const size_t flux_scratch_bytes = 3 * var_size_in_bytes;
 
     // This isn't a pmb0->par_for_outer because Parthenon's current overloaded definitions
     // do not accept three pairs of bounds, which we need in order to iterate over blocks
-    Flag("GetFlux_"+std::to_string(dir)+"_recon");
-    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "calc_flux_recon", pmb0->exec_space,
-        recon_scratch_bytes, scratch_level, block.s, block.e, b.ks, b.ke, b.js, b.je,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& bl, const int& k, const int& j) {
+    Flag("GetFlux_" + std::to_string(dir) + "_recon");
+    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "calc_flux_recon",
+        pmb0->exec_space, recon_scratch_bytes, scratch_level, block.s, block.e, b.ks,
+        b.ke, b.js, b.je,
+        KOKKOS_LAMBDA(parthenon::team_mbr_t member,
+                      const int& bl,
+                      const int& k,
+                      const int& j)
+        {
             const auto& G = U_all.GetCoords(bl);
             ScratchPad2D<Real> Pl_s(member.team_scratch(scratch_level), nvar, n1);
             ScratchPad2D<Real> Pr_s(member.team_scratch(scratch_level), nvar, n1);
@@ -163,105 +180,122 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
             ScratchPad1D<int> fallback_tvd(member.team_scratch(scratch_level), n1);
 
             // We template on reconstruction type to avoid a big switch statement here.
-            // Instead, a version of GetFlux() is generated separately for each reconstruction/direction pair.
-            // See reconstruction.hpp for all the implementations.
+            // Instead, a version of GetFlux() is generated separately for each
+            // reconstruction/direction pair. See reconstruction.hpp for all the
+            // implementations.
             if (use_ismr) {
-                KReconstruction::ReconstructRowIsmr<Recon, dir>(member, P_all(bl), k, j, b.is, b.ie, ng_plus_nlevels, Pl_s, Pr_s);
+                KReconstruction::ReconstructRowIsmr<Recon, dir>(
+                    member, P_all(bl), k, j, b.is, b.ie, ng_plus_nlevels, Pl_s, Pr_s);
             } else {
-                KReconstruction::ReconstructRow<Recon, dir>(member, P_all(bl), k, j, b.is, b.ie, Pl_s, Pr_s);
+                KReconstruction::ReconstructRow<Recon, dir>(
+                    member, P_all(bl), k, j, b.is, b.ie, Pl_s, Pr_s);
             }
 
             // Sync all threads in the team so that scratch memory is consistent
             member.team_barrier();
 
             parthenon::par_for_inner(member, b.is, b.ie,
-                [&](const int& i) {
+                [&](const int& i)
+                {
                     auto Pl = Kokkos::subview(Pl_s, Kokkos::ALL(), i);
                     auto Pr = Kokkos::subview(Pr_s, Kokkos::ALL(), i);
                     // Apply floors to the *reconstructed* primitives, because without TVD
-                    // we have no guarantee they remotely resemble the *centered* primitives
-                    // If we selected to fall back to TVD, the floors are at zero (as intended)
+                    // we have no guarantee they remotely resemble the *centered*
+                    // primitives If we selected to fall back to TVD, the floors are at
+                    // zero (as intended)
                     if (reconstruction_floors || reconstruction_fallback) {
-                        fallback_tvd(i)  = Floors::apply_geo_floors(G, Pl, m_p, gam, j, i, floors, floors_inner, loc);
-                        fallback_tvd(i) |= Floors::apply_geo_floors(G, Pr, m_p, gam, j, i, floors, floors_inner, loc);
+                        fallback_tvd(i) = Floors::apply_geo_floors(
+                            G, Pl, m_p, gam, j, i, floors, floors_inner, loc);
+                        fallback_tvd(i) |= Floors::apply_geo_floors(
+                            G, Pr, m_p, gam, j, i, floors, floors_inner, loc);
                     }
-                }
-            );
+                });
             member.team_barrier();
 
             if (reconstruction_fallback) {
                 // TODO without the whole thing again? Also, option of scheme?
-                KReconstruction::ReconstructRow<RType::ppm, dir>(member, P_all(bl), k, j, b.is, b.ie, Plf_s, Prf_s);
+                KReconstruction::ReconstructRow<RType::ppm, dir>(
+                    member, P_all(bl), k, j, b.is, b.ie, Plf_s, Prf_s);
                 member.team_barrier();
                 for (int p = 0; p <= P_all.GetDim(4) - 1; ++p) {
                     parthenon::par_for_inner(member, b.is, b.ie,
-                        [&](const int& i) {
+                        [&](const int& i)
+                        {
                             if (fallback_tvd(i)) {
                                 Pl_s(p, i) = Plf_s(p, i);
                                 Pr_s(p, i) = Prf_s(p, i);
                             }
-                        }
-                    );
+                        });
                 }
                 member.team_barrier();
             }
 
-            // Copy out state (TODO(BSP) eliminate)
-            for (int p=0; p < nvar; ++p) {
+            // Copy out state (TODO(CEP) eliminate)
+            for (int p = 0; p < nvar; ++p) {
                 parthenon::par_for_inner(member, b.is, b.ie,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
                         Pl_all(bl, p, k, j, i) = Pl_s(p, i);
                         Pr_all(bl, p, k, j, i) = Pr_s(p, i);
-                    }
-                );
+                    });
             }
             member.team_barrier();
-        }
-    );
+        });
     EndFlag();
 
     // If we have B field on faces, we "must" replace reconstructed version with that
-    // Override at user option due to unreasonable effectiveness (https://github.com/AFD-Illinois/kharma/issues/79)
-    if (pmb0->packages.AllPackages().count("B_CT") && packages.Get("Fluxes")->Param<bool>("consistent_face_b")) {
-        const auto& Bf  = md->PackVariables(std::vector<std::string>{"cons.fB"});
-        const TopologicalElement face = FaceOf(dir); // TODO probably can be constexpr, somehow
+    // Override at user option due to unreasonable effectiveness
+    // (https://github.com/AFD-Illinois/kharma/issues/79)
+    if (pmb0->packages.AllPackages().count("B_CT") &&
+        packages.Get("Fluxes")->Param<bool>("consistent_face_b")) {
+        const auto& Bf = md->PackVariables(std::vector<std::string>{"cons.fB"});
+        const TopologicalElement face =
+            FaceOf(dir); // TODO probably can be constexpr, somehow
         IndexRange3 bi = KDomain::GetRange(md, IndexDomain::interior, face);
-        pmb0->par_for("replace_face", block.s, block.e, bi.ks, bi.ke, bi.js, bi.je, bi.is, bi.ie,
-            KOKKOS_LAMBDA(const int& bl, const int& k, const int& j, const int& i) {
+        pmb0->par_for("replace_face", block.s, block.e, bi.ks, bi.ke, bi.js, bi.je, bi.is,
+            bi.ie,
+                      KOKKOS_LAMBDA(const int& bl, const int& k, const int& j,
+                                    const int& i)
+            {
                 const auto& G = U_all.GetCoords(bl);
                 const double bf = Bf(bl, face, 0, k, j, i) / G.gdet(loc, j, i);
-                Pl_all(bl, m_p.B1+dir-1, k, j, i) = bf;
-                Pr_all(bl, m_p.B1+dir-1, k, j, i) = bf;
-            }
-        );
+                Pl_all(bl, m_p.B1 + dir - 1, k, j, i) = bf;
+                Pr_all(bl, m_p.B1 + dir - 1, k, j, i) = bf;
+            });
     }
 
     // Now that this is split, we add the biggest TODO in KHARMA
     // TODO per-package prim_to_flux?  Is that slower?
     // At least, we should refactor to template loops on vchar/stress-energy T type
 
-    Flag("GetFlux_"+std::to_string(dir)+"_left");
-    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "calc_flux_left", pmb0->exec_space,
-        flux_scratch_bytes, scratch_level, block.s, block.e, b.ks, b.ke, b.js, b.je,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& bl, const int& k, const int& j) {
+    Flag("GetFlux_" + std::to_string(dir) + "_left");
+    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "calc_flux_left",
+        pmb0->exec_space, flux_scratch_bytes, scratch_level, block.s, block.e, b.ks, b.ke,
+        b.js, b.je,
+        KOKKOS_LAMBDA(parthenon::team_mbr_t member,
+                      const int& bl,
+                      const int& k,
+                      const int& j)
+        {
             const auto& G = U_all.GetCoords(bl);
             ScratchPad2D<Real> Pl_s(member.team_scratch(scratch_level), nvar, n1);
             ScratchPad2D<Real> Ul_s(member.team_scratch(scratch_level), nvar, n1);
             ScratchPad2D<Real> Fl_s(member.team_scratch(scratch_level), nvar, n1);
 
-            // Copy in state (TODO(BSP) eliminate)
-            for (int p=0; p < nvar; ++p) {
+            // Copy in state (TODO(CEP) eliminate)
+            for (int p = 0; p < nvar; ++p) {
                 parthenon::par_for_inner(member, b.is, b.ie,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
                         Pl_s(p, i) = Pl_all(bl, p, k, j, i);
-                    }
-                );
+                    });
             }
             member.team_barrier();
 
             // LEFT FACES
             parthenon::par_for_inner(member, b.is, b.ie,
-                [&](const int& i) {
+                [&](const int& i)
+                {
                     auto Pl = Kokkos::subview(Pl_s, Kokkos::ALL(), i);
                     auto Ul = Kokkos::subview(Ul_s, Kokkos::ALL(), i);
                     auto Fl = Kokkos::subview(Fl_s, Kokkos::ALL(), i);
@@ -270,55 +304,62 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
 
                     // Left
                     GRMHD::calc_4vecs(G, Pl, m_p, j, i, loc, Dtmp);
-                    Flux::prim_to_flux(G, Pl, m_p, Dtmp, emhd_params, gam, j, i, 0, Ul, m_u, loc);
-                    Flux::prim_to_flux(G, Pl, m_p, Dtmp, emhd_params, gam, j, i, dir, Fl, m_u, loc);
+                    Flux::prim_to_flux(
+                        G, Pl, m_p, Dtmp, emhd_params, gam, j, i, 0, Ul, m_u, loc);
+                    Flux::prim_to_flux(
+                        G, Pl, m_p, Dtmp, emhd_params, gam, j, i, dir, Fl, m_u, loc);
 
                     // Magnetosonic speeds
                     Real cmaxL, cminL;
-                    Flux::vchar(G, Pl, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxL, cminL);
+                    Flux::vchar(G, Pl, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir,
+                        cmaxL, cminL);
 
                     // Record speeds
-                    cmax(bl, dir-1, k, j, i) = m::max(0., cmaxL);
-                    cmin(bl, dir-1, k, j, i) = m::min(0., cminL);
-                }
-            );
+                    cmax(bl, dir - 1, k, j, i) = m::max(0., cmaxL);
+                    cmin(bl, dir - 1, k, j, i) = m::min(0., cminL);
+                });
             member.team_barrier();
 
             // Copy out state
-            for (int p=0; p < nvar; ++p) {
+            for (int p = 0; p < nvar; ++p) {
                 parthenon::par_for_inner(member, b.is, b.ie,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
                         Ul_all(bl, p, k, j, i) = Ul_s(p, i);
                         Fl_all(bl, p, k, j, i) = Fl_s(p, i);
-                    }
-                );
+                    });
             }
-        }
-    );
+        });
     EndFlag();
 
-    Flag("GetFlux_"+std::to_string(dir)+"_right");
-    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "calc_flux_right", pmb0->exec_space,
-        flux_scratch_bytes, scratch_level, block.s, block.e, b.ks, b.ke, b.js, b.je,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& bl, const int& k, const int& j) {
+    Flag("GetFlux_" + std::to_string(dir) + "_right");
+    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "calc_flux_right",
+        pmb0->exec_space, flux_scratch_bytes, scratch_level, block.s, block.e, b.ks, b.ke,
+        b.js, b.je,
+        KOKKOS_LAMBDA(parthenon::team_mbr_t member,
+                      const int& bl,
+                      const int& k,
+                      const int& j)
+        {
             const auto& G = U_all.GetCoords(bl);
             ScratchPad2D<Real> Pr_s(member.team_scratch(scratch_level), nvar, n1);
             ScratchPad2D<Real> Ur_s(member.team_scratch(scratch_level), nvar, n1);
             ScratchPad2D<Real> Fr_s(member.team_scratch(scratch_level), nvar, n1);
 
-            // Copy in state (TODO(BSP) eliminate)
-            for (int p=0; p < nvar; ++p) {
+            // Copy in state (TODO(CEP) eliminate)
+            for (int p = 0; p < nvar; ++p) {
                 parthenon::par_for_inner(member, b.is, b.ie,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
                         Pr_s(p, i) = Pr_all(bl, p, k, j, i);
-                    }
-                );
+                    });
             }
             member.team_barrier();
 
             // RIGHT FACES, finalize signal speed
             parthenon::par_for_inner(member, b.is, b.ie,
-                [&](const int& i) {
+                [&](const int& i)
+                {
                     auto Pr = Kokkos::subview(Pr_s, Kokkos::ALL(), i);
                     auto Ur = Kokkos::subview(Ur_s, Kokkos::ALL(), i);
                     auto Fr = Kokkos::subview(Fr_s, Kokkos::ALL(), i);
@@ -326,52 +367,66 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
                     FourVectors Dtmp;
                     // Right
                     GRMHD::calc_4vecs(G, Pr, m_p, j, i, loc, Dtmp);
-                    Flux::prim_to_flux(G, Pr, m_p, Dtmp, emhd_params, gam, j, i, 0, Ur, m_u, loc);
-                    Flux::prim_to_flux(G, Pr, m_p, Dtmp, emhd_params, gam, j, i, dir, Fr, m_u, loc);
+                    Flux::prim_to_flux(
+                        G, Pr, m_p, Dtmp, emhd_params, gam, j, i, 0, Ur, m_u, loc);
+                    Flux::prim_to_flux(
+                        G, Pr, m_p, Dtmp, emhd_params, gam, j, i, dir, Fr, m_u, loc);
 
                     // Magnetosonic speeds
                     Real cmaxR, cminR;
-                    Flux::vchar(G, Pr, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir, cmaxR, cminR);
+                    Flux::vchar(G, Pr, m_p, Dtmp, gam, emhd_params, k, j, i, loc, dir,
+                        cmaxR, cminR);
 
                     // Calculate cmax/min based on comparison with cached values
-                    cmax(bl, dir-1, k, j, i) =  m::max(cmax(bl, dir-1, k, j, i), cmaxR);
-                    cmin(bl, dir-1, k, j, i) = -m::min(cmin(bl, dir-1, k, j, i), cminR);
-                }
-            );
+                    cmax(bl, dir - 1, k, j, i) =
+                        m::max(cmax(bl, dir - 1, k, j, i), cmaxR);
+                    cmin(bl, dir - 1, k, j, i) =
+                        -m::min(cmin(bl, dir - 1, k, j, i), cminR);
+                });
             member.team_barrier();
 
             // Copy out state
-            for (int p=0; p < nvar; ++p) {
+            for (int p = 0; p < nvar; ++p) {
                 parthenon::par_for_inner(member, b.is, b.ie,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
                         Ur_all(bl, p, k, j, i) = Ur_s(p, i);
                         Fr_all(bl, p, k, j, i) = Fr_s(p, i);
-                    }
-                );
+                    });
             }
-
-        }
-    );
+        });
     EndFlag();
 
     // Apply what we've calculated
-    Flag("GetFlux_"+std::to_string(dir)+"_riemann");
+    Flag("GetFlux_" + std::to_string(dir) + "_riemann");
     if (use_hlle) { // More fluxes would need a template
-        pmb0->par_for("flux_hlle", block.s, block.e, 0, nvar-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA(const int& bl, const int& p, const int& k, const int& j, const int& i) {
-                U_all(bl).flux(dir, p, k, j, i) = hlle(Fl_all(bl, p, k, j, i), Fr_all(bl, p, k, j, i),
-                                                      cmax(bl, dir-1, k, j, i), cmin(bl, dir-1, k, j, i),
-                                                      Ul_all(bl, p, k, j, i), Ur_all(bl, p, k, j, i));
-            }
-        );
+        pmb0->par_for("flux_hlle", block.s, block.e, 0, nvar - 1, b.ks, b.ke, b.js, b.je,
+            b.is, b.ie,
+            KOKKOS_LAMBDA(const int& bl,
+                          const int& p,
+                          const int& k,
+                          const int& j,
+                          const int& i)
+            {
+                U_all(bl).flux(dir, p, k, j, i) =
+                    hlle(Fl_all(bl, p, k, j, i), Fr_all(bl, p, k, j, i),
+                        cmax(bl, dir - 1, k, j, i), cmin(bl, dir - 1, k, j, i),
+                        Ul_all(bl, p, k, j, i), Ur_all(bl, p, k, j, i));
+            });
     } else {
-        pmb0->par_for("flux_llf", block.s, block.e, 0, nvar-1, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA(const int& bl, const int& p, const int& k, const int& j, const int& i) {
-                U_all(bl).flux(dir, p, k, j, i) = llf(Fl_all(bl, p, k, j, i), Fr_all(bl, p, k, j, i),
-                                                     cmax(bl, dir-1, k, j, i), cmin(bl, dir-1, k, j, i),
-                                                     Ul_all(bl, p, k, j, i), Ur_all(bl, p, k, j, i));
-            }
-        );
+        pmb0->par_for("flux_llf", block.s, block.e, 0, nvar - 1, b.ks, b.ke, b.js, b.je,
+            b.is, b.ie,
+            KOKKOS_LAMBDA(const int& bl,
+                          const int& p,
+                          const int& k,
+                          const int& j,
+                          const int& i)
+            {
+                U_all(bl).flux(dir, p, k, j, i) =
+                    llf(Fl_all(bl, p, k, j, i), Fr_all(bl, p, k, j, i),
+                        cmax(bl, dir - 1, k, j, i), cmin(bl, dir - 1, k, j, i),
+                        Ul_all(bl, p, k, j, i), Ur_all(bl, p, k, j, i));
+            });
     }
     EndFlag();
 

--- a/kharma/flux/plm_inline.hpp
+++ b/kharma/flux/plm_inline.hpp
@@ -22,137 +22,152 @@
 #include "coordinates/coordinates.hpp"
 #include "mesh/mesh.hpp"
 
-namespace parthenon {
+namespace parthenon
+{
 
 //----------------------------------------------------------------------------------------
 //! \fn Reconstruction::PiecewiseLinearX1()
 //  \brief
-template <typename T>
-KOKKOS_INLINE_FUNCTION void
-PiecewiseLinearX1(parthenon::team_mbr_t const &member, const int k, const int j,
-                  const int il, const int iu, const T &q,
-                  ScratchPad2D<Real> &ql, ScratchPad2D<Real> &qr, ScratchPad2D<Real> &qc,
-                  ScratchPad2D<Real> &dql, ScratchPad2D<Real> &dqr,
-                  ScratchPad2D<Real> &dqm) {
-  const int nu = q.GetDim(4) - 1;
+template<typename T>
+KOKKOS_INLINE_FUNCTION void PiecewiseLinearX1(parthenon::team_mbr_t const& member,
+    const int k, const int j, const int il, const int iu, const T& q,
+    ScratchPad2D<Real>& ql, ScratchPad2D<Real>& qr, ScratchPad2D<Real>& qc,
+    ScratchPad2D<Real>& dql, ScratchPad2D<Real>& dqr, ScratchPad2D<Real>& dqm)
+{
+    const int nu = q.GetDim(4) - 1;
 
-  // compute L/R slopes for each variable
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      // renamed dw* -> dq* from plm.cpp
-      dql(n, i) = (q(n, k, j, i) - q(n, k, j, i - 1));
-      dqr(n, i) = (q(n, k, j, i + 1) - q(n, k, j, i));
-      qc(n, i) = q(n, k, j, i);
-    });
-  }
-  member.team_barrier();
+    // compute L/R slopes for each variable
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                // renamed dw* -> dq* from plm.cpp
+                dql(n, i) = (q(n, k, j, i) - q(n, k, j, i - 1));
+                dqr(n, i) = (q(n, k, j, i + 1) - q(n, k, j, i));
+                qc(n, i) = q(n, k, j, i);
+            });
+    }
+    member.team_barrier();
 
-  // Apply simplified van Leer (VL) limiter expression for a Cartesian-like coordinate
-  // with uniform mesh spacing
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      Real dq2 = dql(n, i) * dqr(n, i);
-      dqm(n, i) = 2.0 * dq2 / (dql(n, i) + dqr(n, i));
-      if (dq2 <= 0.0) dqm(n, i) = 0.0;
-    });
-  }
-  member.team_barrier();
+    // Apply simplified van Leer (VL) limiter expression for a Cartesian-like coordinate
+    // with uniform mesh spacing
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                Real dq2 = dql(n, i) * dqr(n, i);
+                dqm(n, i) = 2.0 * dq2 / (dql(n, i) + dqr(n, i));
+                if (dq2 <= 0.0) dqm(n, i) = 0.0;
+            });
+    }
+    member.team_barrier();
 
-  // compute ql_(i+1/2) and qr_(i-1/2) using limited slopes
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      // Mignone equation 30
-      ql(n, i + 1) = qc(n, i) + 0.5 * dqm(n, i);
-      qr(n, i) = qc(n, i) - 0.5 * dqm(n, i);
-    });
-  }
+    // compute ql_(i+1/2) and qr_(i-1/2) using limited slopes
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                // Mignone equation 30
+                ql(n, i + 1) = qc(n, i) + 0.5 * dqm(n, i);
+                qr(n, i) = qc(n, i) - 0.5 * dqm(n, i);
+            });
+    }
 }
 
 //----------------------------------------------------------------------------------------
 //! \fn Reconstruction::PiecewiseLinearX2()
 //  \brief
-template <typename T>
-KOKKOS_INLINE_FUNCTION void
-PiecewiseLinearX2(parthenon::team_mbr_t const &member, const int k, const int j,
-                  const int il, const int iu, const T &q,
-                  ScratchPad2D<Real> &ql, ScratchPad2D<Real> &qr, ScratchPad2D<Real> &qc,
-                  ScratchPad2D<Real> &dql, ScratchPad2D<Real> &dqr,
-                  ScratchPad2D<Real> &dqm) {
-  const int nu = q.GetDim(4) - 1;
+template<typename T>
+KOKKOS_INLINE_FUNCTION void PiecewiseLinearX2(parthenon::team_mbr_t const& member,
+    const int k, const int j, const int il, const int iu, const T& q,
+    ScratchPad2D<Real>& ql, ScratchPad2D<Real>& qr, ScratchPad2D<Real>& qc,
+    ScratchPad2D<Real>& dql, ScratchPad2D<Real>& dqr, ScratchPad2D<Real>& dqm)
+{
+    const int nu = q.GetDim(4) - 1;
 
-  // compute L/R slopes for each variable
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      // renamed dw* -> dq* from plm.cpp
-      dql(n, i) = (q(n, k, j, i) - q(n, k, j - 1, i));
-      dqr(n, i) = (q(n, k, j + 1, i) - q(n, k, j, i));
-      qc(n, i) = q(n, k, j, i);
-    });
-  }
-  member.team_barrier();
+    // compute L/R slopes for each variable
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                // renamed dw* -> dq* from plm.cpp
+                dql(n, i) = (q(n, k, j, i) - q(n, k, j - 1, i));
+                dqr(n, i) = (q(n, k, j + 1, i) - q(n, k, j, i));
+                qc(n, i) = q(n, k, j, i);
+            });
+    }
+    member.team_barrier();
 
-  // Apply simplified van Leer (VL) limiter expression for a Cartesian-like coordinate
-  // with uniform mesh spacing
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      Real dq2 = dql(n, i) * dqr(n, i);
-      dqm(n, i) = 2.0 * dq2 / (dql(n, i) + dqr(n, i));
-      if (dq2 <= 0.0) dqm(n, i) = 0.0;
-    });
-  }
-  member.team_barrier();
+    // Apply simplified van Leer (VL) limiter expression for a Cartesian-like coordinate
+    // with uniform mesh spacing
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                Real dq2 = dql(n, i) * dqr(n, i);
+                dqm(n, i) = 2.0 * dq2 / (dql(n, i) + dqr(n, i));
+                if (dq2 <= 0.0) dqm(n, i) = 0.0;
+            });
+    }
+    member.team_barrier();
 
-
-  // compute ql_(j+1/2) and qr_(j-1/2) using limited slopes
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      ql(n, i) = qc(n, i) + 0.5 * dqm(n, i);
-      qr(n, i) = qc(n, i) - 0.5 * dqm(n, i);
-    });
-  }
+    // compute ql_(j+1/2) and qr_(j-1/2) using limited slopes
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                ql(n, i) = qc(n, i) + 0.5 * dqm(n, i);
+                qr(n, i) = qc(n, i) - 0.5 * dqm(n, i);
+            });
+    }
 }
 
 //----------------------------------------------------------------------------------------
 //! \fn Reconstruction::PiecewiseLinearX3()
 //  \brief
-template <typename T>
-KOKKOS_INLINE_FUNCTION void
-PiecewiseLinearX3(parthenon::team_mbr_t const &member, const int k, const int j,
-                  const int il, const int iu, const T &q,
-                  ScratchPad2D<Real> &ql, ScratchPad2D<Real> &qr, ScratchPad2D<Real> &qc,
-                  ScratchPad2D<Real> &dql, ScratchPad2D<Real> &dqr,
-                  ScratchPad2D<Real> &dqm) {
-  const int nu = q.GetDim(4) - 1;
+template<typename T>
+KOKKOS_INLINE_FUNCTION void PiecewiseLinearX3(parthenon::team_mbr_t const& member,
+    const int k, const int j, const int il, const int iu, const T& q,
+    ScratchPad2D<Real>& ql, ScratchPad2D<Real>& qr, ScratchPad2D<Real>& qc,
+    ScratchPad2D<Real>& dql, ScratchPad2D<Real>& dqr, ScratchPad2D<Real>& dqm)
+{
+    const int nu = q.GetDim(4) - 1;
 
-  // compute L/R slopes for each variable
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      // renamed dw* -> dq* from plm.cpp
-      dql(n, i) = (q(n, k, j, i) - q(n, k - 1, j, i));
-      dqr(n, i) = (q(n, k + 1, j, i) - q(n, k, j, i));
-      qc(n, i) = q(n, k, j, i);
-    });
-  }
-  member.team_barrier();
+    // compute L/R slopes for each variable
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                // renamed dw* -> dq* from plm.cpp
+                dql(n, i) = (q(n, k, j, i) - q(n, k - 1, j, i));
+                dqr(n, i) = (q(n, k + 1, j, i) - q(n, k, j, i));
+                qc(n, i) = q(n, k, j, i);
+            });
+    }
+    member.team_barrier();
 
-  // Apply simplified van Leer (VL) limiter expression for a Cartesian-like coordinate
-  // with uniform mesh spacing
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      Real dq2 = dql(n, i) * dqr(n, i);
-      dqm(n, i) = 2.0 * dq2 / (dql(n, i) + dqr(n, i));
-      if (dq2 <= 0.0) dqm(n, i) = 0.0;
-    });
-  }
-  member.team_barrier();
+    // Apply simplified van Leer (VL) limiter expression for a Cartesian-like coordinate
+    // with uniform mesh spacing
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                Real dq2 = dql(n, i) * dqr(n, i);
+                dqm(n, i) = 2.0 * dq2 / (dql(n, i) + dqr(n, i));
+                if (dq2 <= 0.0) dqm(n, i) = 0.0;
+            });
+    }
+    member.team_barrier();
 
-  // compute ql_(k+1/2) and qr_(k-1/2) using limited slopes
-  for (int n = 0; n <= nu; ++n) {
-    parthenon::par_for_inner(member, il, iu, [&](const int i) {
-      ql(n, i) = qc(n, i) + 0.5 * dqm(n, i);
-      qr(n, i) = qc(n, i) - 0.5 * dqm(n, i);
-    });
-  }
+    // compute ql_(k+1/2) and qr_(k-1/2) using limited slopes
+    for (int n = 0; n <= nu; ++n) {
+        parthenon::par_for_inner(member, il, iu,
+            [&](const int i)
+            {
+                ql(n, i) = qc(n, i) + 0.5 * dqm(n, i);
+                qr(n, i) = qc(n, i) - 0.5 * dqm(n, i);
+            });
+    }
 }
 
 } // namespace parthenon

--- a/kharma/flux/reconstruction.hpp
+++ b/kharma/flux/reconstruction.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: reconstruction.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,31 +35,41 @@
 
 #include "decs.hpp"
 
-#include "reconstruct/dc_inline.hpp"
 #include "plm_inline.hpp"
+#include "reconstruct/dc_inline.hpp"
 
 using namespace parthenon;
-
 
 namespace KReconstruction
 {
 constexpr Real EPS = 1.e-26;
 
 // Enum for all supported reconstruction types.
-enum class Type{donor_cell=0, donor_cell_c, linear_mc, linear_vl, ppm, ppmx, mp5, weno5, weno5_lower_edges, weno5_lower_poles, weno5_linear};
+enum class Type {
+    donor_cell = 0,
+    donor_cell_c,
+    linear_mc,
+    linear_vl,
+    ppm,
+    ppmx,
+    mp5,
+    weno5,
+    weno5_lower_edges,
+    weno5_lower_poles,
+    weno5_linear
+};
 
 // Component functions
 KOKKOS_FORCEINLINE_FUNCTION Real mc(const Real dm, const Real dp)
 {
-    const Real r = (m::abs(dp) > 0. ? dm/dp : 2.0);
-    return m::max(0.0, m::min(2.0, m::min(2*r,0.5*(1+r))));
+    const Real r = (m::abs(dp) > 0. ? dm / dp : 2.0);
+    return m::max(0.0, m::min(2.0, m::min(2 * r, 0.5 * (1 + r))));
 }
 
 KOKKOS_FORCEINLINE_FUNCTION Real mc(const Real dm, const Real dp, const Real alpha)
 {
-  const Real dc = (dm * dp > 0.0) * 0.5 * (dm + dp);
-  return m::copysign(
-      m::min(m::abs(dc), alpha * m::min(m::abs(dm), m::abs(dp))), dc);
+    const Real dc = (dm * dp > 0.0) * 0.5 * (dm + dp);
+    return m::copysign(m::min(m::abs(dc), alpha * m::min(m::abs(dm), m::abs(dp))), dc);
 }
 
 // TODO make this a function w/forceinline
@@ -70,20 +80,30 @@ KOKKOS_FORCEINLINE_FUNCTION double Median(double a, double b, double c)
     return (a + MINMOD(b - a, c - a));
 }
 
-// "left" and "right" here are relative to zone centers, so the pencil calls will switch them later.
-#define RECONSTRUCT_ONE_ARGS const Real& x1, const Real& x2, const Real& x3, const Real& x4, const Real& x5, Real &lout, Real &rout
-#define RECONSTRUCT_ONE_LEFT_ARGS const Real& x1, const Real& x2, const Real& x3, const Real& x4, const Real& x5, Real &lout
-#define RECONSTRUCT_ONE_RIGHT_ARGS const Real& x1, const Real& x2, const Real& x3, const Real& x4, const Real& x5, Real &rout
+// "left" and "right" here are relative to zone centers, so the pencil calls will switch
+// them later.
+#define RECONSTRUCT_ONE_ARGS                                                             \
+    const Real &x1, const Real &x2, const Real &x3, const Real &x4, const Real &x5,      \
+        Real &lout, Real &rout
+#define RECONSTRUCT_ONE_LEFT_ARGS                                                        \
+    const Real &x1, const Real &x2, const Real &x3, const Real &x4, const Real &x5,      \
+        Real &lout
+#define RECONSTRUCT_ONE_RIGHT_ARGS                                                       \
+    const Real &x1, const Real &x2, const Real &x3, const Real &x4, const Real &x5,      \
+        Real &rout
 
 // Single-element implementations:
 template<Type recon_type>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct(RECONSTRUCT_ONE_ARGS) {}
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct(RECONSTRUCT_ONE_ARGS)
+{}
 
 // TODO better defaults?  As-is, forgetting to implement these causes problems!
 template<Type recon_type>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left(RECONSTRUCT_ONE_LEFT_ARGS) {}
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left(RECONSTRUCT_ONE_LEFT_ARGS)
+{}
 template<Type recon_type>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right(RECONSTRUCT_ONE_RIGHT_ARGS) {}
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right(RECONSTRUCT_ONE_RIGHT_ARGS)
+{}
 
 // Donor-cell
 template<>
@@ -93,12 +113,14 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::donor_cell_c>(RECONSTRUCT_ONE
     lout = x3;
 }
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::donor_cell_c>(RECONSTRUCT_ONE_LEFT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::donor_cell_c>(
+    RECONSTRUCT_ONE_LEFT_ARGS)
 {
     lout = x3;
 }
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::donor_cell_c>(RECONSTRUCT_ONE_RIGHT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::donor_cell_c>(
+    RECONSTRUCT_ONE_RIGHT_ARGS)
 {
     rout = x3;
 }
@@ -107,19 +129,21 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::donor_cell_c>(RECONSTRU
 template<>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::linear_mc>(RECONSTRUCT_ONE_ARGS)
 {
-    const Real dq = mc(x3 - x2, x4 - x3)*(x4 - x3);
-    rout = x3 + 0.5*dq;
-    lout = x3 - 0.5*dq;
+    const Real dq = mc(x3 - x2, x4 - x3) * (x4 - x3);
+    rout = x3 + 0.5 * dq;
+    lout = x3 - 0.5 * dq;
 }
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::linear_mc>(RECONSTRUCT_ONE_LEFT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::linear_mc>(
+    RECONSTRUCT_ONE_LEFT_ARGS)
 {
-    lout = x3 - 0.5*(mc(x3 - x2, x4 - x3)*(x4 - x3));
+    lout = x3 - 0.5 * (mc(x3 - x2, x4 - x3) * (x4 - x3));
 }
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::linear_mc>(RECONSTRUCT_ONE_RIGHT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::linear_mc>(
+    RECONSTRUCT_ONE_RIGHT_ARGS)
 {
-    rout = x3 + 0.5*(mc(x3 - x2, x4 - x3)*(x4 - x3));
+    rout = x3 + 0.5 * (mc(x3 - x2, x4 - x3) * (x4 - x3));
 }
 
 // WENO5 (no linearization)
@@ -130,77 +154,93 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::weno5>(RECONSTRUCT_ONE_ARGS)
 {
     // Smoothness indicators, T07 A18 or S11 8
     Real beta[3], c1, c2;
-    c1 = x1 - 2.*x2 + x3; c2 = x1 - 4.*x2 + 3.*x3;
-    beta[0] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
-    c1 = x2 - 2.*x3 + x4; c2 = x4 - x2;
-    beta[1] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
-    c1 = x3 - 2.*x4 + x5; c2 = x5 - 4.*x4 + 3.*x3;
-    beta[2] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
+    c1 = x1 - 2. * x2 + x3;
+    c2 = x1 - 4. * x2 + 3. * x3;
+    beta[0] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
+    c1 = x2 - 2. * x3 + x4;
+    c2 = x4 - x2;
+    beta[1] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
+    c1 = x3 - 2. * x4 + x5;
+    c2 = x5 - 4. * x4 + 3. * x3;
+    beta[2] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
 
     // Nonlinear weights S11 9
     Real den[3] = {EPS + beta[0], EPS + beta[1], EPS + beta[2]};
-    den[0] *= den[0]; den[1] *= den[1]; den[2] *= den[2];
+    den[0] *= den[0];
+    den[1] *= den[1];
+    den[2] *= den[2];
 
-    Real wtr[3] = {(1./16.)/den[0], (5./8. )/den[1], (5./16.)/den[2]};
+    Real wtr[3] = {(1. / 16.) / den[0], (5. / 8.) / den[1], (5. / 16.) / den[2]};
     Real Wr = wtr[0] + wtr[1] + wtr[2];
 
-    Real wtl[3] = {(1./16.)/den[2], (5./8. )/den[1], (5./16.)/den[0]};
+    Real wtl[3] = {(1. / 16.) / den[2], (5. / 8.) / den[1], (5. / 16.) / den[0]};
     Real Wl = wtl[0] + wtl[1] + wtl[2];
 
     // S11 1, 2, 3
-    lout = ((3./8.)*x5 - (5./4.)*x4 + (15./8.)*x3)*(wtl[0] / Wl) +
-            ((-1./8.)*x4 + (3./4.)*x3 + (3./8.)*x2)*(wtl[1] / Wl) +
-            ((3./8.)*x3 + (3./4.)*x2 - (1./8.)*x1)*(wtl[2] / Wl);
-    rout = ((3./8.)*x1 - (5./4.)*x2 + (15./8.)*x3)*(wtr[0] / Wr) +
-            ((-1./8.)*x2 + (3./4.)*x3 + (3./8.)*x4)*(wtr[1] / Wr) +
-            ((3./8.)*x3 + (3./4.)*x4 - (1./8.)*x5)*(wtr[2] / Wr);
+    lout = ((3. / 8.) * x5 - (5. / 4.) * x4 + (15. / 8.) * x3) * (wtl[0] / Wl) +
+           ((-1. / 8.) * x4 + (3. / 4.) * x3 + (3. / 8.) * x2) * (wtl[1] / Wl) +
+           ((3. / 8.) * x3 + (3. / 4.) * x2 - (1. / 8.) * x1) * (wtl[2] / Wl);
+    rout = ((3. / 8.) * x1 - (5. / 4.) * x2 + (15. / 8.) * x3) * (wtr[0] / Wr) +
+           ((-1. / 8.) * x2 + (3. / 4.) * x3 + (3. / 8.) * x4) * (wtr[1] / Wr) +
+           ((3. / 8.) * x3 + (3. / 4.) * x4 - (1. / 8.) * x5) * (wtr[2] / Wr);
 }
 template<>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::weno5>(RECONSTRUCT_ONE_LEFT_ARGS)
 {
     // Smoothness indicators, T07 A18 or S11 8
     Real beta[3], c1, c2;
-    c1 = x1 - 2.*x2 + x3; c2 = x1 - 4.*x2 + 3.*x3;
-    beta[0] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
-    c1 = x2 - 2.*x3 + x4; c2 = x4 - x2;
-    beta[1] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
-    c1 = x3 - 2.*x4 + x5; c2 = x5 - 4.*x4 + 3.*x3;
-    beta[2] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
+    c1 = x1 - 2. * x2 + x3;
+    c2 = x1 - 4. * x2 + 3. * x3;
+    beta[0] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
+    c1 = x2 - 2. * x3 + x4;
+    c2 = x4 - x2;
+    beta[1] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
+    c1 = x3 - 2. * x4 + x5;
+    c2 = x5 - 4. * x4 + 3. * x3;
+    beta[2] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
 
     // Nonlinear weights S11 9
     Real den[3] = {EPS + beta[0], EPS + beta[1], EPS + beta[2]};
-    den[0] *= den[0]; den[1] *= den[1]; den[2] *= den[2];
+    den[0] *= den[0];
+    den[1] *= den[1];
+    den[2] *= den[2];
 
-    Real wtl[3] = {(1./16.)/den[2], (5./8. )/den[1], (5./16.)/den[0]};
+    Real wtl[3] = {(1. / 16.) / den[2], (5. / 8.) / den[1], (5. / 16.) / den[0]};
     Real Wl = wtl[0] + wtl[1] + wtl[2];
 
     // S11 1, 2, 3
-    lout = ((3./8.)*x5 - (5./4.)*x4 + (15./8.)*x3)*(wtl[0] / Wl) +
-            ((-1./8.)*x4 + (3./4.)*x3 + (3./8.)*x2)*(wtl[1] / Wl) +
-            ((3./8.)*x3 + (3./4.)*x2 - (1./8.)*x1)*(wtl[2] / Wl);
+    lout = ((3. / 8.) * x5 - (5. / 4.) * x4 + (15. / 8.) * x3) * (wtl[0] / Wl) +
+           ((-1. / 8.) * x4 + (3. / 4.) * x3 + (3. / 8.) * x2) * (wtl[1] / Wl) +
+           ((3. / 8.) * x3 + (3. / 4.) * x2 - (1. / 8.) * x1) * (wtl[2] / Wl);
 }
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::weno5>(RECONSTRUCT_ONE_RIGHT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::weno5>(
+    RECONSTRUCT_ONE_RIGHT_ARGS)
 {
     // Smoothness indicators, T07 A18 or S11 8
     Real beta[3], c1, c2;
-    c1 = x1 - 2.*x2 + x3; c2 = x1 - 4.*x2 + 3.*x3;
-    beta[0] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
-    c1 = x2 - 2.*x3 + x4; c2 = x4 - x2;
-    beta[1] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
-    c1 = x3 - 2.*x4 + x5; c2 = x5 - 4.*x4 + 3.*x3;
-    beta[2] = (13./12.)*c1*c1 + (1./4.)*c2*c2;
+    c1 = x1 - 2. * x2 + x3;
+    c2 = x1 - 4. * x2 + 3. * x3;
+    beta[0] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
+    c1 = x2 - 2. * x3 + x4;
+    c2 = x4 - x2;
+    beta[1] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
+    c1 = x3 - 2. * x4 + x5;
+    c2 = x5 - 4. * x4 + 3. * x3;
+    beta[2] = (13. / 12.) * c1 * c1 + (1. / 4.) * c2 * c2;
 
     // Nonlinear weights S11 9
     Real den[3] = {EPS + beta[0], EPS + beta[1], EPS + beta[2]};
-    den[0] *= den[0]; den[1] *= den[1]; den[2] *= den[2];
+    den[0] *= den[0];
+    den[1] *= den[1];
+    den[2] *= den[2];
 
-    Real wtr[3] = {(1./16.)/den[0], (5./8. )/den[1], (5./16.)/den[2]};
+    Real wtr[3] = {(1. / 16.) / den[0], (5. / 8.) / den[1], (5. / 16.) / den[2]};
     Real Wr = wtr[0] + wtr[1] + wtr[2];
 
-    rout = ((3./8.)*x1 - (5./4.)*x2 + (15./8.)*x3)*(wtr[0] / Wr) +
-            ((-1./8.)*x2 + (3./4.)*x3 + (3./8.)*x4)*(wtr[1] / Wr) +
-            ((3./8.)*x3 + (3./4.)*x4 - (1./8.)*x5)*(wtr[2] / Wr);
+    rout = ((3. / 8.) * x1 - (5. / 4.) * x2 + (15. / 8.) * x3) * (wtr[0] / Wr) +
+           ((-1. / 8.) * x2 + (3. / 4.) * x3 + (3. / 8.) * x4) * (wtr[1] / Wr) +
+           ((3. / 8.) * x3 + (3. / 4.) * x4 - (1. / 8.) * x5) * (wtr[2] / Wr);
 }
 
 // Linearized WENO, stolen from Phoebus
@@ -210,8 +250,7 @@ template<>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::weno5_linear>(RECONSTRUCT_ONE_ARGS)
 {
     constexpr Real w5alpha[3][3] = {{1.0 / 3.0, -7.0 / 6.0, 11.0 / 6.0},
-                                    {-1.0 / 6.0, 5.0 / 6.0, 1.0 / 3.0},
-                                    {1.0 / 3.0, 5.0 / 6.0, -1.0 / 6.0}};
+        {-1.0 / 6.0, 5.0 / 6.0, 1.0 / 3.0}, {1.0 / 3.0, 5.0 / 6.0, -1.0 / 6.0}};
     constexpr Real w5gamma[3] = {0.1, 0.6, 0.3};
     constexpr Real eps = 1e-100;
     constexpr Real thirteen_thirds = 13.0 / 3.0;
@@ -264,16 +303,18 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::weno5_linear>(RECONSTRUCT_ONE
     rout = alpha_lin * rout + (1.0 - alpha_lin) * (x3 + 0.5 * dq);
     lout = alpha_lin * lout + (1.0 - alpha_lin) * (x3 - 0.5 * dq);
 }
-// TODO(BSP) Breaking out l & r probably doesn't save us much time on this one,
+// TODO(CEP) Breaking out l & r probably doesn't save us much time on this one,
 // but we could
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::weno5_linear>(RECONSTRUCT_ONE_LEFT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::weno5_linear>(
+    RECONSTRUCT_ONE_LEFT_ARGS)
 {
     Real null;
     reconstruct<Type::weno5_linear>(x1, x2, x3, x4, x5, lout, null);
 }
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::weno5_linear>(RECONSTRUCT_ONE_RIGHT_ARGS)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::weno5_linear>(
+    RECONSTRUCT_ONE_RIGHT_ARGS)
 {
     Real null;
     reconstruct<Type::weno5_linear>(x1, x2, x3, x4, x5, null, rout);
@@ -281,47 +322,48 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::weno5_linear>(RECONSTRU
 
 // MP5, lifted shamelessly from Phoebus, itself from nubhlight, originally from PLUTO
 // How long can we keep this going?
-KOKKOS_FORCEINLINE_FUNCTION double mp5_subcalc(double Fjm2, double Fjm1, double Fj, double Fjp1, double Fjp2)
+KOKKOS_FORCEINLINE_FUNCTION double mp5_subcalc(
+    double Fjm2, double Fjm1, double Fj, double Fjp1, double Fjp2)
 {
-  double f, d2, d2p, d2m;
-  double dMMm, dMMp;
-  double scrh1, scrh2, min, max;
-  double fAV, fMD, fLC, fUL, fMP;
-  constexpr double alpha = 4.0, epsm = 1.e-12;
+    double f, d2, d2p, d2m;
+    double dMMm, dMMp;
+    double scrh1, scrh2, min, max;
+    double fAV, fMD, fLC, fUL, fMP;
+    constexpr double alpha = 4.0, epsm = 1.e-12;
 
-  f = 2.0 * Fjm2 - 13.0 * Fjm1 + 47.0 * Fj + 27.0 * Fjp1 - 3.0 * Fjp2;
-  f /= 60.0;
+    f = 2.0 * Fjm2 - 13.0 * Fjm1 + 47.0 * Fj + 27.0 * Fjp1 - 3.0 * Fjp2;
+    f /= 60.0;
 
-  fMP = Fj + MINMOD(Fjp1 - Fj, alpha * (Fj - Fjm1));
+    fMP = Fj + MINMOD(Fjp1 - Fj, alpha * (Fj - Fjm1));
 
-  if ((f - Fj) * (f - fMP) <= epsm) return f;
+    if ((f - Fj) * (f - fMP) <= epsm) return f;
 
-  d2m = Fjm2 + Fj - 2.0 * Fjm1; // Eqn. 2.19
-  d2 = Fjm1 + Fjp1 - 2.0 * Fj;
-  d2p = Fj + Fjp2 - 2.0 * Fjp1; // Eqn. 2.19
+    d2m = Fjm2 + Fj - 2.0 * Fjm1; // Eqn. 2.19
+    d2 = Fjm1 + Fjp1 - 2.0 * Fj;
+    d2p = Fj + Fjp2 - 2.0 * Fjp1; // Eqn. 2.19
 
-  scrh1 = MINMOD(4.0 * d2 - d2p, 4.0 * d2p - d2);
-  scrh2 = MINMOD(d2, d2p);
-  dMMp = MINMOD(scrh1, scrh2); // Eqn. 2.27
-  scrh1 = MINMOD(4.0 * d2m - d2, 4.0 * d2 - d2m);
-  scrh2 = MINMOD(d2, d2m);
-  dMMm = MINMOD(scrh1, scrh2); // Eqn. 2.27
+    scrh1 = MINMOD(4.0 * d2 - d2p, 4.0 * d2p - d2);
+    scrh2 = MINMOD(d2, d2p);
+    dMMp = MINMOD(scrh1, scrh2); // Eqn. 2.27
+    scrh1 = MINMOD(4.0 * d2m - d2, 4.0 * d2 - d2m);
+    scrh2 = MINMOD(d2, d2m);
+    dMMm = MINMOD(scrh1, scrh2); // Eqn. 2.27
 
-  fUL = Fj + alpha * (Fj - Fjm1);                   // Eqn. 2.8
-  fAV = 0.5 * (Fj + Fjp1);                          // Eqn. 2.16
-  fMD = fAV - 0.5 * dMMp;                           // Eqn. 2.28
-  fLC = 0.5 * (3.0 * Fj - Fjm1) + 4.0 / 3.0 * dMMm; // Eqn. 2.29
+    fUL = Fj + alpha * (Fj - Fjm1);                   // Eqn. 2.8
+    fAV = 0.5 * (Fj + Fjp1);                          // Eqn. 2.16
+    fMD = fAV - 0.5 * dMMp;                           // Eqn. 2.28
+    fLC = 0.5 * (3.0 * Fj - Fjm1) + 4.0 / 3.0 * dMMm; // Eqn. 2.29
 
-  scrh1 = m::min(m::min(Fj, Fjp1), fMD);
-  scrh2 = m::min(m::min(Fj, fUL), fLC);
-  min = m::max(scrh1, scrh2); // Eqn. (2.24a)
+    scrh1 = m::min(m::min(Fj, Fjp1), fMD);
+    scrh2 = m::min(m::min(Fj, fUL), fLC);
+    min = m::max(scrh1, scrh2); // Eqn. (2.24a)
 
-  scrh1 = m::max(m::max(Fj, Fjp1), fMD);
-  scrh2 = m::max(m::max(Fj, fUL), fLC);
-  max = m::min(scrh1, scrh2); // Eqn. 2.24b
+    scrh1 = m::max(m::max(Fj, Fjp1), fMD);
+    scrh2 = m::max(m::max(Fj, fUL), fLC);
+    max = m::min(scrh1, scrh2); // Eqn. 2.24b
 
-  f = Median(f, min, max); // Eqn. 2.26
-  return f;
+    f = Median(f, min, max); // Eqn. 2.26
+    return f;
 }
 template<>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::mp5>(RECONSTRUCT_ONE_ARGS)
@@ -340,46 +382,46 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::mp5>(RECONSTRUCT_ONE_RI
     rout = mp5_subcalc(x1, x2, x3, x4, x5);
 }
 
-
 /**
  * PPM reconstruction, stolen from AthenaK complete with description
- * 
+ *
  * Original PPM (Colella & Woodward) parabolic reconstruction.  Returns
  * interpolated values at L/R edges of cell i, that is ql(i+1) and qr(i). Works for
  * reconstruction in any dimension by passing in the appropriate q_im2,...,q _ip2.
  */
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::ppm>(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q_ip1,
-                                                    const Real &q_ip2, Real &qlv, Real &qrv)
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::ppm>(const Real& q_im2,
+    const Real& q_im1, const Real& q_i, const Real& q_ip1, const Real& q_ip2, Real& qlv,
+    Real& qrv)
 {
-  //---- Interpolate L/R values (CS eqn 16, PH 3.26 and 3.27) ----
-  // qlv = q at left  side of cell-center = q[i-1/2] = a_{j,-} in CS
-  // qrv = q at right side of cell-center = q[i+1/2] = a_{j,+} in CS
-  qlv = (7.*(q_i + q_im1) - (q_im2 + q_ip1))/12.0;
-  qrv = (7.*(q_i + q_ip1) - (q_im1 + q_ip2))/12.0;
+    //---- Interpolate L/R values (CS eqn 16, PH 3.26 and 3.27) ----
+    // qlv = q at left  side of cell-center = q[i-1/2] = a_{j,-} in CS
+    // qrv = q at right side of cell-center = q[i+1/2] = a_{j,+} in CS
+    qlv = (7. * (q_i + q_im1) - (q_im2 + q_ip1)) / 12.0;
+    qrv = (7. * (q_i + q_ip1) - (q_im1 + q_ip2)) / 12.0;
 
-  //---- limit qrv and qlv to neighboring cell-centered values (CS eqn 13) ----
-  qlv = m::max(qlv, m::min(q_i, q_im1));
-  qlv = m::min(qlv, m::max(q_i, q_im1));
-  qrv = m::max(qrv, m::min(q_i, q_ip1));
-  qrv = m::min(qrv, m::max(q_i, q_ip1));
+    //---- limit qrv and qlv to neighboring cell-centered values (CS eqn 13) ----
+    qlv = m::max(qlv, m::min(q_i, q_im1));
+    qlv = m::min(qlv, m::max(q_i, q_im1));
+    qrv = m::max(qrv, m::min(q_i, q_ip1));
+    qrv = m::min(qrv, m::max(q_i, q_ip1));
 
-  //--- monotonize interpolated L/R states (CS eqns 14, 15) ---
-  Real qc = qrv - q_i;
-  Real qd = qlv - q_i;
-  if ((qc*qd) >= 0.0) {
-    qlv = q_i;
-    qrv = q_i;
-  } else {
-    if (m::abs(qc) >= 2.0*m::abs(qd)) {
-      qrv = q_i - 2.0*qd;
+    //--- monotonize interpolated L/R states (CS eqns 14, 15) ---
+    Real qc = qrv - q_i;
+    Real qd = qlv - q_i;
+    if ((qc * qd) >= 0.0) {
+        qlv = q_i;
+        qrv = q_i;
+    } else {
+        if (m::abs(qc) >= 2.0 * m::abs(qd)) {
+            qrv = q_i - 2.0 * qd;
+        }
+        if (m::abs(qd) >= 2.0 * m::abs(qc)) {
+            qlv = q_i - 2.0 * qc;
+        }
     }
-    if (m::abs(qd) >= 2.0*m::abs(qc)) {
-      qlv = q_i - 2.0*qc;
-    }
-  }
 }
-// TODO(BSP) We also probably don't save much splitting here, but worth a shot?
+// TODO(CEP) We also probably don't save much splitting here, but worth a shot?
 template<>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::ppm>(RECONSTRUCT_ONE_LEFT_ARGS)
 {
@@ -395,103 +437,106 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::ppm>(RECONSTRUCT_ONE_RI
 
 /**
  * PPMX extremum-preserving PPM, stolen from AthenaK complete with description
- * 
+ *
  * PPM parabolic reconstruction with Colella & Sekora limiters.  Returns
  * interpolated values at L/R edges of cell i, that is ql(i+1) and qr(i). Works for
  * reconstruction in any dimension by passing in the appropriate q_im2,...,q _ip2.
  */
 template<>
-KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::ppmx>(const Real &q_im2, const Real &q_im1,
-        const Real &q_i, const Real &q_ip1, const Real &q_ip2, Real &qlv, Real &qrv) {
-  //---- Compute L/R values (CS eqns 12-15, PH 3.26 and 3.27) ----
-  // qlv = q at left  side of cell-center = q[i-1/2] = a_{j,-} in CS
-  // qrv = q at right side of cell-center = q[i+1/2] = a_{j,+} in CS
-  qlv = (7.*(q_i + q_im1) - (q_im2 + q_ip1))/12.0;
-  qrv = (7.*(q_i + q_ip1) - (q_im1 + q_ip2))/12.0;
+KOKKOS_FORCEINLINE_FUNCTION void reconstruct<Type::ppmx>(const Real& q_im2,
+    const Real& q_im1, const Real& q_i, const Real& q_ip1, const Real& q_ip2, Real& qlv,
+    Real& qrv)
+{
+    //---- Compute L/R values (CS eqns 12-15, PH 3.26 and 3.27) ----
+    // qlv = q at left  side of cell-center = q[i-1/2] = a_{j,-} in CS
+    // qrv = q at right side of cell-center = q[i+1/2] = a_{j,+} in CS
+    qlv = (7. * (q_i + q_im1) - (q_im2 + q_ip1)) / 12.0;
+    qrv = (7. * (q_i + q_ip1) - (q_im1 + q_ip2)) / 12.0;
 
-  //---- Apply CS monotonicity limiters to qrv and qlv ----
-  // approximate second derivatives at i-1/2 (PH 3.35)
-  // KGF: add the off-center quantities first to preserve FP symmetry
-  Real d2qc = 3.0*((q_im1 + q_i) - 2.0*qlv);
-  Real d2ql = (q_im2 + q_i  ) - 2.0*q_im1;
-  Real d2qr = (q_im1 + q_ip1) - 2.0*q_i;
-
-  // limit second derivative (PH 3.36)
-  Real d2qlim = 0.0;
-  Real lim_slope = m::min(m::abs(d2ql),m::abs(d2qr));
-  if (d2qc > 0.0 && d2ql > 0.0 && d2qr > 0.0) {
-    d2qlim = SIGN(d2qc)*m::min(1.25*lim_slope,m::abs(d2qc));
-  }
-  if (d2qc < 0.0 && d2ql < 0.0 && d2qr < 0.0) {
-    d2qlim = SIGN(d2qc)*m::min(1.25*lim_slope,m::abs(d2qc));
-  }
-  // compute limited value for qlv (PH 3.33 and 3.34)
-  if (((q_im1 - qlv)*(q_i - qlv)) > 0.0) {
-    qlv = 0.5*(q_i + q_im1) - d2qlim/6.0;
-  }
-
-  // approximate second derivatives at i+1/2 (PH 3.35)
-  // KGF: add the off-center quantities first to preserve FP symmetry
-  d2qc = 3.0*((q_i + q_ip1) - 2.0*qrv);
-  d2ql = d2qr;
-  d2qr = (q_i + q_ip2) - 2.0*q_ip1;
-
-  // limit second derivative (PH 3.36)
-  d2qlim = 0.0;
-  lim_slope = m::min(m::abs(d2ql),m::abs(d2qr));
-  if (d2qc > 0.0 && d2ql > 0.0 && d2qr > 0.0) {
-    d2qlim = SIGN(d2qc)*m::min(1.25*lim_slope,m::abs(d2qc));
-  }
-  if (d2qc < 0.0 && d2ql < 0.0 && d2qr < 0.0) {
-    d2qlim = SIGN(d2qc)*m::min(1.25*lim_slope,m::abs(d2qc));
-  }
-  // compute limited value for qrv (PH 3.33 and 3.34)
-  if (((q_i - qrv)*(q_ip1 - qrv)) > 0.0) {
-    qrv = 0.5*(q_i + q_ip1) - d2qlim/6.0;
-  }
-
-  //---- identify extrema, use smooth extremum limiter ----
-  // CS 20 (missing "OR"), and PH 3.31
-  Real qa = (qrv - q_i)*(q_i - qlv);
-  Real qb = (q_im1 - q_i)*(q_i - q_ip1);
-  if (qa <= 0.0 || qb <= 0.0) {
-    // approximate secnd derivates (PH 3.37)
+    //---- Apply CS monotonicity limiters to qrv and qlv ----
+    // approximate second derivatives at i-1/2 (PH 3.35)
     // KGF: add the off-center quantities first to preserve FP symmetry
-    Real d2q  = 6.0*(qlv + qrv - 2.0*q_i);
-    Real d2qc = (q_im1 + q_ip1) - 2.0*q_i;
-    Real d2ql = (q_im2 + q_i  ) - 2.0*q_im1;
-    Real d2qr = (q_i   + q_ip2) - 2.0*q_ip1;
+    Real d2qc = 3.0 * ((q_im1 + q_i) - 2.0 * qlv);
+    Real d2ql = (q_im2 + q_i) - 2.0 * q_im1;
+    Real d2qr = (q_im1 + q_ip1) - 2.0 * q_i;
 
-    // limit second derivatives (PH 3.38)
+    // limit second derivative (PH 3.36)
+    Real d2qlim = 0.0;
+    Real lim_slope = m::min(m::abs(d2ql), m::abs(d2qr));
+    if (d2qc > 0.0 && d2ql > 0.0 && d2qr > 0.0) {
+        d2qlim = SIGN(d2qc) * m::min(1.25 * lim_slope, m::abs(d2qc));
+    }
+    if (d2qc < 0.0 && d2ql < 0.0 && d2qr < 0.0) {
+        d2qlim = SIGN(d2qc) * m::min(1.25 * lim_slope, m::abs(d2qc));
+    }
+    // compute limited value for qlv (PH 3.33 and 3.34)
+    if (((q_im1 - qlv) * (q_i - qlv)) > 0.0) {
+        qlv = 0.5 * (q_i + q_im1) - d2qlim / 6.0;
+    }
+
+    // approximate second derivatives at i+1/2 (PH 3.35)
+    // KGF: add the off-center quantities first to preserve FP symmetry
+    d2qc = 3.0 * ((q_i + q_ip1) - 2.0 * qrv);
+    d2ql = d2qr;
+    d2qr = (q_i + q_ip2) - 2.0 * q_ip1;
+
+    // limit second derivative (PH 3.36)
     d2qlim = 0.0;
-    lim_slope = m::min(m::abs(d2ql),m::abs(d2qr));
-    lim_slope = m::min(m::abs(d2qc),lim_slope);
-    if (d2qc > 0.0 && d2ql > 0.0 && d2qr > 0.0 && d2q > 0.0) {
-      d2qlim = SIGN(d2q)*m::min(1.25*lim_slope,m::abs(d2q));
+    lim_slope = m::min(m::abs(d2ql), m::abs(d2qr));
+    if (d2qc > 0.0 && d2ql > 0.0 && d2qr > 0.0) {
+        d2qlim = SIGN(d2qc) * m::min(1.25 * lim_slope, m::abs(d2qc));
     }
-    if (d2qc < 0.0 && d2ql < 0.0 && d2qr < 0.0 && d2q < 0.0) {
-      d2qlim = SIGN(d2q)*m::min(1.25*lim_slope,m::abs(d2q));
+    if (d2qc < 0.0 && d2ql < 0.0 && d2qr < 0.0) {
+        d2qlim = SIGN(d2qc) * m::min(1.25 * lim_slope, m::abs(d2qc));
+    }
+    // compute limited value for qrv (PH 3.33 and 3.34)
+    if (((q_i - qrv) * (q_ip1 - qrv)) > 0.0) {
+        qrv = 0.5 * (q_i + q_ip1) - d2qlim / 6.0;
     }
 
-    // limit L/R states at extrema (PH 3.39)
-    Real rho = 0.0;
-    if ( m::abs(d2q) > (1.0e-12)*m::max( m::abs(q_im1), m::max(m::abs(q_i),m::abs(q_ip1))) ) {
-      // Limiter is not sensitive to round-off error.  Use limited slope
-      rho = d2qlim/d2q;
+    //---- identify extrema, use smooth extremum limiter ----
+    // CS 20 (missing "OR"), and PH 3.31
+    Real qa = (qrv - q_i) * (q_i - qlv);
+    Real qb = (q_im1 - q_i) * (q_i - q_ip1);
+    if (qa <= 0.0 || qb <= 0.0) {
+        // approximate secnd derivates (PH 3.37)
+        // KGF: add the off-center quantities first to preserve FP symmetry
+        Real d2q = 6.0 * (qlv + qrv - 2.0 * q_i);
+        Real d2qc = (q_im1 + q_ip1) - 2.0 * q_i;
+        Real d2ql = (q_im2 + q_i) - 2.0 * q_im1;
+        Real d2qr = (q_i + q_ip2) - 2.0 * q_ip1;
+
+        // limit second derivatives (PH 3.38)
+        d2qlim = 0.0;
+        lim_slope = m::min(m::abs(d2ql), m::abs(d2qr));
+        lim_slope = m::min(m::abs(d2qc), lim_slope);
+        if (d2qc > 0.0 && d2ql > 0.0 && d2qr > 0.0 && d2q > 0.0) {
+            d2qlim = SIGN(d2q) * m::min(1.25 * lim_slope, m::abs(d2q));
+        }
+        if (d2qc < 0.0 && d2ql < 0.0 && d2qr < 0.0 && d2q < 0.0) {
+            d2qlim = SIGN(d2q) * m::min(1.25 * lim_slope, m::abs(d2q));
+        }
+
+        // limit L/R states at extrema (PH 3.39)
+        Real rho = 0.0;
+        if (m::abs(d2q) >
+            (1.0e-12) * m::max(m::abs(q_im1), m::max(m::abs(q_i), m::abs(q_ip1)))) {
+            // Limiter is not sensitive to round-off error.  Use limited slope
+            rho = d2qlim / d2q;
+        }
+        qlv = q_i + (qlv - q_i) * rho;
+        qrv = q_i + (qrv - q_i) * rho;
+    } else {
+        // Monotonize again, away from extrema (CW eqn 1.10, PH 3.32)
+        Real qc = qrv - q_i;
+        Real qd = qlv - q_i;
+        if (m::abs(qc) >= 2.0 * m::abs(qd)) {
+            qrv = q_i - 2.0 * qd;
+        }
+        if (m::abs(qd) >= 2.0 * m::abs(qc)) {
+            qlv = q_i - 2.0 * qc;
+        }
     }
-    qlv = q_i + (qlv - q_i)*rho;
-    qrv = q_i + (qrv - q_i)*rho;
-  } else {
-    // Monotonize again, away from extrema (CW eqn 1.10, PH 3.32)
-    Real qc = qrv - q_i;
-    Real qd = qlv - q_i;
-    if (m::abs(qc) >= 2.0*m::abs(qd)) {
-      qrv = q_i - 2.0*qd;
-    }
-    if (m::abs(qd) >= 2.0*m::abs(qc)) {
-      qlv = q_i - 2.0*qc;
-    }
-  }
 }
 template<>
 KOKKOS_FORCEINLINE_FUNCTION void reconstruct_left<Type::ppmx>(RECONSTRUCT_ONE_LEFT_ARGS)
@@ -506,116 +551,87 @@ KOKKOS_FORCEINLINE_FUNCTION void reconstruct_right<Type::ppmx>(RECONSTRUCT_ONE_R
     reconstruct<Type::ppmx>(x1, x2, x3, x4, x5, null, rout);
 }
 
-
 // Row-wise implementations
 // Note that "L" and "R" refer to the sides of the *face*
-// ql(1) is to the right of the first zone center, but corresponds to the face value reconstructed from the left
-// qr(1) is then the value at that face reconstructed from the right
-// This is *opposite* the single-zone convention (or rather, offset from it to the faces):
-// so weirdly, ReconstructX2l calls reconstruct_right.  Get it?
-#define RECONSTRUCT_ROW_INPUT parthenon::team_mbr_t const &member, const int& k, const int& j, \
-                              const int& il, const int& iu, const VariablePack<Real> &q,
-#define RECONSTRUCT_ROW_ARGS RECONSTRUCT_ROW_INPUT ScratchPad2D<Real> &ql, ScratchPad2D<Real> &qr
-#define RECONSTRUCT_ROW_LEFT_ARGS RECONSTRUCT_ROW_INPUT ScratchPad2D<Real> &ql
-#define RECONSTRUCT_ROW_RIGHT_ARGS RECONSTRUCT_ROW_INPUT ScratchPad2D<Real> &qr
+// ql(1) is to the right of the first zone center, but corresponds to the face value
+// reconstructed from the left qr(1) is then the value at that face reconstructed from the
+// right This is *opposite* the single-zone convention (or rather, offset from it to the
+// faces): so weirdly, ReconstructX2l calls reconstruct_right.  Get it?
+#define RECONSTRUCT_ROW_INPUT                                                            \
+    parthenon::team_mbr_t const &member, const int &k, const int &j, const int &il,      \
+        const int &iu, const VariablePack<Real>&q,
+#define RECONSTRUCT_ROW_ARGS                                                             \
+    RECONSTRUCT_ROW_INPUT ScratchPad2D<Real>&ql, ScratchPad2D<Real>&qr
+#define RECONSTRUCT_ROW_LEFT_ARGS RECONSTRUCT_ROW_INPUT ScratchPad2D<Real>& ql
+#define RECONSTRUCT_ROW_RIGHT_ARGS RECONSTRUCT_ROW_INPUT ScratchPad2D<Real>& qr
 
-// TODO(BSP) I'm sure these could be shorter with more C++ magic
-template <Type recon_type>
+// TODO(CEP) I'm sure these could be shorter with more C++ magic
+template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void ReconstructX1(RECONSTRUCT_ROW_ARGS)
 {
     for (int p = 0; p <= q.GetDim(4) - 1; ++p) {
-        parthenon::par_for_inner(member, il, iu,
-            KOKKOS_LAMBDA (const int& i) {
-                reconstruct<recon_type>(
-                    q(p, k, j, i - 2),
-                    q(p, k, j, i - 1),
-                    q(p, k, j, i),
-                    q(p, k, j, i + 1),
-                    q(p, k, j, i + 2),
-                    qr(p, i), ql(p, i+1));
-            }
-        );
+        parthenon::par_for_inner(member, il, iu, KOKKOS_LAMBDA(const int& i)
+            {
+                reconstruct<recon_type>(q(p, k, j, i - 2), q(p, k, j, i - 1),
+                    q(p, k, j, i), q(p, k, j, i + 1), q(p, k, j, i + 2), qr(p, i),
+                    ql(p, i + 1));
+            });
     }
 }
-template <Type recon_type>
+template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void ReconstructX2l(RECONSTRUCT_ROW_LEFT_ARGS)
 {
     for (int p = 0; p <= q.GetDim(4) - 1; ++p) {
-        parthenon::par_for_inner(member, il, iu,
-            KOKKOS_LAMBDA (const int& i) {
-                reconstruct_right<recon_type>(
-                    q(p, k, j - 2, i),
-                    q(p, k, j - 1, i),
-                    q(p, k, j, i),
-                    q(p, k, j + 1, i),
-                    q(p, k, j + 2, i),
-                    ql(p, i));
-            }
-        );
+        parthenon::par_for_inner(member, il, iu, KOKKOS_LAMBDA(const int& i)
+            {
+                reconstruct_right<recon_type>(q(p, k, j - 2, i), q(p, k, j - 1, i),
+                    q(p, k, j, i), q(p, k, j + 1, i), q(p, k, j + 2, i), ql(p, i));
+            });
     }
 }
-template <Type recon_type>
+template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void ReconstructX2r(RECONSTRUCT_ROW_RIGHT_ARGS)
 {
     for (int p = 0; p <= q.GetDim(4) - 1; ++p) {
-        parthenon::par_for_inner(member, il, iu,
-            KOKKOS_LAMBDA (const int& i) {
-                reconstruct_left<recon_type>(
-                    q(p, k, j - 2, i),
-                    q(p, k, j - 1, i),
-                    q(p, k, j, i),
-                    q(p, k, j + 1, i),
-                    q(p, k, j + 2, i),
-                    qr(p, i));
-            }
-        );
+        parthenon::par_for_inner(member, il, iu, KOKKOS_LAMBDA(const int& i)
+            {
+                reconstruct_left<recon_type>(q(p, k, j - 2, i), q(p, k, j - 1, i),
+                    q(p, k, j, i), q(p, k, j + 1, i), q(p, k, j + 2, i), qr(p, i));
+            });
     }
 }
-template <Type recon_type>
+template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void ReconstructX3l(RECONSTRUCT_ROW_LEFT_ARGS)
 {
     for (int p = 0; p <= q.GetDim(4) - 1; ++p) {
-        parthenon::par_for_inner(member, il, iu,
-            KOKKOS_LAMBDA (const int& i) {
-                reconstruct_right<recon_type>(
-                    q(p, k - 2, j, i),
-                    q(p, k - 1, j, i),
-                    q(p, k, j, i),
-                    q(p, k + 1, j, i),
-                    q(p, k + 2, j, i),
-                    ql(p, i));
-            }
-        );
+        parthenon::par_for_inner(member, il, iu, KOKKOS_LAMBDA(const int& i)
+            {
+                reconstruct_right<recon_type>(q(p, k - 2, j, i), q(p, k - 1, j, i),
+                    q(p, k, j, i), q(p, k + 1, j, i), q(p, k + 2, j, i), ql(p, i));
+            });
     }
 }
-template <Type recon_type>
+template<Type recon_type>
 KOKKOS_FORCEINLINE_FUNCTION void ReconstructX3r(RECONSTRUCT_ROW_RIGHT_ARGS)
 {
     for (int p = 0; p <= q.GetDim(4) - 1; ++p) {
-        parthenon::par_for_inner(member, il, iu,
-            KOKKOS_LAMBDA (const int& i) {
-                reconstruct_left<recon_type>(
-                    q(p, k - 2, j, i),
-                    q(p, k - 1, j, i),
-                    q(p, k, j, i),
-                    q(p, k + 1, j, i),
-                    q(p, k + 2, j, i),
-                    qr(p, i));
-            }
-        );
+        parthenon::par_for_inner(member, il, iu, KOKKOS_LAMBDA(const int& i)
+            {
+                reconstruct_left<recon_type>(q(p, k - 2, j, i), q(p, k - 1, j, i),
+                    q(p, k, j, i), q(p, k + 1, j, i), q(p, k + 2, j, i), qr(p, i));
+            });
     }
 }
 
-
 /**
  * Templated calls to different reconstruction algorithms
- * This is basically a compile-time 'if' or 'switch' statement, where all the options get generated
- * at compile-time (see driver.cpp for the different instantiations)
+ * This is basically a compile-time 'if' or 'switch' statement, where all the options get
+ * generated at compile-time (see driver.cpp for the different instantiations)
  */
-template <Type recon_type, int dir>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow(parthenon::team_mbr_t& member, const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<Type recon_type, int dir>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow(parthenon::team_mbr_t& member,
+    const VariablePack<Real>& P, const int& k, const int& j, const int& is_l,
+    const int& ie_l, ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
 {
     if constexpr (dir == X1DIR) {
         ReconstructX1<recon_type>(member, k, j, is_l, ie_l, P, ql, qr);
@@ -630,16 +646,20 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow(parthenon::team_mbr_t& member, c
 
 // Reconstruct with ismr:
 // Linear X3 reconstruction near X2 boundaries, but otherwise call through
-// TODO higher-order with spacing of the coarse cells? Would need new ReconstructXN+no DC/VL support
-template <Type recon_type, int dir>
-KOKKOS_INLINE_FUNCTION void ReconstructRowIsmr(parthenon::team_mbr_t& member, const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, const int& ng_plus_nlevels,
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+// TODO higher-order with spacing of the coarse cells? Would need new ReconstructXN+no
+// DC/VL support
+template<Type recon_type, int dir>
+KOKKOS_INLINE_FUNCTION void ReconstructRowIsmr(parthenon::team_mbr_t& member,
+    const VariablePack<Real>& P, const int& k, const int& j, const int& is_l,
+    const int& ie_l, const int& ng_plus_nlevels, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     if constexpr (dir == X3DIR) {
         if (j < ng_plus_nlevels || j > P.GetDim(2) - 1 - ng_plus_nlevels) {
-            KReconstruction::ReconstructX3l<Type::linear_mc>(member, k - 1, j, is_l, ie_l, P, ql);
-            KReconstruction::ReconstructX3r<Type::linear_mc>(member, k, j, is_l, ie_l, P, qr);
+            KReconstruction::ReconstructX3l<Type::linear_mc>(
+                member, k - 1, j, is_l, ie_l, P, ql);
+            KReconstruction::ReconstructX3r<Type::linear_mc>(
+                member, k, j, is_l, ie_l, P, qr);
         } else {
             ReconstructRow<recon_type, dir>(member, P, k, j, is_l, ie_l, ql, qr);
         }
@@ -649,29 +669,29 @@ KOKKOS_INLINE_FUNCTION void ReconstructRowIsmr(parthenon::team_mbr_t& member, co
 }
 
 // Donor cell: Parthenon already implemented the row versions, so we call through.
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X1DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X1DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     DonorCellX1(member, k, j, is_l, ie_l, P, ql, qr);
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X2DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X2DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     ScratchPad2D<Real> q_u(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     DonorCellX2(member, k, j - 1, is_l, ie_l, P, ql, q_u);
     DonorCellX2(member, k, j, is_l, ie_l, P, q_u, qr);
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X3DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X3DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     ScratchPad2D<Real> q_u(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     DonorCellX3(member, k - 1, j, is_l, ie_l, P, ql, q_u);
@@ -679,27 +699,27 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::donor_cell, X3DIR>(parthen
 }
 
 // Linear from Parthenon, w/simplified van Leer limiting
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X1DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X1DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     // Extra scratch space for Parthenon's VL limiter stuff
-    ScratchPad2D<Real>  qc(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
+    ScratchPad2D<Real> qc(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dql(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dqr(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dqm(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     PiecewiseLinearX1(member, k, j, is_l, ie_l, P, ql, qr, qc, dql, dqr, dqm);
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X2DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X2DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     // Extra scratch space for Parthenon's VL limiter stuff
-    ScratchPad2D<Real>  qc(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
+    ScratchPad2D<Real> qc(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dql(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dqr(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dqm(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
@@ -707,14 +727,14 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X2DIR>(partheno
     PiecewiseLinearX2(member, k, j - 1, is_l, ie_l, P, ql, q_u, qc, dql, dqr, dqm);
     PiecewiseLinearX2(member, k, j, is_l, ie_l, P, q_u, qr, qc, dql, dqr, dqm);
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X3DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X3DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     // Extra scratch space for Parthenon's VL limiter stuff
-    ScratchPad2D<Real>  qc(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
+    ScratchPad2D<Real> qc(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dql(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dqr(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
     ScratchPad2D<Real> dqm(member.team_scratch(1), P.GetDim(4), P.GetDim(1));
@@ -725,43 +745,43 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::linear_vl, X3DIR>(partheno
 
 // WENO5 lowered edges:
 // Linear X1 reconstruction near X1 boundaries
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_edges, X1DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_edges, X1DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     // This prioiritizes using the same-order fluxes on faces rather than for cells.
     // Neither is transparently wrong (afaict) but this feels nicer
     constexpr int o = 5; // offset
-    ReconstructX1<Type::weno5>(member, k, j, is_l+o, ie_l-o, P, ql, qr);
-    ReconstructX1<Type::linear_mc>(member, k, j, is_l, is_l+o-1, P, ql, qr);
-    ReconstructX1<Type::linear_mc>(member, k, j, ie_l-o+1, ie_l, P, ql, qr);
+    ReconstructX1<Type::weno5>(member, k, j, is_l + o, ie_l - o, P, ql, qr);
+    ReconstructX1<Type::linear_mc>(member, k, j, is_l, is_l + o - 1, P, ql, qr);
+    ReconstructX1<Type::linear_mc>(member, k, j, ie_l - o + 1, ie_l, P, ql, qr);
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_edges, X2DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_edges, X2DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     ReconstructRow<Type::weno5, X2DIR>(member, P, k, j, is_l, ie_l, ql, qr);
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_edges, X3DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_edges, X3DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     ReconstructRow<Type::weno5, X3DIR>(member, P, k, j, is_l, ie_l, ql, qr);
 }
 
 // WENO5 lowered poles:
 // Linear X2 reconstruction near X2 boundaries
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X1DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X1DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     constexpr int o = 6;
     if (j > o && j < P.GetDim(2) - o) {
@@ -770,15 +790,16 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X1DIR>(
         ReconstructRow<Type::linear_mc, X1DIR>(member, P, k, j, is_l, ie_l, ql, qr);
     }
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X2DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X2DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     // This prioiritizes using the same fluxes on faces rather than for cells.
     // Neither is transparently wrong (afaict) but this feels nicer
-    // Use first 2 physical rows to prevent high-order recon reaching from rank 2 across pole
+    // Use first 2 physical rows to prevent high-order recon reaching from rank 2 across
+    // pole
     constexpr int o = 6;
     if (j > o && j < P.GetDim(2) - o) {
         ReconstructX2l<Type::weno5>(member, k, j - 1, is_l, ie_l, P, ql);
@@ -788,11 +809,11 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X2DIR>(
         ReconstructX2r<Type::linear_mc>(member, k, j, is_l, ie_l, P, qr);
     }
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X3DIR>(parthenon::team_mbr_t& member,
-                                        const VariablePack<Real> &P,
-                                        const int& k, const int& j, const int& is_l, const int& ie_l, 
-                                        ScratchPad2D<Real> ql, ScratchPad2D<Real> qr)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X3DIR>(
+    parthenon::team_mbr_t& member, const VariablePack<Real>& P, const int& k,
+    const int& j, const int& is_l, const int& ie_l, ScratchPad2D<Real> ql,
+    ScratchPad2D<Real> qr)
 {
     constexpr int o = 6;
     if (j > o && j < P.GetDim(2) - o) {
@@ -806,11 +827,12 @@ KOKKOS_FORCEINLINE_FUNCTION void ReconstructRow<Type::weno5_lower_poles, X3DIR>(
  * Versions computing just the (limited) slope, for linear reconstructions.
  * Used for gradient calculations needed to implement Extended GRMHD.
  */
-template <Type Recon>
+template<Type Recon>
 KOKKOS_FORCEINLINE_FUNCTION Real slope_limit(Real x1, Real x2, Real x3, Real dx);
 // Linear MC slope limiter
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_limit<Type::linear_mc>(Real x1, Real x2, Real x3, Real dx)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_limit<Type::linear_mc>(
+    Real x1, Real x2, Real x3, Real dx)
 {
     const Real Dqm = 2 * (x2 - x1) / dx;
     const Real Dqp = 2 * (x3 - x2) / dx;
@@ -829,8 +851,9 @@ KOKKOS_FORCEINLINE_FUNCTION Real slope_limit<Type::linear_mc>(Real x1, Real x2, 
     }
 }
 // Linear Van Leer slope limiter
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_limit<Type::linear_vl>(Real x1, Real x2, Real x3, Real dx)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_limit<Type::linear_vl>(
+    Real x1, Real x2, Real x3, Real dx)
 {
     const Real Dqm = (x2 - x1) / dx;
     const Real Dqp = (x3 - x2) / dx;
@@ -840,52 +863,64 @@ KOKKOS_FORCEINLINE_FUNCTION Real slope_limit<Type::linear_vl>(Real x1, Real x2, 
     if (extrema <= 0) {
         return 0;
     } else {
-        return (2 * extrema / (Dqm + Dqp)); 
+        return (2 * extrema / (Dqm + Dqp));
     }
 }
 
 /**
  * Run slope_limit in direction 'dir' using limiter 'recon'
  */
-template <Type recon, int dir>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i);
+template<Type recon, int dir>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc(const GRCoordinates& G,
+    const VariablePack<Real>& P, const int& p, const int& k, const int& j, const int& i);
 // And six implementations.  Why can't you partial-specialize functions?  Why?
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_mc, X1DIR>(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_mc, X1DIR>(
+    const GRCoordinates& G, const VariablePack<Real>& P, const int& p, const int& k,
+    const int& j, const int& i)
 {
-    return slope_limit<Type::linear_mc>(P(p, k, j, i-1), P(p, k, j, i), P(p, k, j, i+1), G.Dxc<X1DIR>(i));
+    return slope_limit<Type::linear_mc>(
+        P(p, k, j, i - 1), P(p, k, j, i), P(p, k, j, i + 1), G.Dxc<X1DIR>(i));
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_mc, X2DIR>(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_mc, X2DIR>(
+    const GRCoordinates& G, const VariablePack<Real>& P, const int& p, const int& k,
+    const int& j, const int& i)
 {
-    return slope_limit<Type::linear_mc>(P(p, k, j-1, i), P(p, k, j, i), P(p, k, j+1, i), G.Dxc<X2DIR>(j));
+    return slope_limit<Type::linear_mc>(
+        P(p, k, j - 1, i), P(p, k, j, i), P(p, k, j + 1, i), G.Dxc<X2DIR>(j));
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_mc, X3DIR>(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_mc, X3DIR>(
+    const GRCoordinates& G, const VariablePack<Real>& P, const int& p, const int& k,
+    const int& j, const int& i)
 {
-    return slope_limit<Type::linear_mc>(P(p, k-1, j, i), P(p, k, j, i), P(p, k+1, j, i), G.Dxc<X3DIR>(k));
+    return slope_limit<Type::linear_mc>(
+        P(p, k - 1, j, i), P(p, k, j, i), P(p, k + 1, j, i), G.Dxc<X3DIR>(k));
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_vl, X1DIR>(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_vl, X1DIR>(
+    const GRCoordinates& G, const VariablePack<Real>& P, const int& p, const int& k,
+    const int& j, const int& i)
 {
-    return slope_limit<Type::linear_vl>(P(p, k, j, i-1), P(p, k, j, i), P(p, k, j, i+1), G.Dxc<X1DIR>(i));
+    return slope_limit<Type::linear_vl>(
+        P(p, k, j, i - 1), P(p, k, j, i), P(p, k, j, i + 1), G.Dxc<X1DIR>(i));
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_vl, X2DIR>(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_vl, X2DIR>(
+    const GRCoordinates& G, const VariablePack<Real>& P, const int& p, const int& k,
+    const int& j, const int& i)
 {
-    return slope_limit<Type::linear_vl>(P(p, k, j-1, i), P(p, k, j, i), P(p, k, j+1, i), G.Dxc<X2DIR>(j));
+    return slope_limit<Type::linear_vl>(
+        P(p, k, j - 1, i), P(p, k, j, i), P(p, k, j + 1, i), G.Dxc<X2DIR>(j));
 }
-template <>
-KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_vl, X3DIR>(const GRCoordinates& G, const VariablePack<Real>& P,
-                                              const int& p, const int& k, const int& j, const int& i)
+template<>
+KOKKOS_FORCEINLINE_FUNCTION Real slope_calc<Type::linear_vl, X3DIR>(
+    const GRCoordinates& G, const VariablePack<Real>& P, const int& p, const int& k,
+    const int& j, const int& i)
 {
-    return slope_limit<Type::linear_vl>(P(p, k-1, j, i), P(p, k, j, i), P(p, k+1, j, i), G.Dxc<X3DIR>(k));
+    return slope_limit<Type::linear_vl>(
+        P(p, k - 1, j, i), P(p, k, j, i), P(p, k + 1, j, i), G.Dxc<X3DIR>(k));
 }
 
 } // namespace KReconstruction

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -59,7 +59,8 @@
 namespace GRMHD
 {
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     // This function builds and returns a "KHARMAPackage" object, which is a light
     // superset of Parthenon's "StateDescriptor" class for packages.
@@ -70,7 +71,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     // This "dictionary" is mostly immutable, and should always be treated as immutable,
     // except in the "Globals" package.
     auto pkg = std::make_shared<KHARMAPackage>("GRMHD");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // GRMHD PARAMETERS
     // Fluid gamma for ideal EOS.  Don't guess this.
@@ -84,9 +85,9 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     params.Add("cfl", cfl);
 
     // TIME PARAMETERS
-    // These parameters are put in "parthenon/time" to match others, but ultimately we should
-    // override the parthenon timestep chooser
-    // Minimum timestep, if something about the sound speed goes wonky. Probably won't save you :)
+    // These parameters are put in "parthenon/time" to match others, but ultimately we
+    // should override the parthenon timestep chooser Minimum timestep, if something about
+    // the sound speed goes wonky. Probably won't save you :)
     double dt_min = pin->GetOrAddReal("parthenon/time", "dt_min", 1.e-5);
     params.Add("dt_min", dt_min);
     // Starting timestep: guaranteed step 1 timestep returned by EstimateTimestep,
@@ -96,22 +97,26 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     double max_dt_increase = pin->GetOrAddReal("parthenon/time", "max_dt_increase", 2.0);
     params.Add("max_dt_increase", max_dt_increase);
 
-    // Alternatively, you can start with (or just always use) the light (phase) speed crossing time
-    // of the smallest zone. Useful when you're not sure of/modeling the characteristic velocities
+    // Alternatively, you can start with (or just always use) the light (phase) speed
+    // crossing time of the smallest zone. Useful when you're not sure of/modeling the
+    // characteristic velocities
     bool start_dt_light = pin->GetOrAddBoolean("parthenon/time", "start_dt_light", false);
     params.Add("start_dt_light", start_dt_light);
     bool use_dt_light = pin->GetOrAddBoolean("parthenon/time", "use_dt_light", false);
     params.Add("use_dt_light", use_dt_light);
-    bool use_dt_light_phase_speed = pin->GetOrAddBoolean("parthenon/time", "use_dt_light_phase_speed", false);
+    bool use_dt_light_phase_speed =
+        pin->GetOrAddBoolean("parthenon/time", "use_dt_light_phase_speed", false);
     params.Add("use_dt_light_phase_speed", use_dt_light_phase_speed);
 
     // IMPLICIT PARAMETERS
-    // The ImEx driver is necessary to evolve implicitly, but doesn't require it.  Using explicit
-    // updates for GRMHD vars is useful for testing, or if adding just a couple of implicit variables
-    // Doing EGRMHD requires implicit evolution of GRMHD variables, of course
+    // The ImEx driver is necessary to evolve implicitly, but doesn't require it.  Using
+    // explicit updates for GRMHD vars is useful for testing, or if adding just a couple
+    // of implicit variables Doing EGRMHD requires implicit evolution of GRMHD variables,
+    // of course
     auto& driver = packages->Get("Driver")->AllParams();
     auto implicit_grmhd = (driver.Get<DriverType>("type") == DriverType::imex) &&
-                          (pin->GetBoolean("emhd", "on") || pin->GetOrAddBoolean("GRMHD", "implicit", false));
+                          (pin->GetBoolean("emhd", "on") ||
+                              pin->GetOrAddBoolean("GRMHD", "implicit", false));
     params.Add("implicit", implicit_grmhd);
     // Explicitly-evolved ideal MHD variables as guess for Extended MHD runs
     // TODO move to EMHD package, guard reads on package presence
@@ -138,31 +143,37 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     Metadata::AddUserFlag("HD");
     // Magnetohydrodynamics (all HD fields plus B field, which we'll need to make use of)
     Metadata::AddUserFlag("MHD");
-    // Mark whether to evolve our variables via the explicit or implicit step inside the driver
+    // Mark whether to evolve our variables via the explicit or implicit step inside the
+    // driver
     MetadataFlag areWeImplicit = (implicit_grmhd) ? Metadata::GetUserFlag("Implicit")
                                                   : Metadata::GetUserFlag("Explicit");
-    std::vector<MetadataFlag> flags_grmhd = {Metadata::Cell, areWeImplicit, Metadata::GetUserFlag("HD"), Metadata::GetUserFlag("MHD")};
+    std::vector<MetadataFlag> flags_grmhd = {Metadata::Cell, areWeImplicit,
+        Metadata::GetUserFlag("HD"), Metadata::GetUserFlag("MHD")};
 
     auto flags_prim = driver.Get<std::vector<MetadataFlag>>("prim_flags");
     flags_prim.insert(flags_prim.end(), flags_grmhd.begin(), flags_grmhd.end());
     auto flags_cons = driver.Get<std::vector<MetadataFlag>>("cons_flags");
     flags_cons.insert(flags_cons.end(), flags_grmhd.begin(), flags_grmhd.end());
 
-    // Mark whether the ideal MHD variables are to be updated explicitly for the guess to the solver
+    // Mark whether the ideal MHD variables are to be updated explicitly for the guess to
+    // the solver
     if (ideal_guess) {
         flags_prim.push_back(Metadata::GetUserFlag("IdealGuess"));
         flags_cons.push_back(Metadata::GetUserFlag("IdealGuess"));
     }
 
-    // We must additionally save the primtive variables as the "seed" for the next U->P solve
+    // We must additionally save the primtive variables as the "seed" for the next U->P
+    // solve
     flags_prim.push_back(Metadata::Restart);
 
-    // We must additionally fill ghost zones of primitive variables in GRMHD, to seed the solver
-    // Only necessary to add here if syncing conserved vars
-    // Note some startup behavior relies on having the GRHD prims marked for syncing,
-    // so disable sync_utop_seed at your peril
-    // TODO work out disabling this automatically if Kastaun solver is enabled (requires no seed to converge)
-    if (!driver.Get<bool>("sync_prims") && pin->GetOrAddBoolean("GRMHD", "sync_utop_seed", true)) {
+    // We must additionally fill ghost zones of primitive variables in GRMHD, to seed the
+    // solver Only necessary to add here if syncing conserved vars Note some startup
+    // behavior relies on having the GRHD prims marked for syncing, so disable
+    // sync_utop_seed at your peril
+    // TODO work out disabling this automatically if Kastaun solver is enabled (requires
+    // no seed to converge)
+    if (!driver.Get<bool>("sync_prims") &&
+        pin->GetOrAddBoolean("GRMHD", "sync_utop_seed", true)) {
         flags_prim.push_back(Metadata::FillGhost);
     }
 
@@ -192,67 +203,93 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     // A KHARMAPackage also contains quite a few "callbacks," or functions called at
     // specific points in a step if the package is loaded.
     // Generally, see the headers for function descriptions.
-    pkg->CheckRefinementBlock    = GRMHD::CheckRefinement;
-    pkg->EstimateTimestepMesh    = GRMHD::EstimateTimestep;
+    pkg->CheckRefinementBlock = GRMHD::CheckRefinement;
+    pkg->EstimateTimestepMesh = GRMHD::EstimateTimestep;
     pkg->PostStepDiagnosticsMesh = GRMHD::PostStepDiagnostics;
-    // NOTE: PtoU and UtoP for the five fluid variables are taken care of by the "Inverter"
-    // package, which registers the relevant callbacks
-    // This is so that the whole package can be disabled when running implicitly or w/EMHD
+    // NOTE: PtoU and UtoP for the five fluid variables are taken care of by the
+    // "Inverter" package, which registers the relevant callbacks This is so that the
+    // whole package can be disabled when running implicitly or w/EMHD
 
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
     bool do_all = KHARMA::FieldIsOutput(pin, "all_reductions");
     // Common tracking variables
     if (do_all || KHARMA::FieldIsOutput(pin, "conserved_vars")) {
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::rhou0>, "Mass"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T00>, "Egas"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T01>, "X1_Mom"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T02>, "X2_Mom"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T03>, "Ang_Mom"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::rhou0>, "Mass"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::mix_T00>, "Egas"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::mix_T01>, "X1_Mom"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::mix_T02>, "X2_Mom"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::mix_T03>, "Ang_Mom"));
     }
     // TODO these are probably more useful at/within/without certain radii
     if (do_all || KHARMA::FieldIsOutput(pin, "luminosities")) {
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::eht_lum>, "EHT_Lum_Proxy"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::jet_lum>, "Jet_Lum"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::eht_lum>, "EHT_Lum_Proxy"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+            Reductions::Total<Reductions::Var::jet_lum>, "Jet_Lum"));
     }
     // Event horizon fluxes
     if (pin->GetBoolean("coordinates", "domain_intersects_eh")) {
         if (do_all || KHARMA::FieldIsOutput(pin, "eh_fluxes_cell")) {
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::mdot>, "Mdot"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::mdot>, "Mdot_EH"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::mdot>, "Mdot_5M"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::edot>, "Edot"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::edot>, "Edot_EH"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::edot>, "Edot_5M"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::ldot>, "Ldot"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::ldot>, "Ldot_EH"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::ldot>, "Ldot_5M"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt0<Reductions::Var::mdot>, "Mdot"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAtEH<Reductions::Var::mdot>, "Mdot_EH"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt5M<Reductions::Var::mdot>, "Mdot_5M"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt0<Reductions::Var::edot>, "Edot"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAtEH<Reductions::Var::edot>, "Edot_EH"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt5M<Reductions::Var::edot>, "Edot_5M"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt0<Reductions::Var::ldot>, "Ldot"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAtEH<Reductions::Var::ldot>, "Ldot_EH"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt5M<Reductions::Var::ldot>, "Ldot_5M"));
         }
 
         // Add event-horizon fluxes by default as a check
         if (true || do_all || KHARMA::FieldIsOutput(pin, "eh_fluxes_flux")) {
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::mdot_flux>, "Mdot_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::mdot_flux>, "Mdot_EH_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::mdot_flux>, "Mdot_5M_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::edot_flux>, "Edot_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::edot_flux>, "Edot_EH_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::edot_flux>, "Edot_5M_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::ldot_flux>, "Ldot_0_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::ldot_flux>, "Ldot_EH_Flux"));
-            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::ldot_flux>, "Ldot_5M_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt0<Reductions::Var::mdot_flux>, "Mdot_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAtEH<Reductions::Var::mdot_flux>, "Mdot_EH_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt5M<Reductions::Var::mdot_flux>, "Mdot_5M_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt0<Reductions::Var::edot_flux>, "Edot_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAtEH<Reductions::Var::edot_flux>, "Edot_EH_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt5M<Reductions::Var::edot_flux>, "Edot_5M_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt0<Reductions::Var::ldot_flux>, "Ldot_0_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAtEH<Reductions::Var::ldot_flux>, "Ldot_EH_Flux"));
+            hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum,
+                Reductions::SumAt5M<Reductions::Var::ldot_flux>, "Ldot_5M_Flux"));
         }
     }
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     return pkg;
 }
 
-Real EstimateTimestep(MeshData<Real> *md)
+Real EstimateTimestep(MeshData<Real>* md)
 {
-    // Normally the caller would place this flag before calling us, but this is from Parthenon
-    // This function is a nice demo of why client-side flagging
-    // like this is inadvisable: you have to EndFlag() at every different return
+    // Normally the caller would place this flag before calling us, but this is from
+    // Parthenon This function is a nice demo of why client-side flagging like this is
+    // inadvisable: you have to EndFlag() at every different return
     Flag("EstimateTimestep");
     auto pmesh = md->GetMeshPointer();
     auto& globals = pmesh->packages.Get("Globals")->AllParams();
@@ -301,29 +338,34 @@ Real EstimateTimestep(MeshData<Real> *md)
     // Internal SMR adds a factor to dx3 at poles based on larger cell width
     // TODO distinguish polar from other ISMR if more modes are added
     const bool ismr_poles = pmesh->packages.AllPackages().count("ISMR");
-    const uint ismr_nlevels = (ismr_poles) ? pmesh->packages.Get("ISMR")->Param<uint>("nlevels") : 0;
+    const uint ismr_nlevels =
+        (ismr_poles) ? pmesh->packages.Get("ISMR")->Param<uint>("nlevels") : 0;
 
     // TODO version preserving location, with switch to keep this fast one
     // TODO maybe split normal vs funky/additional timesteps (ISMR, excised polar)?
     // TODO Make the base calculation a mesh-wise function?
     double min_ndt = std::numeric_limits<double>::max();
-    for (auto &pmb : pmesh->block_list) {
+    for (auto& pmb : pmesh->block_list) {
         auto rc = pmb->meshblock_data.Get(md->StageName()).get();
-        // We only need this block-wise to check boundary flags for ISMR, could special-case that
-        const bool is_inner_x2 = KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2);
-        const bool is_outer_x2 = KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2);
+        // We only need this block-wise to check boundary flags for ISMR, could
+        // special-case that
+        const bool is_inner_x2 =
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::inner_x2);
+        const bool is_outer_x2 =
+            KBoundaries::IsPhysicalBoundary(pmb, BoundaryFace::outer_x2);
 
-        const auto& cmax  = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
-        const auto& cmin  = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
+        const auto& cmax = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
+        const auto& cmin = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
         auto& boundaries = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
         const bool excise_inner_x2 = boundaries.Get<bool>("excise_flux_inner_x2");
         const bool excise_outer_x2 = boundaries.Get<bool>("excise_flux_outer_x2");
 
         double block_min_ndt = 0.;
-        pmb->par_reduce("ndt_min", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-            KOKKOS_LAMBDA (const int k, const int j, const int i,
-                        double &local_result) {
+        pmb->par_reduce(
+            "ndt_min", b.ks, b.ke, b.js, b.je, b.is, b.ie,
+            KOKKOS_LAMBDA(const int k, const int j, const int i, double& local_result)
+            {
                 const auto& G = cmax.GetCoords();
                 int ismr_factor = 1;
                 double excise_factor = 1.0;
@@ -343,19 +385,23 @@ Real EstimateTimestep(MeshData<Real> *md)
                     excise_factor = 0.5;
                 }
 
-                double ndt_zone = courant_limit / (1 / (G.Dxc<1>(i) /  m::max(cmax(V1, k, j, i), cmin(V1, k, j, i))) +
-                                    1 / (G.Dxc<2>(j) * excise_factor /  m::max(cmax(V2, k, j, i), cmin(V2, k, j, i))) +
-                                    1 / (G.Dxc<3>(k) * ismr_factor /  m::max(cmax(V3, k, j, i), cmin(V3, k, j, i))));
+                double ndt_zone =
+                    courant_limit /
+                    (1 / (G.Dxc<1>(i) / m::max(cmax(V1, k, j, i), cmin(V1, k, j, i))) +
+                        1 / (G.Dxc<2>(j) * excise_factor /
+                                m::max(cmax(V2, k, j, i), cmin(V2, k, j, i))) +
+                        1 / (G.Dxc<3>(k) * ismr_factor /
+                                m::max(cmax(V3, k, j, i), cmin(V3, k, j, i))));
 
                 if (!m::isnan(ndt_zone) && (ndt_zone < local_result)) {
                     local_result = ndt_zone;
                 }
-            }
-        , Kokkos::Min<double>(block_min_ndt));
+            },
+            Kokkos::Min<double>(block_min_ndt));
         if (block_min_ndt < min_ndt) min_ndt = block_min_ndt;
-        //std::cerr << "Got block timestep: " << block_min_ndt << std::endl;
+        // std::cerr << "Got block timestep: " << block_min_ndt << std::endl;
     }
-    //std::cerr << "Got min timestep: " << min_ndt << std::endl;
+    // std::cerr << "Got min timestep: " << min_ndt << std::endl;
 
     // Apply limits (TODO move into KHARMADriver::SetGlobalTimestep)
     const double cfl = grmhd_pars.Get<double>("cfl");
@@ -368,7 +414,7 @@ Real EstimateTimestep(MeshData<Real> *md)
     return ndt;
 }
 
-Real EstimateRadiativeTimestep(MeshData<Real> *md)
+Real EstimateRadiativeTimestep(MeshData<Real>* md)
 {
     Flag("EstimateRadiativeTimestep");
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -377,16 +423,18 @@ Real EstimateRadiativeTimestep(MeshData<Real> *md)
     const bool phase_speed = grmhd_pars.Get<bool>("use_dt_light_phase_speed");
 
     // Doesn't actually matter what we pack here, we're just pulling G
-    const auto& dummy  = md->PackVariables(std::vector<std::string>{});
+    const auto& dummy = md->PackVariables(std::vector<std::string>{});
 
     const IndexRange3 b = KDomain::GetRange(md, IndexDomain::interior);
-    const IndexRange block = IndexRange{0, dummy.GetDim(5)-1};
+    const IndexRange block = IndexRange{0, dummy.GetDim(5) - 1};
 
     // Leaving minmax in case the max phase speed is useful
     typename Kokkos::MinMax<Real>::value_type minmax;
-    pmb0->par_reduce("ndt_min", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
+    pmb0->par_reduce(
+        "ndt_min", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
         KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
-                      typename Kokkos::MinMax<Real>::value_type& lminmax) {
+            typename Kokkos::MinMax<Real>::value_type& lminmax)
+        {
             const auto& G = dummy.GetCoords(b);
 
             double light_phase_speed = SMALL_NUM;
@@ -395,41 +443,46 @@ Real EstimateRadiativeTimestep(MeshData<Real> *md)
             if (phase_speed) {
                 double local_phase_speed[GR_DIM];
                 for (int mu = 1; mu < GR_DIM; mu++) {
-                    if(SQR(G.gcon(Loci::center, j, i, 0, mu)) -
-                        G.gcon(Loci::center, j, i, mu, mu)*G.gcon(Loci::center, j, i, 0, 0) >= 0.) {
+                    if (SQR(G.gcon(Loci::center, j, i, 0, mu)) -
+                            G.gcon(Loci::center, j, i, mu, mu) *
+                                G.gcon(Loci::center, j, i, 0, 0) >=
+                        0.) {
 
-                        double cplus = m::abs((-G.gcon(Loci::center, j, i, 0, mu) +
-                                            m::sqrt(SQR(G.gcon(Loci::center, j, i, 0, mu)) -
-                                                G.gcon(Loci::center, j, i, mu, mu)*G.gcon(Loci::center, j, i, 0, 0)))/
-                                            G.gcon(Loci::center, j, i, 0, 0));
+                        double cplus =
+                            m::abs((-G.gcon(Loci::center, j, i, 0, mu) +
+                                       m::sqrt(SQR(G.gcon(Loci::center, j, i, 0, mu)) -
+                                               G.gcon(Loci::center, j, i, mu, mu) *
+                                                   G.gcon(Loci::center, j, i, 0, 0))) /
+                                   G.gcon(Loci::center, j, i, 0, 0));
 
-                        double cminus = m::abs((-G.gcon(Loci::center, j, i, 0, mu) -
-                                            m::sqrt(SQR(G.gcon(Loci::center, j, i, 0, mu)) -
-                                                G.gcon(Loci::center, j, i, mu, mu)*G.gcon(Loci::center, j, i, 0, 0)))/
-                                            G.gcon(Loci::center, j, i, 0, 0));
+                        double cminus =
+                            m::abs((-G.gcon(Loci::center, j, i, 0, mu) -
+                                       m::sqrt(SQR(G.gcon(Loci::center, j, i, 0, mu)) -
+                                               G.gcon(Loci::center, j, i, mu, mu) *
+                                                   G.gcon(Loci::center, j, i, 0, 0))) /
+                                   G.gcon(Loci::center, j, i, 0, 0));
 
-                        local_phase_speed[mu] = m::max(cplus,cminus);
+                        local_phase_speed[mu] = m::max(cplus, cminus);
                     } else {
                         local_phase_speed[mu] = SMALL_NUM;
                     }
                 }
-                dt_light_local = 1./(G.Dxc<1>(0)/local_phase_speed[1]) +
-                                 1./(G.Dxc<2>(0)/local_phase_speed[2]) +
-                                 1./(G.Dxc<3>(0)/local_phase_speed[3]);
-                light_phase_speed = m::max(local_phase_speed[1], m::max(local_phase_speed[2], local_phase_speed[3]));
+                dt_light_local = 1. / (G.Dxc<1>(0) / local_phase_speed[1]) +
+                                 1. / (G.Dxc<2>(0) / local_phase_speed[2]) +
+                                 1. / (G.Dxc<3>(0) / local_phase_speed[3]);
+                light_phase_speed = m::max(local_phase_speed[1],
+                    m::max(local_phase_speed[2], local_phase_speed[3]));
             } else {
-                dt_light_local = 1./G.Dxc<1>(0) +
-                                 1./G.Dxc<2>(0) +
-                                 1./G.Dxc<3>(0);
+                dt_light_local = 1. / G.Dxc<1>(0) + 1. / G.Dxc<2>(0) + 1. / G.Dxc<3>(0);
             }
-            dt_light_local = 1/dt_light_local;
+            dt_light_local = 1 / dt_light_local;
 
             if (!m::isnan(dt_light_local) && (dt_light_local < lminmax.min_val))
                 lminmax.min_val = dt_light_local;
             if (!m::isnan(light_phase_speed) && (light_phase_speed > lminmax.max_val))
                 lminmax.max_val = light_phase_speed;
-        }
-    , Kokkos::MinMax<Real>(minmax));
+        },
+        Kokkos::MinMax<Real>(minmax));
 
     // Just spit out dt
     const double cfl = grmhd_pars.Get<double>("cfl");
@@ -439,7 +492,7 @@ Real EstimateRadiativeTimestep(MeshData<Real> *md)
     return ndt;
 }
 
-AmrTag CheckRefinement(MeshBlockData<Real> *rc)
+AmrTag CheckRefinement(MeshBlockData<Real>* rc)
 {
     auto pmb = rc->GetBlockPointer();
     auto v = rc->Get("prims.rho").data;
@@ -450,26 +503,26 @@ AmrTag CheckRefinement(MeshBlockData<Real> *rc)
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
 
     typename Kokkos::MinMax<Real>::value_type minmax;
-    pmb->par_reduce("check_refinement", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+    pmb->par_reduce(
+        "check_refinement", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA(const int k, const int j, const int i,
-                      typename Kokkos::MinMax<Real>::value_type &lminmax) {
-        lminmax.min_val =
-            v(k, j, i) < lminmax.min_val ? v(k, j, i) : lminmax.min_val;
-        lminmax.max_val =
-            v(k, j, i) > lminmax.max_val ? v(k, j, i) : lminmax.max_val;
-        }
-    , Kokkos::MinMax<Real>(minmax));
+            typename Kokkos::MinMax<Real>::value_type& lminmax)
+        {
+            lminmax.min_val = v(k, j, i) < lminmax.min_val ? v(k, j, i) : lminmax.min_val;
+            lminmax.max_val = v(k, j, i) > lminmax.max_val ? v(k, j, i) : lminmax.max_val;
+        },
+        Kokkos::MinMax<Real>(minmax));
 
     auto pkg = pmb->packages.Get("GRMHD");
-    const auto &refine_tol   = pkg->Param<Real>("refine_tol");
-    const auto &derefine_tol = pkg->Param<Real>("derefine_tol");
+    const auto& refine_tol = pkg->Param<Real>("refine_tol");
+    const auto& derefine_tol = pkg->Param<Real>("derefine_tol");
 
     if (minmax.max_val - minmax.min_val > refine_tol) return AmrTag::refine;
     if (minmax.max_val - minmax.min_val < derefine_tol) return AmrTag::derefine;
     return AmrTag::same;
 }
 
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -482,20 +535,26 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
     if (extra_checks >= 2) {
         // Not sure when I'd do the check to hide latency, it's a step-end sort of deal
         // Just as well it's behind extra_checks 2
-        // This may happen while ch0-1 are in flight from floors, but ch2-4 are now reusable
-        Reductions::DomainReduction<Reductions::Var::neg_rho, UserHistoryOperation::sum, int>(md, 2);
-        Reductions::DomainReduction<Reductions::Var::neg_u, UserHistoryOperation::sum, int>(md, 3);
-        Reductions::DomainReduction<Reductions::Var::neg_rhout, UserHistoryOperation::sum, int>(md, 4);
+        // This may happen while ch0-1 are in flight from floors, but ch2-4 are now
+        // reusable
+        Reductions::DomainReduction<Reductions::Var::neg_rho, UserHistoryOperation::sum,
+            int>(md, 2);
+        Reductions::DomainReduction<Reductions::Var::neg_u, UserHistoryOperation::sum,
+            int>(md, 3);
+        Reductions::DomainReduction<Reductions::Var::neg_rhout, UserHistoryOperation::sum,
+            int>(md, 4);
         int nless_rho = Reductions::Check<int>(md, 2);
         int nless_u = Reductions::Check<int>(md, 3);
         int nless_rhout = Reductions::Check<int>(md, 4);
 
         if (MPIRank0()) {
             if (nless_rhout > 0) {
-                std::cout << "Number of negative conserved rho: " << nless_rhout << std::endl;
+                std::cout << "Number of negative conserved rho: " << nless_rhout
+                          << std::endl;
             }
             if (nless_rho > 0 || nless_u > 0) {
-                std::cout << "Number of negative primitive rho, u: " << nless_rho << "," << nless_u << std::endl;
+                std::cout << "Number of negative primitive rho, u: " << nless_rho << ","
+                          << nless_u << std::endl;
             }
         }
     }
@@ -503,7 +562,7 @@ TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
     return TaskStatus::complete;
 }
 
-void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void CancelBoundaryU3(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     // We're sometimes called on coarse buffers with or without AMR.
     // Use of transmitting polar conditions when coarse buffers matter (e.g., refinement
@@ -516,69 +575,78 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
     const auto bdir = KBoundaries::BoundaryDirection(bface);
-    if (bdir != 2) throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
+    if (bdir != 2)
+        throw std::runtime_error(
+            "T3 Cancellation is only implemented for polar X2 boundaries!");
 
     // Pull variables (TODO take packs & maps, see boundaries.cpp)
     PackIndexMap prims_map, cons_map;
-    auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    auto U = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    auto P = rc->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+    auto U = rc->PackVariables(
+        std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
-    const auto &G = pmb->coords;
+    const auto& G = pmb->coords;
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
     const bool sync_prims = pmb->packages.Get("Driver")->Param<bool>("sync_prims");
 
-    const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+    const Floors::Prescription floors =
+        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
     // Subtract the average B3 as "reconnection" through the pole
     IndexRange3 b = KDomain::GetRange(rc, domain, coarse);
     IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, coarse);
     const int jf = (binner) ? bi.js : bi.je; // j index of last zone next to pole
-    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_U3_" + bname, pmb->exec_space,
-        0, 1, b.is, b.ie,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i) {
+    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_U3_" + bname,
+        pmb->exec_space, 0, 1, b.is, b.ie,
+        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i)
+        {
             if (!sync_prims) {
                 // Recover primitive GRMHD variables to sync them
                 parthenon::par_for_inner(member, bi.ks, bi.ke,
-                    [&](const int& k) {
-                    Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              25, 1e-12, false);
-                    }
-                );
+                    [&](const int& k)
+                    {
+                        Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf,
+                            i, P, m_p, Loci::center, 25, 1e-12, false);
+                    });
             }
             member.team_barrier();
 
             // Sum the first rank of U3
             Real U3_sum = 0.;
             Kokkos::Sum<Real> sum_reducer(U3_sum);
-            parthenon::par_reduce_inner(inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke,
-                [&](const int& k, Real& local_result) {
-                    local_result += m::isnan(P(m_p.U3, k, jf, i)) ? 0. : P(m_p.U3, k, jf, i);
-                }
-            , sum_reducer);
+            parthenon::par_reduce_inner(
+                inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke,
+                [&](const int& k, Real& local_result)
+                {
+                    local_result +=
+                        m::isnan(P(m_p.U3, k, jf, i)) ? 0. : P(m_p.U3, k, jf, i);
+                },
+                sum_reducer);
             member.team_barrier();
 
             // Subtract the average, floor, restore conserved vars, update ctop
             const Real U3_avg = U3_sum / (bi.ke - bi.ks + 1);
             parthenon::par_for_inner(member, b.ks, b.ke,
-                [&](const int& k) {
+                [&](const int& k)
+                {
                     P(m_p.U3, k, jf, i) -= U3_avg;
 
                     // Apply floors
-                    Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
+                    Floors::apply_geo_floors(
+                        G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
 
                     // Always PtoU, we modified P.  Accommodate EMHD
                     Flux::p_to_u_mhd(G, P, m_p, emhd_params, gam, k, jf, i, U, m_u);
-                }
-            );
-        }
-    );
+                });
+        });
 }
 
-void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void CancelBoundaryT3(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     // We're sometimes called on coarse buffers with or without AMR.
     // Use of transmitting polar conditions when coarse buffers matter (e.g., refinement
@@ -591,21 +659,26 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     const bool binner = KBoundaries::BoundaryIsInner(bface);
     const auto bname = KBoundaries::BoundaryName(bface);
     const auto bdir = KBoundaries::BoundaryDirection(bface);
-    if (bdir != 2) throw std::runtime_error("T3 Cancellation is only implemented for polar X2 boundaries!");
+    if (bdir != 2)
+        throw std::runtime_error(
+            "T3 Cancellation is only implemented for polar X2 boundaries!");
 
     // Pull variables (TODO take packs & maps, see boundaries.cpp)
     PackIndexMap prims_map, cons_map;
-    auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    auto U = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    auto P = rc->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+    auto U = rc->PackVariables(
+        std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
-    const auto &G = pmb->coords;
+    const auto& G = pmb->coords;
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
     const bool sync_prims = pmb->packages.Get("Driver")->Param<bool>("sync_prims");
 
-    const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
+    const Floors::Prescription floors =
+        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
     // Don't be fooled, this function does *not* support/preserve EMHD values
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
@@ -613,55 +686,58 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
     IndexRange3 b = KDomain::GetRange(rc, domain, coarse);
     IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior, coarse);
     const int jf = (binner) ? bi.js : bi.je; // j index of last zone next to pole
-    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_T3_" + bname, pmb->exec_space,
-        0, 1, b.is, b.ie,
-        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i) {
+    parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "reduce_T3_" + bname,
+        pmb->exec_space, 0, 1, b.is, b.ie,
+        KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& i)
+        {
             if (sync_prims) {
                 parthenon::par_for_inner(member, bi.ks, bi.ke,
-                    [&](const int& k) {
+                    [&](const int& k)
+                    {
                         p_to_u(G, P, m_p, gam, k, jf, i, U, m_u, Loci::center);
-                    }
-                );
+                    });
             }
             member.team_barrier();
 
             // Sum the first rank of the angular momentum T3
             Real T3_sum = 0.;
             Kokkos::Sum<Real> sum_reducer(T3_sum);
-            parthenon::par_reduce_inner(inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke,
-                [&](const int& k, Real& local_result) {
-                    local_result += m::isnan(U(m_u.U3, k, jf, i)) ? 0. : U(m_u.U3, k, jf, i);
-                }
-            , sum_reducer);
+            parthenon::par_reduce_inner(
+                inner_loop_pattern_ttr_tag, member, bi.ks, bi.ke,
+                [&](const int& k, Real& local_result)
+                {
+                    local_result +=
+                        m::isnan(U(m_u.U3, k, jf, i)) ? 0. : U(m_u.U3, k, jf, i);
+                },
+                sum_reducer);
             member.team_barrier();
 
             // Calculate the average and subtract it
             const Real T3_avg = T3_sum / (bi.ke - bi.ks + 1);
             parthenon::par_for_inner(member, b.ks, b.ke,
-                [&](const int& k) {
+                [&](const int& k)
+                {
                     U(m_u.U3, k, jf, i) -= T3_avg;
                     // Recover primitive GRMHD variables from our modified U
-                    Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              25, 1e-12, false);
+                    Inverter::u_to_p<Inverter::Type::kastaun>(
+                        G, U, m_u, gam, k, jf, i, P, m_p, Loci::center, 25, 1e-12, false);
                     // Floor them
-                    int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
+                    int fflag = Floors::apply_geo_floors(
+                        G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Recalculate U on anything we floored
-                    if (fflag)
-                        p_to_u(G, P, m_p, gam, k, jf, i, U, m_u, Loci::center);
-                }
-            );
-        }
-    );
+                    if (fflag) p_to_u(G, P, m_p, gam, k, jf, i, U, m_u, Loci::center);
+                });
+        });
 }
 
-void UpdateAveragedCtop(MeshData<Real> *md)
+void UpdateAveragedCtop(MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     if (pmesh->packages.AllPackages().count("B_CT"))
         B_CT::MeshUtoP(md, IndexDomain::interior);
     auto& params = pmesh->packages.Get<KHARMAPackage>("Boundaries")->AllParams();
-    for (auto &pmb : pmesh->block_list) {
-        auto &rc = pmb->meshblock_data.Get(md->StageName());
+    for (auto& pmb : pmesh->block_list) {
+        auto& rc = pmb->meshblock_data.Get(md->StageName());
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
             BoundaryFace bface = (BoundaryFace)i;
             auto bname = KBoundaries::BoundaryName(bface);
@@ -671,27 +747,32 @@ void UpdateAveragedCtop(MeshData<Real> *md)
 
             if (bdir > pmesh->ndim) continue;
 
-            bool b3_is_reconnected = (pmesh->packages.AllPackages().count("B_CT")) ?
-                                      params.Get<bool>("reconnect_B3_" + bname) :
-                                      false;
+            bool b3_is_reconnected = (pmesh->packages.AllPackages().count("B_CT"))
+                                         ? params.Get<bool>("reconnect_B3_" + bname)
+                                         : false;
 
             // If we've modified values on the pole...
             if (params.Get<bool>("cancel_T3_" + bname) ||
-                params.Get<bool>("cancel_U3_" + bname) ||
-                b3_is_reconnected ||
+                params.Get<bool>("cancel_U3_" + bname) || b3_is_reconnected ||
                 params.Get<bool>("excise_flux_" + bname)) {
                 // ...and if this face of the block corresponds to a global boundary...
                 if (KBoundaries::IsPhysicalBoundary(pmb, bface)) {
                     PackIndexMap prims_map, cons_map;
-                    auto P = rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+                    auto P = rc->PackVariables(
+                        {Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
                     const VarMap m_p(prims_map, false);
-                    const auto& cmax  = rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
-                    const auto& cmin  = rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
+                    const auto& cmax =
+                        rc->PackVariables(std::vector<std::string>{"Flux.cmax"});
+                    const auto& cmin =
+                        rc->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
                     const auto& G = pmb->coords;
                     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
-                    const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
-                    const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
+                    const Floors::Prescription floors =
+                        pmb->packages.Get("Floors")->Param<Floors::Prescription>(
+                            "prescription");
+                    const EMHD::EMHD_parameters& emhd_params =
+                        EMHD::GetEMHDParameters(pmb->packages);
 
                     // If we calculated the flux assuming half-size cells,
                     // we modify ctop rather than special-case in EstimateTimestep
@@ -700,25 +781,27 @@ void UpdateAveragedCtop(MeshData<Real> *md)
                     // Recompute ctop in zones affected by averaging
                     IndexRange3 b = KDomain::GetRange(rc, bdomain);
                     IndexRange3 bi = KDomain::GetRange(rc, IndexDomain::interior);
-                    // TODO this part wouldn't be hard to generalize if polar boundary moves
+                    // TODO this part wouldn't be hard to generalize if polar boundary
+                    // moves
                     const int jf = (binner) ? bi.js : bi.je;
                     pmb->par_for("update_ctop_in_averaged", b.ks, b.ke, b.is, b.ie,
-                        KOKKOS_LAMBDA(const int& k, const int& i) {
+                        KOKKOS_LAMBDA(const int& k, const int& i)
+                        {
                             FourVectors Dtmp;
                             GRMHD::calc_4vecs(G, P, m_p, k, jf, i, Loci::center, Dtmp);
-                            // Remember our 'cmin' array stores *positive* values!
+                            // Remember our 'cmin' array stores *positive*
+                            // values!
                             Real cmin_minus;
-                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, X1DIR,
-                                        cmax(V1, k, jf, i), cmin_minus);
+                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf,
+                                i, Loci::center, X1DIR, cmax(V1, k, jf, i), cmin_minus);
                             cmin(V1, k, jf, i) = -cmin_minus;
-                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, X2DIR,
-                                        cmax(V2, k, jf, i), cmin_minus);
+                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf,
+                                i, Loci::center, X2DIR, cmax(V2, k, jf, i), cmin_minus);
                             cmin(V2, k, jf, i) = -cmin_minus;
-                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf, i, Loci::center, X3DIR,
-                                        cmax(V3, k, jf, i), cmin_minus);
+                            Flux::vchar_global(G, P, m_p, Dtmp, gam, emhd_params, k, jf,
+                                i, Loci::center, X3DIR, cmax(V3, k, jf, i), cmin_minus);
                             cmin(V3, k, jf, i) = -cmin_minus;
-                        }
-                    );
+                        });
                 }
             }
         }

--- a/kharma/grmhd/grmhd.hpp
+++ b/kharma/grmhd/grmhd.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: grmhd.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,9 +43,12 @@
  * is implemented in this namespace, in the files grmhd.cpp, source.cpp, and fixup.cpp.
  * Many device-side functions related to GRMHD are implemented in grmhd_functions.hpp
  */
-namespace GRMHD {
-// For declaring variables, as well as the full intermediates we need (right & left fluxes etc)
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+namespace GRMHD
+{
+// For declaring variables, as well as the full intermediates we need (right & left fluxes
+// etc)
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Returns the minimum CFL timestep among all zones in the block,
@@ -54,45 +57,45 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
  * This is just for a particular MeshBlock/package, so don't rely on it
  * Parthenon will take the minimum and put it in pmy_mesh->dt
  */
-Real EstimateTimestep(MeshData<Real> *md);
+Real EstimateTimestep(MeshData<Real>* md);
 
 // Internal version for the light phase speed crossing time of smallest zone
-Real EstimateRadiativeTimestep(MeshData<Real> *md);
+Real EstimateRadiativeTimestep(MeshData<Real>* md);
 
 /**
  * Return a tag per-block indicating whether to refine it
- * 
+ *
  * Criteria are very WIP
  */
-AmrTag CheckRefinement(MeshBlockData<Real> *rc);
+AmrTag CheckRefinement(MeshBlockData<Real>* rc);
 
 /**
  * Fill fields which are calculated only for output to file
  * Currently just the current jcon
  */
-void FillOutput(MeshBlock *pmb, ParameterInput *pin);
+void FillOutput(MeshBlock* pmb, ParameterInput* pin);
 
 /**
  * Diagnostics performed after each step.
  * Currently just looks for negative density/internal energy
  */
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *rc);
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* rc);
 
 /**
  * Subtract the average phi-component of velocity (U3) next to the pole,
  * simulating polar velocity advecting together
  */
-void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+void CancelBoundaryU3(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse);
 
 /**
  * Same but for the conserved angular momentum T3
  */
-void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
+void CancelBoundaryT3(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse);
 
 /**
  * Update the signal speeds in zones affected by the above operations.
  * This is important to stay under the Courant limit at times
  */
-void UpdateAveragedCtop(MeshData<Real> *md);
+void UpdateAveragedCtop(MeshData<Real>* md);
 
 }

--- a/kharma/grmhd/grmhd_functions.hpp
+++ b/kharma/grmhd/grmhd_functions.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: grmhd_functions.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,8 +36,8 @@
 #include "decs.hpp"
 
 #include "gr_coordinates.hpp"
-#include "types.hpp"
 #include "kharma_utils.hpp"
+#include "types.hpp"
 
 /**
  * This namespace is solely for calc_tensor.
@@ -46,16 +46,15 @@
 namespace GRHD
 {
 /**
- * Get a row of the hydrodynamic stress-energy tensor with first index up, second index down.
+ * Get a row of the hydrodynamic stress-energy tensor with first index up, second index
+ * down.
  */
 KOKKOS_INLINE_FUNCTION void calc_tensor(const Real& rho, const Real& u, const Real& pgas,
-                                            const FourVectors& D, const int dir,
-                                            Real hd[GR_DIM])
+    const FourVectors& D, const int dir, Real hd[GR_DIM])
 {
     const Real eta = pgas + rho + u;
     DLOOP1 {
-        hd[mu] = eta * D.ucon[dir] * D.ucov[mu] +
-                 pgas * (dir == mu);
+        hd[mu] = eta * D.ucon[dir] * D.ucov[mu] + pgas * (dir == mu);
     }
 }
 
@@ -67,9 +66,9 @@ KOKKOS_INLINE_FUNCTION void calc_tensor(const Real& rho, const Real& u, const Re
  * lorentz factor, stress-energy tensor, 4-vectors ucon/bcon
  *
  * These functions mostly have several overloads, related to local vs global variables.
- * Many also have a form for split variables rho, uvec, etc, and one for a full array of primitive variables P.
- * Where all 4 combinations are used, we get 4 overloads.
- * 
+ * Many also have a form for split variables rho, uvec, etc, and one for a full array of
+ * primitive variables P. Where all 4 combinations are used, we get 4 overloads.
+ *
  * Local full-primitives versions are templated, to accept Slices/Scratch/etc equivalently
  */
 namespace GRMHD
@@ -79,55 +78,56 @@ namespace GRMHD
  * Find gamma-factor of the fluid w.r.t. normal observer
  */
 KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G, const GridVector uvec,
-                                         const int& k, const int& j, const int& i,
-                                         const Loci loc)
+    const int& k, const int& j, const int& i, const Loci loc)
 {
 
-    const Real qsq = G.gcov(loc, j, i, 1, 1) * uvec(V1, k, j, i) * uvec(V1, k, j, i) +
-                    G.gcov(loc, j, i, 2, 2) * uvec(V2, k, j, i) * uvec(V2, k, j, i) +
-                    G.gcov(loc, j, i, 3, 3) * uvec(V3, k, j, i) * uvec(V3, k, j, i) +
-                    2. * (G.gcov(loc, j, i, 1, 2) * uvec(V1, k, j, i) * uvec(V2, k, j, i) +
-                        G.gcov(loc, j, i, 1, 3) * uvec(V1, k, j, i) * uvec(V3, k, j, i) +
-                        G.gcov(loc, j, i, 2, 3) * uvec(V2, k, j, i) * uvec(V3, k, j, i));
+    const Real qsq =
+        G.gcov(loc, j, i, 1, 1) * uvec(V1, k, j, i) * uvec(V1, k, j, i) +
+        G.gcov(loc, j, i, 2, 2) * uvec(V2, k, j, i) * uvec(V2, k, j, i) +
+        G.gcov(loc, j, i, 3, 3) * uvec(V3, k, j, i) * uvec(V3, k, j, i) +
+        2. * (G.gcov(loc, j, i, 1, 2) * uvec(V1, k, j, i) * uvec(V2, k, j, i) +
+                 G.gcov(loc, j, i, 1, 3) * uvec(V1, k, j, i) * uvec(V3, k, j, i) +
+                 G.gcov(loc, j, i, 2, 3) * uvec(V2, k, j, i) * uvec(V3, k, j, i));
 
     return m::sqrt(1. + qsq);
 }
 KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G, const Real uv[NVEC],
-                                         const int& k, const int& j, const int& i,
-                                         const Loci loc)
+    const int& k, const int& j, const int& i, const Loci loc)
 {
     const Real qsq = G.gcov(loc, j, i, 1, 1) * uv[V1] * uv[V1] +
-                    G.gcov(loc, j, i, 2, 2) * uv[V2] * uv[V2] +
-                    G.gcov(loc, j, i, 3, 3) * uv[V3] * uv[V3] +
-                    2. * (G.gcov(loc, j, i, 1, 2) * uv[V1] * uv[V2] +
-                        G.gcov(loc, j, i, 1, 3) * uv[V1] * uv[V3] +
-                        G.gcov(loc, j, i, 2, 3) * uv[V2] * uv[V3]);
+                     G.gcov(loc, j, i, 2, 2) * uv[V2] * uv[V2] +
+                     G.gcov(loc, j, i, 3, 3) * uv[V3] * uv[V3] +
+                     2. * (G.gcov(loc, j, i, 1, 2) * uv[V1] * uv[V2] +
+                              G.gcov(loc, j, i, 1, 3) * uv[V1] * uv[V3] +
+                              G.gcov(loc, j, i, 2, 3) * uv[V2] * uv[V3]);
 
     return m::sqrt(1. + qsq);
 }
 // Versions for full primitives array
-KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m,
-                                         const int& k, const int& j, const int& i, const Loci& loc=Loci::center)
+KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m, const int& k, const int& j,
+    const int& i, const Loci& loc = Loci::center)
 {
-    const Real qsq = G.gcov(loc, j, i, 1, 1) * P(m.U1, k, j, i) * P(m.U1, k, j, i) +
-                    G.gcov(loc, j, i, 2, 2) * P(m.U2, k, j, i) * P(m.U2, k, j, i) +
-                    G.gcov(loc, j, i, 3, 3) * P(m.U3, k, j, i) * P(m.U3, k, j, i) +
-                    2. * (G.gcov(loc, j, i, 1, 2) * P(m.U1, k, j, i) * P(m.U2, k, j, i) +
-                        G.gcov(loc, j, i, 1, 3) * P(m.U1, k, j, i) * P(m.U3, k, j, i) +
-                        G.gcov(loc, j, i, 2, 3) * P(m.U2, k, j, i) * P(m.U3, k, j, i));
+    const Real qsq =
+        G.gcov(loc, j, i, 1, 1) * P(m.U1, k, j, i) * P(m.U1, k, j, i) +
+        G.gcov(loc, j, i, 2, 2) * P(m.U2, k, j, i) * P(m.U2, k, j, i) +
+        G.gcov(loc, j, i, 3, 3) * P(m.U3, k, j, i) * P(m.U3, k, j, i) +
+        2. * (G.gcov(loc, j, i, 1, 2) * P(m.U1, k, j, i) * P(m.U2, k, j, i) +
+                 G.gcov(loc, j, i, 1, 3) * P(m.U1, k, j, i) * P(m.U3, k, j, i) +
+                 G.gcov(loc, j, i, 2, 3) * P(m.U2, k, j, i) * P(m.U3, k, j, i));
 
     return m::sqrt(1. + qsq);
 }
-template <typename Local>
-KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G, const Local& P, const VarMap& m,
-                                         const int& j, const int& i, const Loci& loc=Loci::center)
+template<typename Local>
+KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G, const Local& P,
+    const VarMap& m, const int& j, const int& i, const Loci& loc = Loci::center)
 {
     const Real qsq = G.gcov(loc, j, i, 1, 1) * P(m.U1) * P(m.U1) +
-                    G.gcov(loc, j, i, 2, 2) * P(m.U2) * P(m.U2) +
-                    G.gcov(loc, j, i, 3, 3) * P(m.U3) * P(m.U3) +
-                    2. * (G.gcov(loc, j, i, 1, 2) * P(m.U1) * P(m.U2) +
-                        G.gcov(loc, j, i, 1, 3) * P(m.U1) * P(m.U3) +
-                        G.gcov(loc, j, i, 2, 3) * P(m.U2) * P(m.U3));
+                     G.gcov(loc, j, i, 2, 2) * P(m.U2) * P(m.U2) +
+                     G.gcov(loc, j, i, 3, 3) * P(m.U3) * P(m.U3) +
+                     2. * (G.gcov(loc, j, i, 1, 2) * P(m.U1) * P(m.U2) +
+                              G.gcov(loc, j, i, 1, 3) * P(m.U1) * P(m.U3) +
+                              G.gcov(loc, j, i, 2, 3) * P(m.U2) * P(m.U3));
 
     return m::sqrt(1. + qsq);
 }
@@ -140,163 +140,181 @@ KOKKOS_INLINE_FUNCTION Real lorentz_calc(const GRCoordinates& G, const Local& P,
  * Entirely local!
  */
 KOKKOS_INLINE_FUNCTION void calc_tensor(const Real& rho, const Real& u, const Real& pgas,
-                                            const FourVectors& D, const int dir,
-                                            Real mhd[GR_DIM])
+    const FourVectors& D, const int dir, Real mhd[GR_DIM])
 {
     const Real bsq = dot(D.bcon, D.bcov);
     const Real eta = pgas + rho + u + bsq;
     const Real ptot = pgas + 0.5 * bsq;
 
     DLOOP1 {
-        mhd[mu] = eta * D.ucon[dir] * D.ucov[mu] +
-                  ptot * (dir == mu) -
+        mhd[mu] = eta * D.ucon[dir] * D.ucov[mu] + ptot * (dir == mu) -
                   D.bcon[dir] * D.bcov[mu];
     }
 }
 
 /**
  * Calculate the 4-velocities ucon, ucov, and 4-fields bcon, bcov from primitive versions
- * 
- * First two versions are for local stack variables and split global variables, respectively,
- * as we sometimes want the 4-vectors without having assembled the full primitives list or anything.
- * 
+ *
+ * First two versions are for local stack variables and split global variables,
+ * respectively, as we sometimes want the 4-vectors without having assembled the full
+ * primitives list or anything.
+ *
  * The latter are the usual Local/Global versions for primitives arrays
  */
-KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const Real uvec[NVEC], const Real B_P[NVEC],
-                                      const int& k, const int& j, const int& i, const Loci loc,
-                                      FourVectors& D)
+KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const Real uvec[NVEC],
+    const Real B_P[NVEC], const int& k, const int& j, const int& i, const Loci loc,
+    FourVectors& D)
 {
     const Real gamma = lorentz_calc(G, uvec, k, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     D.ucon[0] = gamma / alpha;
-    VLOOP D.ucon[v+1] = uvec[v] - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        D.ucon[v + 1] = uvec[v] - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 
     G.lower(D.ucon, D.ucov, k, j, i, loc);
 
     // This fn is guaranteed to have B values
     D.bcon[0] = 0;
-    VLOOP D.bcon[0]  += B_P[v] * D.ucov[v+1];
-    VLOOP D.bcon[v+1] = (B_P[v] + D.bcon[0] * D.ucon[v+1]) / D.ucon[0];
+    VLOOP
+        D.bcon[0] += B_P[v] * D.ucov[v + 1];
+    VLOOP
+        D.bcon[v + 1] = (B_P[v] + D.bcon[0] * D.ucon[v + 1]) / D.ucon[0];
 
     G.lower(D.bcon, D.bcov, k, j, i, loc);
 }
-KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const GridVector uvec, const GridVector B_P,
-                                      const int& k, const int& j, const int& i, const Loci loc,
-                                      FourVectors& D)
+KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const GridVector uvec,
+    const GridVector B_P, const int& k, const int& j, const int& i, const Loci loc,
+    FourVectors& D)
 {
     const Real gamma = lorentz_calc(G, uvec, k, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     D.ucon[0] = gamma / alpha;
-    VLOOP D.ucon[v+1] = uvec(v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        D.ucon[v + 1] = uvec(v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 
     G.lower(D.ucon, D.ucov, k, j, i, loc);
 
     // This fn is guaranteed to have B values
     D.bcon[0] = 0;
-    VLOOP D.bcon[0] += B_P(v, k, j, i) * D.ucov[v+1];
-    VLOOP D.bcon[v+1] = (B_P(v, k, j, i) + D.bcon[0] * D.ucon[v+1]) / D.ucon[0];
+    VLOOP
+        D.bcon[0] += B_P(v, k, j, i) * D.ucov[v + 1];
+    VLOOP
+        D.bcon[v + 1] = (B_P(v, k, j, i) + D.bcon[0] * D.ucon[v + 1]) / D.ucon[0];
 
     G.lower(D.bcon, D.bcov, k, j, i, loc);
 }
 // Primitive/VarMap versions of calc_4vecs for kernels that use "packed" primitives
-KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m,
-                                      const int& k, const int& j, const int& i, const Loci loc, FourVectors& D)
+KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m, const int& k, const int& j,
+    const int& i, const Loci loc, FourVectors& D)
 {
     const Real gamma = lorentz_calc(G, P, m, k, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     D.ucon[0] = gamma / alpha;
-    VLOOP D.ucon[v+1] = P(m.U1 + v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        D.ucon[v + 1] =
+            P(m.U1 + v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 
     G.lower(D.ucon, D.ucov, k, j, i, loc);
 
     if (m.B1 >= 0) {
         D.bcon[0] = 0;
-        VLOOP D.bcon[0]  += P(m.B1 + v, k, j, i) * D.ucov[v+1];
-        VLOOP D.bcon[v+1] = (P(m.B1 + v, k, j, i) + D.bcon[0] * D.ucon[v+1]) / D.ucon[0];
+        VLOOP
+            D.bcon[0] += P(m.B1 + v, k, j, i) * D.ucov[v + 1];
+        VLOOP
+            D.bcon[v + 1] =
+                (P(m.B1 + v, k, j, i) + D.bcon[0] * D.ucon[v + 1]) / D.ucon[0];
 
         G.lower(D.bcon, D.bcov, k, j, i, loc);
     } else {
-        DLOOP1 D.bcon[mu] = D.bcov[mu] = 0.;
+        DLOOP1
+            D.bcon[mu] = D.bcov[mu] = 0.;
     }
 }
-template <typename Local>
-KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const Local& P, const VarMap& m,
-                                      const int& j, const int& i, const Loci loc, FourVectors& D)
+template<typename Local>
+KOKKOS_INLINE_FUNCTION void calc_4vecs(const GRCoordinates& G, const Local& P,
+    const VarMap& m, const int& j, const int& i, const Loci loc, FourVectors& D)
 {
     const Real gamma = lorentz_calc(G, P, m, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     D.ucon[0] = gamma / alpha;
-    VLOOP D.ucon[v+1] = P(m.U1 + v) - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        D.ucon[v + 1] = P(m.U1 + v) - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 
     G.lower(D.ucon, D.ucov, 0, j, i, loc);
 
     if (m.B1 >= 0) {
         D.bcon[0] = 0;
-        VLOOP D.bcon[0] += P(m.B1 + v) * D.ucov[v+1];
-        VLOOP D.bcon[v+1] = (P(m.B1 + v) + D.bcon[0] * D.ucon[v+1]) / D.ucon[0];
+        VLOOP
+            D.bcon[0] += P(m.B1 + v) * D.ucov[v + 1];
+        VLOOP
+            D.bcon[v + 1] = (P(m.B1 + v) + D.bcon[0] * D.ucon[v + 1]) / D.ucon[0];
 
         G.lower(D.bcon, D.bcov, 0, j, i, loc);
     } else {
-        DLOOP1 D.bcon[mu] = D.bcov[mu] = 0.;
+        DLOOP1
+            D.bcon[mu] = D.bcov[mu] = 0.;
     }
 }
 /**
- * Just the velocity 4-vector, in the first two styles of calc_4vecs.  For various corners.
+ * Just the velocity 4-vector, in the first two styles of calc_4vecs.  For various
+ * corners.
  */
-KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates &G, const GridVector uvec,
-                                      const int& k, const int& j, const int& i, const Loci loc,
-                                      Real ucon[GR_DIM])
+KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates& G, const GridVector uvec,
+    const int& k, const int& j, const int& i, const Loci loc, Real ucon[GR_DIM])
 {
     const Real gamma = lorentz_calc(G, uvec, k, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     ucon[0] = gamma / alpha;
-    VLOOP ucon[v+1] = uvec(v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        ucon[v + 1] = uvec(v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 }
-KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates &G, const Real uvec[NVEC],
-                                      const int& k, const int& j, const int& i, const Loci loc,
-                                      Real ucon[GR_DIM])
+KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates& G, const Real uvec[NVEC],
+    const int& k, const int& j, const int& i, const Loci loc, Real ucon[GR_DIM])
 {
     const Real gamma = lorentz_calc(G, uvec, k, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     ucon[0] = gamma / alpha;
-    VLOOP ucon[v+1] = uvec[v] - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        ucon[v + 1] = uvec[v] - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 }
 template<typename Local>
-KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates& G, const Local& P, const VarMap& m,
-                                      const int& j, const int& i, const Loci loc,
-                                      Real ucon[GR_DIM])
+KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates& G, const Local& P,
+    const VarMap& m, const int& j, const int& i, const Loci loc, Real ucon[GR_DIM])
 {
     const Real gamma = lorentz_calc(G, P, m, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     ucon[0] = gamma / alpha;
-    VLOOP ucon[v+1] = P(m.U1 + v) - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        ucon[v + 1] = P(m.U1 + v) - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 }
 template<typename Global>
-KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates& G, const Global& P, const VarMap& m,
-                                      const int& k, const int& j, const int& i, const Loci loc,
-                                      Real ucon[GR_DIM])
+KOKKOS_INLINE_FUNCTION void calc_ucon(const GRCoordinates& G, const Global& P,
+    const VarMap& m, const int& k, const int& j, const int& i, const Loci loc,
+    Real ucon[GR_DIM])
 {
     const Real gamma = lorentz_calc(G, P, m, k, j, i, loc);
     const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
 
     ucon[0] = gamma / alpha;
-    VLOOP ucon[v+1] = P(m.U1 + v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v+1);
+    VLOOP
+        ucon[v + 1] = P(m.U1 + v, k, j, i) - gamma * alpha * G.gcon(loc, j, i, 0, v + 1);
 }
 
 /**
  * Global GRMHD-only "p_to_u" call: for areas where nonideal terms are *always* 0!
  */
 template<typename Local>
-KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P, const VarMap& m_p,
-                                   const Real& gam, const int& j, const int& i,
-                                   const Local& U, const VarMap& m_u, const Loci& loc=Loci::center)
+KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P,
+    const VarMap& m_p, const Real& gam, const int& j, const int& i, const Local& U,
+    const VarMap& m_u, const Loci& loc = Loci::center)
 {
     Real gdet = G.gdet(loc, j, i);
     FourVectors Dtmp;
@@ -308,10 +326,10 @@ KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P, const
         // MHD stress-energy tensor w/ first index up, second index down
         Real mhd[GR_DIM];
         GRMHD::calc_tensor(P(m_p.RHO), P(m_p.UU), (gam - 1) * P(m_p.UU), Dtmp, 0, mhd);
-        U(m_u.UU)  = mhd[0] * gdet + U(m_u.RHO);
-        U(m_u.U1) =  mhd[1] * gdet;
-        U(m_u.U2) =  mhd[2] * gdet;
-        U(m_u.U3) =  mhd[3] * gdet;
+        U(m_u.UU) = mhd[0] * gdet + U(m_u.RHO);
+        U(m_u.U1) = mhd[1] * gdet;
+        U(m_u.U2) = mhd[2] * gdet;
+        U(m_u.U3) = mhd[3] * gdet;
     } else {
         // HD stress-energy tensor w/ first index up, second index down
         Real hd[GR_DIM];
@@ -323,9 +341,9 @@ KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Local& P, const
     }
 }
 template<typename Global>
-KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P, const VarMap& m_p,
-                                   const Real& gam, const int& k, const int& j, const int& i,
-                                   const Global& U, const VarMap& m_u, const Loci& loc=Loci::center)
+KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P,
+    const VarMap& m_p, const Real& gam, const int& k, const int& j, const int& i,
+    const Global& U, const VarMap& m_u, const Loci& loc = Loci::center)
 {
     Real gdet = G.gdet(loc, j, i);
     FourVectors Dtmp;
@@ -336,15 +354,17 @@ KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P, cons
     if (m_u.B1 >= 0) {
         // MHD stress-energy tensor w/ first index up, second index down
         Real mhd[GR_DIM];
-        GRMHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), (gam - 1) * P(m_p.UU, k, j, i), Dtmp, 0, mhd);
-        U(m_u.UU, k, j, i)  = mhd[0] * gdet + U(m_u.RHO, k, j, i);
-        U(m_u.U1, k, j, i) =  mhd[1] * gdet;
-        U(m_u.U2, k, j, i) =  mhd[2] * gdet;
-        U(m_u.U3, k, j, i) =  mhd[3] * gdet;
+        GRMHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+            (gam - 1) * P(m_p.UU, k, j, i), Dtmp, 0, mhd);
+        U(m_u.UU, k, j, i) = mhd[0] * gdet + U(m_u.RHO, k, j, i);
+        U(m_u.U1, k, j, i) = mhd[1] * gdet;
+        U(m_u.U2, k, j, i) = mhd[2] * gdet;
+        U(m_u.U3, k, j, i) = mhd[3] * gdet;
     } else {
         // HD stress-energy tensor w/ first index up, second index down
         Real hd[GR_DIM];
-        GRHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i), (gam - 1) * P(m_p.UU, k, j, i), Dtmp, 0, hd);
+        GRHD::calc_tensor(P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+            (gam - 1) * P(m_p.UU, k, j, i), Dtmp, 0, hd);
         U(m_u.UU, k, j, i) = hd[0] * gdet + U(m_u.RHO, k, j, i);
         U(m_u.U1, k, j, i) = hd[1] * gdet;
         U(m_u.U2, k, j, i) = hd[2] * gdet;
@@ -353,11 +373,13 @@ KOKKOS_INLINE_FUNCTION void p_to_u(const GRCoordinates& G, const Global& P, cons
 }
 
 /**
- * Special all-local "p_to_u" call for just MHD variables, used in fluid frame floors & wind source.
+ * Special all-local "p_to_u" call for just MHD variables, used in fluid frame floors &
+ * wind source.
  */
-KOKKOS_INLINE_FUNCTION void p_to_u_mhd(const GRCoordinates& G, const Real& rho, const Real& u, const Real uvec[NVEC],
-                                   const Real B_P[NVEC], const Real& gam, const int& k, const int& j, const int& i,
-                                   Real& rho_ut, Real T[GR_DIM], const Loci loc=Loci::center)
+KOKKOS_INLINE_FUNCTION void p_to_u_mhd(const GRCoordinates& G, const Real& rho,
+    const Real& u, const Real uvec[NVEC], const Real B_P[NVEC], const Real& gam,
+    const int& k, const int& j, const int& i, Real& rho_ut, Real T[GR_DIM],
+    const Loci loc = Loci::center)
 {
     Real gdet = G.gdet(loc, j, i);
 
@@ -371,8 +393,9 @@ KOKKOS_INLINE_FUNCTION void p_to_u_mhd(const GRCoordinates& G, const Real& rho, 
     Real mhd[GR_DIM];
     calc_tensor(rho, u, (gam - 1) * u, Dtmp, 0, mhd);
 
-    T[0]  = mhd[0] * gdet + rho_ut;
-    VLOOP T[1 + v] = mhd[1 + v] * gdet;
+    T[0] = mhd[0] * gdet + rho_ut;
+    VLOOP
+        T[1 + v] = mhd[1 + v] * gdet;
 }
 
 }

--- a/kharma/grmhd/pack.hpp
+++ b/kharma/grmhd/pack.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: pack.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,56 +37,85 @@
 
 using namespace parthenon;
 
-namespace GRMHD {
+namespace GRMHD
+{
 
 /**
- * These functions exist to "pack up" just the variables involved in hydrodynamics (rho, u, uvec),
- * or magnetohydrodynamics (those plus B).
- * 
- * They are just thin convenience wrappers aroung Parthenon's functions to do the same, and you'll
- * see a bunch of rc->PackVariables and md->PackVariables calls by themselves.
- * Usually, bare calls are for *all* variables (potentially including e-, passives, entropy, etc),
- * whereas these calls are for functions within this package which deal with GRMHD variables only.
+ * These functions exist to "pack up" just the variables involved in hydrodynamics (rho,
+ * u, uvec), or magnetohydrodynamics (those plus B).
+ *
+ * They are just thin convenience wrappers aroung Parthenon's functions to do the same,
+ * and you'll see a bunch of rc->PackVariables and md->PackVariables calls by themselves.
+ * Usually, bare calls are for *all* variables (potentially including e-, passives,
+ * entropy, etc), whereas these calls are for functions within this package which deal
+ * with GRMHD variables only.
  */
-inline VariablePack<Real> PackMHDPrims(MeshBlockData<Real> *rc, PackIndexMap& prims_map, bool coarse=false)
+inline VariablePack<Real> PackMHDPrims(
+    MeshBlockData<Real>* rc, PackIndexMap& prims_map, bool coarse = false)
 {
-    return rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::GetUserFlag("MHD"), Metadata::Cell}, prims_map, coarse);
+    return rc->PackVariables({Metadata::GetUserFlag("Primitive"),
+                                 Metadata::GetUserFlag("MHD"), Metadata::Cell},
+        prims_map, coarse);
 }
-inline MeshBlockPack<VariablePack<Real>> PackMHDPrims(MeshData<Real> *md, PackIndexMap& prims_map, bool coarse=false)
+inline MeshBlockPack<VariablePack<Real>> PackMHDPrims(
+    MeshData<Real>* md, PackIndexMap& prims_map, bool coarse = false)
 {
-    return md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::GetUserFlag("MHD"), Metadata::Cell}, prims_map, coarse);
-}
-
-inline VariablePack<Real> PackMHDCons(MeshBlockData<Real> *rc, PackIndexMap& cons_map, bool coarse=false)
-{
-    return rc->PackVariables({Metadata::Conserved, Metadata::GetUserFlag("MHD"), Metadata::Cell}, cons_map, coarse);
-}
-inline MeshBlockPack<VariablePack<Real>> PackMHDCons(MeshData<Real> *md, PackIndexMap& cons_map, bool coarse=false)
-{
-    return md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::GetUserFlag("MHD"), Metadata::Cell}, cons_map, coarse);
+    return md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"),
+                                 Metadata::GetUserFlag("MHD"), Metadata::Cell},
+        prims_map, coarse);
 }
 
-inline VariablePack<Real> PackHDPrims(MeshBlockData<Real> *rc, PackIndexMap& prims_map, bool coarse=false)
+inline VariablePack<Real> PackMHDCons(
+    MeshBlockData<Real>* rc, PackIndexMap& cons_map, bool coarse = false)
 {
-    return rc->PackVariables({Metadata::GetUserFlag("Primitive"), Metadata::GetUserFlag("HD"), Metadata::Cell}, prims_map, coarse);
+    return rc->PackVariables(
+        {Metadata::Conserved, Metadata::GetUserFlag("MHD"), Metadata::Cell}, cons_map,
+        coarse);
 }
-inline MeshBlockPack<VariablePack<Real>> PackHDPrims(MeshData<Real> *md, PackIndexMap& prims_map, bool coarse=false)
+inline MeshBlockPack<VariablePack<Real>> PackMHDCons(
+    MeshData<Real>* md, PackIndexMap& cons_map, bool coarse = false)
 {
-    return md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::GetUserFlag("HD"), Metadata::Cell}, prims_map, coarse);
+    return md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved,
+                                 Metadata::GetUserFlag("MHD"), Metadata::Cell},
+        cons_map, coarse);
 }
-// Version without 
+
+inline VariablePack<Real> PackHDPrims(
+    MeshBlockData<Real>* rc, PackIndexMap& prims_map, bool coarse = false)
+{
+    return rc->PackVariables(
+        {Metadata::GetUserFlag("Primitive"), Metadata::GetUserFlag("HD"), Metadata::Cell},
+        prims_map, coarse);
+}
+inline MeshBlockPack<VariablePack<Real>> PackHDPrims(
+    MeshData<Real>* md, PackIndexMap& prims_map, bool coarse = false)
+{
+    return md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"),
+                                 Metadata::GetUserFlag("HD"), Metadata::Cell},
+        prims_map, coarse);
+}
+// Version without
 template<typename T>
-inline VariablePack<Real> PackHDPrims(T data) { PackIndexMap nop; return PackHDPrims(data, nop); }
+inline VariablePack<Real> PackHDPrims(T data)
+{
+    PackIndexMap nop;
+    return PackHDPrims(data, nop);
+}
 
-inline VariablePack<Real> PackHDCons(MeshBlockData<Real> *rc, PackIndexMap& cons_map, bool coarse=false)
+inline VariablePack<Real> PackHDCons(
+    MeshBlockData<Real>* rc, PackIndexMap& cons_map, bool coarse = false)
 {
     auto pmb = rc->GetBlockPointer();
-    return rc->PackVariables({Metadata::Conserved, Metadata::GetUserFlag("HD"), Metadata::Cell}, cons_map, coarse);
+    return rc->PackVariables(
+        {Metadata::Conserved, Metadata::GetUserFlag("HD"), Metadata::Cell}, cons_map,
+        coarse);
 }
-inline MeshBlockPack<VariablePack<Real>> PackHDCons(MeshData<Real> *md, PackIndexMap& cons_map, bool coarse=false)
+inline MeshBlockPack<VariablePack<Real>> PackHDCons(
+    MeshData<Real>* md, PackIndexMap& cons_map, bool coarse = false)
 {
-    return md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::GetUserFlag("HD"), Metadata::Cell}, cons_map, coarse);
+    return md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved,
+                                 Metadata::GetUserFlag("HD"), Metadata::Cell},
+        cons_map, coarse);
 }
-
 
 } // namespace GRMHD

--- a/kharma/implicit/fix_solve.cpp
+++ b/kharma/implicit/fix_solve.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: fix_solve.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,8 +40,9 @@
 
 #define NFVAR_MAX 10
 
-// TODO(BSP) should merge this with FixUtoP by generalizing that
-TaskStatus Implicit::FixSolve(MeshBlockData<Real> *mbd) {
+// TODO(CEP) should merge this with FixUtoP by generalizing that
+TaskStatus Implicit::FixSolve(MeshBlockData<Real>* mbd)
+{
 
     Flag("FixSolve");
     // Get MeshBlock pointer and obtain flag for primitives
@@ -49,9 +50,10 @@ TaskStatus Implicit::FixSolve(MeshBlockData<Real> *mbd) {
 
     // Get number of implicit variables
     PackIndexMap implicit_prims_map;
-    auto implicit_vars = Implicit::GetOrderedNames(mbd, Metadata::GetUserFlag("Primitive"), true);
-    auto& P            = mbd->PackVariables(implicit_vars, implicit_prims_map);
-    const int nfvar    = P.GetDim(4);
+    auto implicit_vars =
+        Implicit::GetOrderedNames(mbd, Metadata::GetUserFlag("Primitive"), true);
+    auto& P = mbd->PackVariables(implicit_vars, implicit_prims_map);
+    const int nfvar = P.GetDim(4);
 
     // Since we're after sync, we run over the entire domain
     const IndexRange3 b = KDomain::GetRange(mbd, IndexDomain::entire);
@@ -59,15 +61,16 @@ TaskStatus Implicit::FixSolve(MeshBlockData<Real> *mbd) {
 
     GridScalar solve_fail = mbd->Get("solve_fail").data;
 
-    const Real gam    = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
+    const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
     const int flag_verbose = pmb->packages.Get("Globals")->Param<int>("flag_verbose");
 
     pmb->par_for("fix_solver_failures", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int& k, const int& j, const int& i) {
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             // Fix only bad zones
             // Remember "failed" here has a different implementation
             if (failed(solve_fail(k, j, i))) {
-                //printf("Fixing zone %d %d %d!\n", i, j, k);
+                // printf("Fixing zone %d %d %d!\n", i, j, k);
                 double wsum = 0., wsum_x = 0.;
                 double sum[NFVAR_MAX] = {0.}, sum_x[NFVAR_MAX] = {0.};
                 // For all neighboring cells...
@@ -79,11 +82,12 @@ TaskStatus Implicit::FixSolve(MeshBlockData<Real> *mbd) {
                             if (KDomain::inside(kk, jj, ii, b)) {
                                 // Weight by distance
                                 // TODO abs(l) == l*l always?
-                                double w = 1./(m::abs(l) + m::abs(m) + m::abs(n) + 1);
+                                double w = 1. / (m::abs(l) + m::abs(m) + m::abs(n) + 1);
 
                                 // Count only the good cells, if we can
                                 if (!failed(solve_fail(kk, jj, ii))) {
-                                    // Weight by distance.  Note interpolated "fixed" cells stay flagged
+                                    // Weight by distance.  Note interpolated "fixed"
+                                    // cells stay flagged
                                     wsum += w;
                                     FLOOP sum[ip] += w * P(ip, kk, jj, ii);
                                 }
@@ -95,39 +99,41 @@ TaskStatus Implicit::FixSolve(MeshBlockData<Real> *mbd) {
                     }
                 }
 
-                if(wsum < 1.e-10) {
-                    // TODO probably should crash here.
+                if (wsum < 1.e-10) {
+                // TODO probably should crash here.
 #ifndef KOKKOS_ENABLE_SYCL
-                    if (flag_verbose >= 3) // && KDomain::inside(k, j, i, kb_b, jb_b, ib_b)) // If an interior zone...
+                    if (flag_verbose >=
+                        3) // && KDomain::inside(k, j, i, kb_b, jb_b, ib_b))
+                           // // If an interior zone...
                         printf("No neighbors were available at %d %d %d!\n", i, j, k);
 #endif
-                    FLOOP P(ip, k, j, i) = sum_x[ip]/wsum_x;
+                    FLOOP P(ip, k, j, i) = sum_x[ip] / wsum_x;
                 } else {
-                    FLOOP P(ip, k, j, i) = sum[ip]/wsum;
+                    FLOOP P(ip, k, j, i) = sum[ip] / wsum;
                 }
             }
-        }
-    );
+        });
 
-    // Since floors were applied earlier, we assume the zones obtained by averaging the neighbors also respect the floors.
-    // Compute new conserved variables
+    // Since floors were applied earlier, we assume the zones obtained by averaging the
+    // neighbors also respect the floors. Compute new conserved variables
     // TODO encapsulate version from FixUtoP & try calling whole thing here?
     PackIndexMap prims_map, cons_map;
-    auto& P_all = mbd->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
-    auto& U_all = mbd->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
+    auto& P_all = mbd->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive")}, prims_map);
+    auto& U_all =
+        mbd->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
     // Need emhd_params object
     const EMHD::EMHD_parameters emhd_params = EMHD::GetEMHDParameters(pmb->packages);
 
     pmb->par_for("fix_solver_failures_PtoU", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int& k, const int& j, const int& i) {
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             if (failed(solve_fail(k, j, i)))
                 Flux::p_to_u(G, P_all, m_p, emhd_params, gam, k, j, i, U_all, m_u);
-        }
-    );
+        });
 
     EndFlag();
     return TaskStatus::complete;
-
 }

--- a/kharma/implicit/implicit.cpp
+++ b/kharma/implicit/implicit.cpp
@@ -45,35 +45,41 @@
 
 // The package should never be loaded if there are not implicitly-evolved variables
 // Therefore we yell at load time rather than waiting for the first solve
-std::shared_ptr<KHARMAPackage> Implicit::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
-{ throw std::runtime_error("KHARMA was compiled without implicit stepping support!"); }
+std::shared_ptr<KHARMAPackage> Implicit::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
+{
+    throw std::runtime_error("KHARMA was compiled without implicit stepping support!");
+}
 // We still need a stub for Step() in order to compile, but it will never be called
-TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init, MeshData<Real> *md_flux_src,
-                MeshData<Real> *md_linesearch, MeshData<Real> *md_solver, const Real& dt) {}
+TaskStatus Implicit::Step(MeshData<Real>* md_full_step_init,
+    MeshData<Real>* md_sub_step_init, MeshData<Real>* md_flux_src,
+    MeshData<Real>* md_linesearch, MeshData<Real>* md_solver, const Real& dt)
+{}
 
 #else
 
 // Implicit nonlinear solve requires several linear solves per-zone
 // Use Kokkos-kernels QR decomposition & triangular solve, they're fast.
+#include <KokkosBatched_ApplyPivot_Decl.hpp>
+#include <KokkosBatched_ApplyQ_Decl.hpp>
 #include <KokkosBatched_LU_Decl.hpp>
 #include <KokkosBatched_QR_Decl.hpp>
-#include <KokkosBatched_ApplyQ_Decl.hpp>
 #include <KokkosBatched_Trsv_Decl.hpp>
-#include <KokkosBatched_ApplyPivot_Decl.hpp>
 
-std::vector<std::string> Implicit::GetOrderedNames(MeshBlockData<Real> *rc, const MetadataFlag& flag, bool only_implicit)
+std::vector<std::string> Implicit::GetOrderedNames(
+    MeshBlockData<Real>* rc, const MetadataFlag& flag, bool only_implicit)
 {
     auto pmb0 = rc->GetBlockPointer();
     std::vector<std::string> out;
     auto vars = rc->GetVariablesByFlag({Metadata::GetUserFlag("Implicit"), flag}).vars();
-    for (int i=0; i < vars.size(); ++i) {
+    for (int i = 0; i < vars.size(); ++i) {
         if (rc->Contains(vars[i]->label())) {
             out.push_back(vars[i]->label());
         }
     }
     if (!only_implicit) {
         vars = rc->GetVariablesByFlag({Metadata::GetUserFlag("Explicit"), flag}).vars();
-        for (int i=0; i < vars.size(); ++i) {
+        for (int i = 0; i < vars.size(); ++i) {
             if (rc->Contains(vars[i]->label())) {
                 out.push_back(vars[i]->label());
             }
@@ -82,15 +88,17 @@ std::vector<std::string> Implicit::GetOrderedNames(MeshBlockData<Real> *rc, cons
     return out;
 }
 
-int Implicit::CountSolverFails(MeshData<Real> *md)
+int Implicit::CountSolverFails(MeshData<Real>* md)
 {
-    return Reductions::CountFlags(md, "solve_fail", Implicit::status_names, IndexDomain::interior, false)[0];
+    return Reductions::CountFlags(
+        md, "solve_fail", Implicit::status_names, IndexDomain::interior, false)[0];
 }
 
-std::shared_ptr<KHARMAPackage> Implicit::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Implicit::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Implicit");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Implicit evolution must use predictor-corrector i.e. "vl2" integrator
     pin->SetString("parthenon/time", "integrator", "vl2");
@@ -124,24 +132,32 @@ std::shared_ptr<KHARMAPackage> Implicit::Initialize(ParameterInput *pin, std::sh
     int nvars_explicit = resolved->GetPackDimension(Metadata::GetUserFlag("Explicit"));
     std::vector<int> s_vars_implicit({nvars_implicit});
     std::vector<int> s_jac_implicit({nvars_implicit, nvars_implicit});
-    std::vector<int> s_vars_all({nvars_implicit+nvars_explicit});
-    Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_jac_implicit);
+    std::vector<int> s_vars_all({nvars_implicit + nvars_explicit});
+    Metadata m =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy},
+            s_jac_implicit);
     pkg->AddField("Implicit.jacobian", m);
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_vars_implicit);
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy},
+        s_vars_implicit);
     pkg->AddField("Implicit.residual", m);
-    // While the *guess* for delta_prim == -residual, we require *solved* delta_prim and original residual in-flight at once
+    // While the *guess* for delta_prim == -residual, we require *solved* delta_prim and
+    // original residual in-flight at once
     pkg->AddField("Implicit.delta_prim", m);
     // We also need to carry around the implicit sources
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_vars_all);
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy},
+        s_vars_all);
     pkg->AddField("Implicit.dU_implicit", m);
 
     // Allocate additional fields that reflect the success of the solver
     // L2 norm of the residual
-    Metadata m_real = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+    Metadata m_real =
+        Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
     pkg->AddField("solve_norm", m_real);
     // Integer field that saves where the solver fails (rho + drho < 0 || u + du < 0)
-    m_real = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::FillGhost});
-    pkg->AddField("solve_fail", m_real); // TODO: Replace with m_int once Integer is supported for CellVariable
+    m_real = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
+        Metadata::OneCopy, Metadata::FillGhost});
+    pkg->AddField("solve_fail",
+        m_real); // TODO: Replace with m_int once Integer is supported for CellVariable
 
     // The major call, to Step(), is done manually from the ImEx driver
     // But, we just register the diagnostics function to print out solver failures
@@ -150,40 +166,43 @@ std::shared_ptr<KHARMAPackage> Implicit::Initialize(ParameterInput *pin, std::sh
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
     // Count total floors as a history item
-    hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, CountSolverFails, "ImpSolverFails"));
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    hst_vars.emplace_back(parthenon::HistoryOutputVar(
+        UserHistoryOperation::sum, CountSolverFails, "ImpSolverFails"));
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     return pkg;
 }
 
-TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init, MeshData<Real> *md_flux_src,
-                MeshData<Real> *md_linesearch, MeshData<Real> *md_solver, const Real& dt)
+TaskStatus Implicit::Step(MeshData<Real>* md_full_step_init,
+    MeshData<Real>* md_sub_step_init, MeshData<Real>* md_flux_src,
+    MeshData<Real>* md_linesearch, MeshData<Real>* md_solver, const Real& dt)
 {
     Flag("Implicit::Step");
     // Pull out the block pointers for each sub-step, as we need the *mutable parameters*
-    // of the EMHD package.  TODO(BSP) restrict state back to the variables...
+    // of the EMHD package.  TODO(CEP) restrict state back to the variables...
     auto pmb_full_step_init = md_full_step_init->GetBlockData(0)->GetBlockPointer();
-    auto pmb_sub_step_init  = md_sub_step_init->GetBlockData(0)->GetBlockPointer();
-    auto pmb_solver         = md_solver->GetBlockData(0)->GetBlockPointer();
-    auto pmb_linesearch     = md_linesearch->GetBlockData(0)->GetBlockPointer();
+    auto pmb_sub_step_init = md_sub_step_init->GetBlockData(0)->GetBlockPointer();
+    auto pmb_solver = md_solver->GetBlockData(0)->GetBlockPointer();
+    auto pmb_linesearch = md_linesearch->GetBlockData(0)->GetBlockPointer();
 
     // Parameters
     const auto& implicit_par = pmb_full_step_init->packages.Get("Implicit")->AllParams();
-    const int iter_min       = implicit_par.Get<int>("min_nonlinear_iter");
-    const int iter_max       = implicit_par.Get<int>("max_nonlinear_iter");
-    const Real delta         = implicit_par.Get<Real>("jacobian_delta");
-    const Real rootfind_tol  = implicit_par.Get<Real>("rootfind_tol");
-    const bool use_qr        = implicit_par.Get<bool>("use_qr");
-    const auto& globals      = pmb_full_step_init->packages.Get("Globals")->AllParams();
-    const int verbose        = globals.Get<int>("verbose");
-    const int flag_verbose   = globals.Get<int>("flag_verbose");
-    const Real gam           = pmb_full_step_init->packages.Get("GRMHD")->Param<Real>("gamma");
+    const int iter_min = implicit_par.Get<int>("min_nonlinear_iter");
+    const int iter_max = implicit_par.Get<int>("max_nonlinear_iter");
+    const Real delta = implicit_par.Get<Real>("jacobian_delta");
+    const Real rootfind_tol = implicit_par.Get<Real>("rootfind_tol");
+    const bool use_qr = implicit_par.Get<bool>("use_qr");
+    const auto& globals = pmb_full_step_init->packages.Get("Globals")->AllParams();
+    const int verbose = globals.Get<int>("verbose");
+    const int flag_verbose = globals.Get<int>("flag_verbose");
+    const Real gam = pmb_full_step_init->packages.Get("GRMHD")->Param<Real>("gamma");
 
-    const bool linesearch         = implicit_par.Get<bool>("linesearch");
+    const bool linesearch = implicit_par.Get<bool>("linesearch");
     const int max_linesearch_iter = implicit_par.Get<int>("max_linesearch_iter");
-    const Real linesearch_eps     = implicit_par.Get<Real>("linesearch_eps");
-    const Real linesearch_lambda  = implicit_par.Get<Real>("linesearch_lambda");
+    const Real linesearch_eps = implicit_par.Get<Real>("linesearch_eps");
+    const Real linesearch_lambda = implicit_par.Get<Real>("linesearch_lambda");
 
     // Misc other constants for inside the kernel
     const bool am_rank0 = MPIRank0();
@@ -192,29 +211,37 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
     // We need two sets of emhd_params because we need the relaxation scale
     // at the same state in the implicit source terms
     // Need an object of `EMHD_parameters` for the `linesearch` state
-    EMHD::EMHD_parameters emhd_params_sub_step_init, emhd_params_solver, emhd_params_linesearch;
+    EMHD::EMHD_parameters emhd_params_sub_step_init, emhd_params_solver,
+        emhd_params_linesearch;
     if (pmb_sub_step_init->packages.AllPackages().count("EMHD")) {
-        const auto& pars_sub_step_init  = pmb_sub_step_init->packages.Get("EMHD")->AllParams();
-        const auto& pars_solver         = pmb_solver->packages.Get("EMHD")->AllParams();
-        const auto& pars_linesearch     = pmb_linesearch->packages.Get("EMHD")->AllParams();
-        emhd_params_sub_step_init       = pars_sub_step_init.Get<EMHD::EMHD_parameters>("emhd_params");
-        emhd_params_solver              = pars_solver.Get<EMHD::EMHD_parameters>("emhd_params");
-        emhd_params_linesearch          = pars_linesearch.Get<EMHD::EMHD_parameters>("emhd_params");
+        const auto& pars_sub_step_init =
+            pmb_sub_step_init->packages.Get("EMHD")->AllParams();
+        const auto& pars_solver = pmb_solver->packages.Get("EMHD")->AllParams();
+        const auto& pars_linesearch = pmb_linesearch->packages.Get("EMHD")->AllParams();
+        emhd_params_sub_step_init =
+            pars_sub_step_init.Get<EMHD::EMHD_parameters>("emhd_params");
+        emhd_params_solver = pars_solver.Get<EMHD::EMHD_parameters>("emhd_params");
+        emhd_params_linesearch =
+            pars_linesearch.Get<EMHD::EMHD_parameters>("emhd_params");
     }
 
     // I don't normally do this, but we *really* care about variable ordering here.
-    // The implicit variables need to be first, so we know how to iterate over just them to fill
-    // just the residual & Jacobian we care about, which makes the solve faster.
-    auto& mbd_full_step_init  = md_full_step_init->GetBlockData(0); // MeshBlockData object, more member functions
+    // The implicit variables need to be first, so we know how to iterate over just them
+    // to fill just the residual & Jacobian we care about, which makes the solve faster.
+    auto& mbd_full_step_init =
+        md_full_step_init->GetBlockData(0); // MeshBlockData object, more member functions
 
-    auto ordered_prims = GetOrderedNames(mbd_full_step_init.get(), Metadata::GetUserFlag("Primitive"));
-    auto ordered_cons  = GetOrderedNames(mbd_full_step_init.get(), Metadata::Conserved);
-    //std::cerr << "Ordered prims:"; for(auto prim: ordered_prims) std::cerr << " " << prim; std::cerr << std::endl;
-    //std::cerr << "Ordered cons:"; for(auto con: ordered_cons) std::cerr << " " << con; std::cerr << std::endl;
+    auto ordered_prims =
+        GetOrderedNames(mbd_full_step_init.get(), Metadata::GetUserFlag("Primitive"));
+    auto ordered_cons = GetOrderedNames(mbd_full_step_init.get(), Metadata::Conserved);
+    // std::cerr << "Ordered prims:"; for(auto prim: ordered_prims) std::cerr << " " <<
+    // prim; std::cerr << std::endl; std::cerr << "Ordered cons:"; for(auto con:
+    // ordered_cons) std::cerr << " " << con; std::cerr << std::endl;
 
     // Initial state.  Also mapping template
     PackIndexMap prims_map, cons_map;
-    auto& P_full_step_init_all = md_full_step_init->PackVariables(ordered_prims, prims_map);
+    auto& P_full_step_init_all =
+        md_full_step_init->PackVariables(ordered_prims, prims_map);
     auto& U_full_step_init_all = md_full_step_init->PackVariables(ordered_cons, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
     // Current sub-step starting state.
@@ -223,36 +250,45 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
     // Flux divergence plus explicit source terms. This is what we'd be adding.
     auto& flux_src_all = md_flux_src->PackVariables(ordered_cons);
     // Guess at initial state. We update only the implicit primitive vars
-    auto& P_solver_all     = md_solver->PackVariables(ordered_prims);
+    auto& P_solver_all = md_solver->PackVariables(ordered_prims);
     auto& P_linesearch_all = md_linesearch->PackVariables(ordered_prims);
 
     // Sizes and scratchpads
     const int nblock = U_full_step_init_all.GetDim(5);
-    const int nvar   = U_full_step_init_all.GetDim(4);
+    const int nvar = U_full_step_init_all.GetDim(4);
     // Get number of implicit variables
-    auto implicit_vars = GetOrderedNames(mbd_full_step_init.get(), Metadata::GetUserFlag("Primitive"), true);
-    //std::cerr << "Ordered implicit:"; for(auto var: implicit_vars) std::cerr << " " << var; std::cerr << std::endl;
+    auto implicit_vars = GetOrderedNames(
+        mbd_full_step_init.get(), Metadata::GetUserFlag("Primitive"), true);
+    // std::cerr << "Ordered implicit:"; for(auto var: implicit_vars) std::cerr << " " <<
+    // var; std::cerr << std::endl;
 
     PackIndexMap implicit_prims_map;
-    auto& P_full_step_init_implicit = md_full_step_init->PackVariables(implicit_vars, implicit_prims_map);
+    auto& P_full_step_init_implicit =
+        md_full_step_init->PackVariables(implicit_vars, implicit_prims_map);
     const int nfvar = P_full_step_init_implicit.GetDim(4);
 
     // Pull fields associated with the solver's performance
-    auto& solve_norm_all = md_solver->PackVariables(std::vector<std::string>{"solve_norm"});
-    auto& solve_fail_all = md_solver->PackVariables(std::vector<std::string>{"solve_fail"});
+    auto& solve_norm_all =
+        md_solver->PackVariables(std::vector<std::string>{"solve_norm"});
+    auto& solve_fail_all =
+        md_solver->PackVariables(std::vector<std::string>{"solve_fail"});
 
-    auto& jacobian_all = md_solver->PackVariables(std::vector<std::string>{"Implicit.jacobian"});
-    auto& delta_prim_all = md_solver->PackVariables(std::vector<std::string>{"Implicit.delta_prim"});
-    auto& residual_all = md_solver->PackVariables(std::vector<std::string>{"Implicit.residual"});
-    auto& dU_implicit_all = md_solver->PackVariables(std::vector<std::string>{"Implicit.dU_implicit"});
+    auto& jacobian_all =
+        md_solver->PackVariables(std::vector<std::string>{"Implicit.jacobian"});
+    auto& delta_prim_all =
+        md_solver->PackVariables(std::vector<std::string>{"Implicit.delta_prim"});
+    auto& residual_all =
+        md_solver->PackVariables(std::vector<std::string>{"Implicit.residual"});
+    auto& dU_implicit_all =
+        md_solver->PackVariables(std::vector<std::string>{"Implicit.dU_implicit"});
 
-    auto bounds  = pmb_sub_step_init->cellbounds;
+    auto bounds = pmb_sub_step_init->cellbounds;
     const int n1 = bounds.ncellsi(IndexDomain::entire);
     const int n2 = bounds.ncellsj(IndexDomain::entire);
     const int n3 = bounds.ncellsk(IndexDomain::entire);
 
     // RETURN if there aren't any implicit variables to evolve
-    // TODO(BSP) probably redundant with not loading package, see kharma.cpp
+    // TODO(CEP) probably redundant with not loading package, see kharma.cpp
     // std::cerr << "Solve size " << nfvar << " on prim size " << nvar << std::endl;
     if (nfvar == 0) return TaskStatus::complete;
 
@@ -263,231 +299,285 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
 
     // Get meshblock array bounds from Parthenon
     const IndexDomain domain = IndexDomain::interior;
-    const IndexRange ib      = bounds.GetBoundsI(domain);
-    const IndexRange jb      = bounds.GetBoundsJ(domain);
-    const IndexRange kb      = bounds.GetBoundsK(domain);
-    const IndexRange block   = IndexRange{0, nblock - 1};
+    const IndexRange ib = bounds.GetBoundsI(domain);
+    const IndexRange jb = bounds.GetBoundsJ(domain);
+    const IndexRange kb = bounds.GetBoundsK(domain);
+    const IndexRange block = IndexRange{0, nblock - 1};
 
     // Allocate scratch space
     // Only needed for the Kokkos-kernels solve, anymore
     // Otherwise we pull a bad hack and allocate constant temporaries
     const int scratch_level = 1; // 0 is actual scratch (tiny); 1 is HBM
-    const size_t tensor_size_in_bytes = parthenon::ScratchPad3D<Real>::shmem_size(n1, nfvar, nfvar);
-    const size_t fvar_size_in_bytes   = parthenon::ScratchPad2D<Real>::shmem_size(n1, nfvar);
-    const size_t fvar_int_size_in_bytes = parthenon::ScratchPad2D<int>::shmem_size(n1, nfvar);
-    const size_t total_scratch_bytes = tensor_size_in_bytes + 4 * fvar_size_in_bytes + fvar_int_size_in_bytes;
+    const size_t tensor_size_in_bytes =
+        parthenon::ScratchPad3D<Real>::shmem_size(n1, nfvar, nfvar);
+    const size_t fvar_size_in_bytes =
+        parthenon::ScratchPad2D<Real>::shmem_size(n1, nfvar);
+    const size_t fvar_int_size_in_bytes =
+        parthenon::ScratchPad2D<int>::shmem_size(n1, nfvar);
+    const size_t total_scratch_bytes =
+        tensor_size_in_bytes + 4 * fvar_size_in_bytes + fvar_int_size_in_bytes;
 
     // Iterate.  This loop is outside the kokkos kernel in order to print max_norm
     // There are generally a low and similar number of iterations between
     // different zones, so probably acceptable speed loss.
-    for (int iter=1; iter <= iter_max; ++iter) {
+    for (int iter = 1; iter <= iter_max; ++iter) {
         // Flags per iter, since debugging here will be rampant
-        Flag("ImplicitIteration_"+std::to_string(iter));
+        Flag("ImplicitIteration_" + std::to_string(iter));
 
 #if SPLIT_IMPLICIT_SOLVE
-        pmb_solver->par_for("implicit_jacobian",
-            block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i) {
+        pmb_solver->par_for(
+            "implicit_jacobian", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+            {
 #else
-        parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "implicit_solve", pmb_sub_step_init->exec_space,
+        parthenon::par_for_outer(
+            DEFAULT_OUTER_LOOP_PATTERN, "implicit_solve", pmb_sub_step_init->exec_space,
             total_scratch_bytes, scratch_level, block.s, block.e, kb.s, kb.e, jb.s, jb.e,
-            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& b, const int& k, const int& j) {
+            KOKKOS_LAMBDA(
+                parthenon::team_mbr_t member, const int& b, const int& k, const int& j)
+            {
                 parthenon::par_for_inner(member, ib.s, ib.e,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
 #endif
                 const auto& G = U_full_step_init_all.GetCoords(b);
 
                 // Solver performance diagnostics.
-                Real &solve_fail = solve_fail_all(b, 0, k, j, i);
+                Real& solve_fail = solve_fail_all(b, 0, k, j, i);
                 // Reset (locally and in View) at first iteration!
                 if (iter == 1) solve_fail = SolverStatusR::converged;
 
-                // Perform the solve only if it hadn't failed in any of the previous iterations.
+                // Perform the solve only if it hadn't failed in any of the previous
+                // iterations.
                 if (solve_fail != SolverStatusR::fail) {
-                    // Now that we know that it isn't a bad zone, reset solve_fail for this iteration
+                    // Now that we know that it isn't a bad zone, reset solve_fail for
+                    // this iteration
                     solve_fail = SolverStatusR::converged;
 
                     if (m_p.Q >= 0 || m_p.DP >= 0) {
                         Real throwaway;
-                        Real &dUq  = (m_u.Q >= 0)  ? dU_implicit_all(b, m_u.Q, k, j, i) : throwaway;
-                        Real &dUdP = (m_u.DP >= 0) ? dU_implicit_all(b, m_u.DP, k, j, i): throwaway;
+                        Real& dUq =
+                            (m_u.Q >= 0) ? dU_implicit_all(b, m_u.Q, k, j, i) : throwaway;
+                        Real& dUdP = (m_u.DP >= 0) ? dU_implicit_all(b, m_u.DP, k, j, i)
+                                                   : throwaway;
                         Real tau, chi_e, nu_e;
-                        EMHD::set_parameters(G, P_sub_step_init_all(b), m_p, emhd_params_sub_step_init,
-                                                gam, k, j, i, tau, chi_e, nu_e);
-                        EMHD::implicit_sources(G, P_full_step_init_all(b), m_p,
-                                                gam, tau, k, j, i, dUq, dUdP);
+                        EMHD::set_parameters(G, P_sub_step_init_all(b), m_p,
+                            emhd_params_sub_step_init, gam, k, j, i, tau, chi_e, nu_e);
+                        EMHD::implicit_sources(G, P_full_step_init_all(b), m_p, gam, tau,
+                            k, j, i, dUq, dUdP);
                     }
 
                     // Jacobian calculation
                     // Requires calculating the residual anyway, so we grab it here
-                    calc_jacobian(G, P_solver_all(b), P_full_step_init_all(b), U_full_step_init_all(b), P_sub_step_init_all(b),
-                                flux_src_all(b), dU_implicit_all(b), m_p, m_u, emhd_params_solver, emhd_params_sub_step_init,
-                                nvar, nfvar, k, j, i, delta, gam, dt,
-                                jacobian_all(b), residual_all(b));
+                    calc_jacobian(G, P_solver_all(b), P_full_step_init_all(b),
+                        U_full_step_init_all(b), P_sub_step_init_all(b), flux_src_all(b),
+                        dU_implicit_all(b), m_p, m_u, emhd_params_solver,
+                        emhd_params_sub_step_init, nvar, nfvar, k, j, i, delta, gam, dt,
+                        jacobian_all(b), residual_all(b));
                 }
 #if SPLIT_IMPLICIT_SOLVE
             } // End lambda
         ); // End par_for
 
-        parthenon::par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, "implicit_solve", pmb_sub_step_init->exec_space,
+        parthenon::par_for_outer(
+            DEFAULT_OUTER_LOOP_PATTERN, "implicit_solve", pmb_sub_step_init->exec_space,
             total_scratch_bytes, scratch_level, block.s, block.e, kb.s, kb.e, jb.s, jb.e,
-            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& b, const int& k, const int& j) {
+            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int& b, const int& k, const int& j)
+            {
 #else
-                }); // End par_for_inner
+                    }); // End par_for_inner
                 member.team_barrier();
 #endif
                 const auto& G = U_full_step_init_all.GetCoords(b);
                 // Scratchpads for implicit vars
-                ScratchPad3D<Real> jacobian_s(member.team_scratch(scratch_level), n1, nfvar, nfvar);
-                ScratchPad2D<Real> delta_prim_s(member.team_scratch(scratch_level), n1, nfvar);
+                ScratchPad3D<Real> jacobian_s(
+                    member.team_scratch(scratch_level), n1, nfvar, nfvar);
+                ScratchPad2D<Real> delta_prim_s(
+                    member.team_scratch(scratch_level), n1, nfvar);
                 ScratchPad2D<Real> trans_s(member.team_scratch(scratch_level), n1, nfvar);
-                ScratchPad2D<Real> work_s(member.team_scratch(scratch_level), n1, 2*nfvar);
+                ScratchPad2D<Real> work_s(
+                    member.team_scratch(scratch_level), n1, 2 * nfvar);
                 ScratchPad2D<int> pivot_s(member.team_scratch(scratch_level), n1, nfvar);
 
                 // Copy in to scratchpads
-                FLOOP {
-                    parthenon::par_for_inner(member, 0, n1-1,
-                        [&](const int& i) {
+                FLOOP
+                {
+                    parthenon::par_for_inner(member, 0, n1 - 1,
+                        [&](const int& i)
+                        {
                             delta_prim_s(i, ip) = -residual_all(b)(ip, k, j, i);
-                        }
-                    );
+                        });
                 }
-                FLOOP2 {
-                    parthenon::par_for_inner(member, 0, n1-1,
-                        [&](const int& i) {
-                            jacobian_s(i, ip, jp) = jacobian_all(b)(ip*nfvar+jp, k, j, i);
-                        }
-                    );
+                FLOOP2
+                {
+                    parthenon::par_for_inner(member, 0, n1 - 1,
+                        [&](const int& i)
+                        {
+                            jacobian_s(i, ip, jp) =
+                                jacobian_all(b)(ip * nfvar + jp, k, j, i);
+                        });
                 }
                 member.team_barrier();
 
-                // TODO(BSP) even still worth keeping non-QR version?  Much less stable
+                // TODO(CEP) even still worth keeping non-QR version?  Much less stable
                 if (use_qr) {
                     parthenon::par_for_inner(member, ib.s, ib.e,
-                        [&](const int& i) {
+                        [&](const int& i)
+                        {
                             // Solver variables
-                            auto jacobian   = Kokkos::subview(jacobian_s, i, Kokkos::ALL(), Kokkos::ALL());
-                            auto delta_prim = Kokkos::subview(delta_prim_s, i, Kokkos::ALL());
-                            auto pivot      = Kokkos::subview(pivot_s, i, Kokkos::ALL());
-                            auto trans      = Kokkos::subview(trans_s, i, Kokkos::ALL());
-                            auto work       = Kokkos::subview(work_s, i, Kokkos::ALL());
+                            auto jacobian = Kokkos::subview(
+                                jacobian_s, i, Kokkos::ALL(), Kokkos::ALL());
+                            auto delta_prim =
+                                Kokkos::subview(delta_prim_s, i, Kokkos::ALL());
+                            auto pivot = Kokkos::subview(pivot_s, i, Kokkos::ALL());
+                            auto trans = Kokkos::subview(trans_s, i, Kokkos::ALL());
+                            auto work = Kokkos::subview(work_s, i, Kokkos::ALL());
 
                             if (solve_fail_all(b, 0, k, j, i) != SolverStatusR::fail) {
                                 // Linear solve by QR decomposition
-                                KokkosBatched::SerialQR<KokkosBatched::Algo::QR::Unblocked>::invoke(jacobian, trans, pivot, work);
-                                KokkosBatched::SerialApplyQ<KokkosBatched::Side::Left, KokkosBatched::Trans::Transpose,
-                                                            KokkosBatched::Algo::ApplyQ::Unblocked>
-                                ::invoke(jacobian, trans, delta_prim, work);
-                                KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
-                                                        KokkosBatched::Diag::NonUnit, KokkosBatched::Algo::Trsv::Unblocked>
-                                ::invoke(alpha, jacobian, delta_prim);
+                                KokkosBatched::SerialQR<
+                                    KokkosBatched::Algo::QR::Unblocked>::invoke(jacobian,
+                                    trans, pivot, work);
+                                KokkosBatched::SerialApplyQ<KokkosBatched::Side::Left,
+                                    KokkosBatched::Trans::Transpose,
+                                    KokkosBatched::Algo::ApplyQ::Unblocked>::
+                                    invoke(jacobian, trans, delta_prim, work);
+                                KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Upper,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Diag::NonUnit,
+                                    KokkosBatched::Algo::Trsv::Unblocked>::invoke(alpha,
+                                    jacobian, delta_prim);
                                 // Linear solve by QR decomposition
-                                KokkosBatched::SerialApplyPivot<KokkosBatched::Side::Left,KokkosBatched::Direct::Backward>
-                                    ::invoke(pivot, delta_prim);
+                                KokkosBatched::SerialApplyPivot<KokkosBatched::Side::Left,
+                                    KokkosBatched::Direct::Backward>::invoke(pivot,
+                                    delta_prim);
                             }
-                        }
-                    );
+                        });
                 } else {
                     parthenon::par_for_inner(member, ib.s, ib.e,
-                        [&](const int& i) {
+                        [&](const int& i)
+                        {
                             // Solver variables
-                            auto jacobian   = Kokkos::subview(jacobian_s, i, Kokkos::ALL(), Kokkos::ALL());
-                            auto delta_prim = Kokkos::subview(delta_prim_s, i, Kokkos::ALL());
+                            auto jacobian = Kokkos::subview(
+                                jacobian_s, i, Kokkos::ALL(), Kokkos::ALL());
+                            auto delta_prim =
+                                Kokkos::subview(delta_prim_s, i, Kokkos::ALL());
 
                             if (solve_fail_all(b, 0, k, j, i) != SolverStatusR::fail) {
-                                KokkosBatched::SerialLU<KokkosBatched::Algo::LU::Unblocked>::invoke(jacobian, tiny);
-                                KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
-                                                        KokkosBatched::Diag::NonUnit, KokkosBatched::Algo::Trsv::Unblocked>
-                                ::invoke(alpha, jacobian, delta_prim);
+                                KokkosBatched::SerialLU<
+                                    KokkosBatched::Algo::LU::Unblocked>::invoke(jacobian,
+                                    tiny);
+                                KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Upper,
+                                    KokkosBatched::Trans::NoTranspose,
+                                    KokkosBatched::Diag::NonUnit,
+                                    KokkosBatched::Algo::Trsv::Unblocked>::invoke(alpha,
+                                    jacobian, delta_prim);
                             }
-                        }
-                    );
+                        });
                 }
                 member.team_barrier();
 
                 // Copy out delta_prim
-                FLOOP {
+                FLOOP
+                {
                     parthenon::par_for_inner(member, ib.s, ib.e,
-                        [&](const int& i) {
+                        [&](const int& i)
+                        {
                             delta_prim_all(b)(ip, k, j, i) = delta_prim_s(i, ip);
-                        }
-                    );
+                        });
                 }
 #if SPLIT_IMPLICIT_SOLVE
             } // End lambda
         ); // End par_for
 
-        pmb_solver->par_for("implicit_set_step",
-            block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i) {
+        pmb_solver->par_for(
+            "implicit_set_step", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+            KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+            {
 #else
                 member.team_barrier();
                 parthenon::par_for_inner(member, ib.s, ib.e,
-                    [&](const int& i) {
+                    [&](const int& i)
+                    {
 #endif
                 const auto& G = U_full_step_init_all.GetCoords(b);
 
                 // Solver performance diagnostics
-                Real &solve_norm = solve_norm_all(b, 0, k, j, i);
-                Real &solve_fail = solve_fail_all(b, 0, k, j, i);
+                Real& solve_norm = solve_norm_all(b, 0, k, j, i);
+                Real& solve_fail = solve_fail_all(b, 0, k, j, i);
 
                 if (solve_fail == SolverStatusR::fail) return;
 
-                // Copy `solver` prims to `linesearch`. This doesn't matter for the first step of the solver
-                // since we do a copy in imex_driver just before, but it is required for the subsequent
-                // iterations of the solver.
+                // Copy `solver` prims to `linesearch`. This doesn't matter for the first
+                // step of the solver since we do a copy in imex_driver just before, but
+                // it is required for the subsequent iterations of the solver.
                 if (iter > 1)
-                   PLOOP P_linesearch_all(b, ip, k, j, i) = P_solver_all(b, ip, k, j, i);
+                    PLOOP
+                        P_linesearch_all(b, ip, k, j, i) = P_solver_all(b, ip, k, j, i);
 
                 // Check for positive definite values of density and internal energy.
                 // Ignore zone if manual backtracking is not sufficient.
                 // The primitives will be averaged over good neighbors.
                 Real lambda = linesearch_lambda;
-                if ((P_solver_all(b, m_p.RHO, k, j, i) + lambda*delta_prim_all(b, m_p.RHO, k, j, i) < 0.) ||
-                    (P_solver_all(b, m_p.UU, k, j, i) + lambda*delta_prim_all(b, m_p.UU, k, j, i) < 0.)) {
+                if ((P_solver_all(b, m_p.RHO, k, j, i) +
+                            lambda * delta_prim_all(b, m_p.RHO, k, j, i) <
+                        0.) ||
+                    (P_solver_all(b, m_p.UU, k, j, i) +
+                            lambda * delta_prim_all(b, m_p.UU, k, j, i) <
+                        0.)) {
                     solve_fail = SolverStatusR::backtrack;
-                    lambda       = 0.1;
+                    lambda = 0.1;
                 }
-                if ((P_solver_all(b, m_p.RHO, k, j, i) + lambda*delta_prim_all(b, m_p.RHO, k, j, i) < 0.) ||
-                    (P_solver_all(b, m_p.UU, k, j, i) + lambda*delta_prim_all(b, m_p.UU, k, j, i) < 0.)) {
+                if ((P_solver_all(b, m_p.RHO, k, j, i) +
+                            lambda * delta_prim_all(b, m_p.RHO, k, j, i) <
+                        0.) ||
+                    (P_solver_all(b, m_p.UU, k, j, i) +
+                            lambda * delta_prim_all(b, m_p.UU, k, j, i) <
+                        0.)) {
                     solve_fail = SolverStatusR::fail;
                     // Set all fluid primitives to value at beginning of substep.
                     // We average over neighboring good zones later.
-                    FLOOP P_solver_all(b, ip, k, j, i) = P_sub_step_init_all(b, ip, k, j, i);
+                    FLOOP P_solver_all(b, ip, k, j, i) =
+                        P_sub_step_init_all(b, ip, k, j, i);
                     return;
                 }
 
                 // Assuming we did not fail...
                 // Linesearch
                 if (linesearch) {
-                    solve_norm        = 0.;
+                    solve_norm = 0.;
                     FLOOP solve_norm += SQR(residual_all(b, ip, k, j, i));
-                    solve_norm        = m::sqrt(solve_norm);
+                    solve_norm = m::sqrt(solve_norm);
 
-                    Real f0      = 0.5 * solve_norm;
+                    Real f0 = 0.5 * solve_norm;
                     Real fprime0 = -2. * f0;
 
-                    for (int linesearch_iter = 0; linesearch_iter < max_linesearch_iter; linesearch_iter++) {
+                    for (int linesearch_iter = 0; linesearch_iter < max_linesearch_iter;
+                        linesearch_iter++) {
                         // Take step
                         FLOOP P_linesearch_all(b, ip, k, j, i) =
-                                P_solver_all(b, ip, k, j, i) + (lambda * delta_prim_all(b, ip, k, j, i));
+                            P_solver_all(b, ip, k, j, i) +
+                            (lambda * delta_prim_all(b, ip, k, j, i));
 
                         // Compute solve_norm of the residual (loss function)
-                        calc_residual(G, P_linesearch_all(b), P_full_step_init_all(b), U_full_step_init_all(b),
-                                    P_sub_step_init_all(b), flux_src_all(b), dU_implicit_all(b),
-                                    m_p, m_u, emhd_params_linesearch, emhd_params_solver, nfvar,
-                                    k, j, i, gam, dt, residual_all(b));
+                        calc_residual(G, P_linesearch_all(b), P_full_step_init_all(b),
+                            U_full_step_init_all(b), P_sub_step_init_all(b),
+                            flux_src_all(b), dU_implicit_all(b), m_p, m_u,
+                            emhd_params_linesearch, emhd_params_solver, nfvar, k, j, i,
+                            gam, dt, residual_all(b));
 
-                        solve_norm        = 0.;
+                        solve_norm = 0.;
                         FLOOP solve_norm += SQR(residual_all(b, ip, k, j, i));
-                        solve_norm        = m::sqrt(solve_norm);
-                        Real f1             = 0.5 * solve_norm;
+                        solve_norm = m::sqrt(solve_norm);
+                        Real f1 = 0.5 * solve_norm;
 
                         // Compute new step length
-                        int condition   = f1 > (f0 * (1. - linesearch_eps * lambda) + SMALL_NUM);
-                        Real denom      = (f1 - f0 - (fprime0 * lambda)) * condition + (1 - condition);
+                        int condition =
+                            f1 > (f0 * (1. - linesearch_eps * lambda) + SMALL_NUM);
+                        Real denom =
+                            (f1 - f0 - (fprime0 * lambda)) * condition + (1 - condition);
                         Real lambda_new = -fprime0 * lambda * lambda / denom * 0.5;
-                        lambda          = lambda * (1 - condition) + (condition * lambda_new);
+                        lambda = lambda * (1 - condition) + (condition * lambda_new);
 
                         // Check if new solution has converged within required tolerance
                         if (condition == 0) break;
@@ -495,31 +585,36 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
                 }
 
                 // Update the guess
-                FLOOP P_solver_all(b, ip, k, j, i) += lambda * delta_prim_all(b, ip, k, j, i);
+                FLOOP P_solver_all(b, ip, k, j, i) +=
+                    lambda * delta_prim_all(b, ip, k, j, i);
 
-                calc_residual(G, P_solver_all(b), P_full_step_init_all(b), U_full_step_init_all(b),
-                            P_sub_step_init_all(b), flux_src_all(b), dU_implicit_all(b),
-                            m_p, m_u, emhd_params_solver, emhd_params_sub_step_init, nfvar,
-                            k, j, i, gam, dt, residual_all(b));
+                calc_residual(G, P_solver_all(b), P_full_step_init_all(b),
+                    U_full_step_init_all(b), P_sub_step_init_all(b), flux_src_all(b),
+                    dU_implicit_all(b), m_p, m_u, emhd_params_solver,
+                    emhd_params_sub_step_init, nfvar, k, j, i, gam, dt, residual_all(b));
 
                 // Store for maximum/output
-                solve_norm        = 0;
+                solve_norm = 0;
                 FLOOP solve_norm += SQR(residual_all(b, ip, k, j, i));
-                solve_norm        = m::sqrt(solve_norm);
+                solve_norm = m::sqrt(solve_norm);
 
-                // Did we converge to required tolerance? If not, update solve_fail accordingly
+                // Did we converge to required tolerance? If not, update solve_fail
+                // accordingly
                 if (m::isnan(solve_norm)) {
-                    // TODO(BSP) this can probably be detected/implemented alongside the floors above
+                    // TODO(CEP) this can probably be detected/implemented alongside the
+                    // floors above
                     solve_fail = SolverStatusR::fail;
-                    FLOOP P_solver_all(b, ip, k, j, i) = P_sub_step_init_all(b, ip, k, j, i);
+                    FLOOP P_solver_all(b, ip, k, j, i) =
+                        P_sub_step_init_all(b, ip, k, j, i);
                 } else if (solve_norm > rootfind_tol) {
-                    solve_fail = SolverStatusR::beyond_tol; // TODO was changed from +=. Valid?
+                    solve_fail =
+                        SolverStatusR::beyond_tol; // TODO was changed from +=. Valid?
                 }
 #if SPLIT_IMPLICIT_SOLVE
             } // End lambda
         ); // End par_for
 #else
-                }); // End par_for_inner
+                    }); // End par_for_inner
             } // End lambda
         ); // End par_for
 #endif
@@ -527,11 +622,15 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
         if (iter >= iter_min || verbose >= 1) {
             // Take the maximum L2 norm on this rank
             Real lmax_norm = 0.0;
-            pmb_sub_step_init->par_reduce("max_norm", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-                KOKKOS_LAMBDA (const int& b, const int& k, const int& j, const int& i, Real& local_result) {
-                    if (solve_norm_all(b, 0, k, j, i) > local_result) local_result = solve_norm_all(b, 0, k, j, i);
-                }
-            , Kokkos::Max<Real>(lmax_norm));
+            pmb_sub_step_init->par_reduce(
+                "max_norm", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
+                    Real& local_result)
+                {
+                    if (solve_norm_all(b, 0, k, j, i) > local_result)
+                        local_result = solve_norm_all(b, 0, k, j, i);
+                },
+                Kokkos::Max<Real>(lmax_norm));
             // Then MPI AllReduce to copy the global max to every rank
             Reductions::StartToAll<Real>(md_solver, 4, lmax_norm, MPI_MAX);
             Real max_norm = Reductions::CheckOnAll<Real>(md_solver, 4);
@@ -539,16 +638,21 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
             if (verbose >= 1) {
                 // Count total number of solver fails
                 int lnfails = 0;
-                pmb_sub_step_init->par_reduce("count_solver_fails", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-                    KOKKOS_LAMBDA (const int& b, const int& k, const int& j, const int& i, int& local_result) {
+                pmb_sub_step_init->par_reduce(
+                    "count_solver_fails", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s,
+                    ib.e,
+                    KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
+                        int& local_result)
+                    {
                         if (failed(solve_fail_all(b, 0, k, j, i))) ++local_result;
-                    }
-                , Kokkos::Sum<int>(lnfails));
+                    },
+                    Kokkos::Sum<int>(lnfails));
                 // Then reduce to rank 0 to print the iteration by iteration
                 Reductions::Start<int>(md_solver, 5, lnfails, MPI_SUM);
                 int nfails = Reductions::Check<int>(md_solver, 5);
                 if (MPIRank0()) {
-                    printf("Iteration %d max L2 norm: %g, failed zones: %d\n", iter, max_norm, nfails);
+                    printf("Iteration %d max L2 norm: %g, failed zones: %d\n", iter,
+                        max_norm, nfails);
                 }
             }
 
@@ -565,15 +669,15 @@ TaskStatus Implicit::Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_
     // if (flag_verbose > 0) {
     //     // Start the reduction as soon as we have the data
     //     // Dangerous, so commented
-    //     Reductions::StartFlagReduce(md_solver, "solve_fail", Implicit::status_names, IndexDomain::interior, false, 2);
+    //     Reductions::StartFlagReduce(md_solver, "solve_fail", Implicit::status_names,
+    //     IndexDomain::interior, false, 2);
     // }
 
     EndFlag();
     return TaskStatus::complete;
-
 }
 
-TaskStatus Implicit::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+TaskStatus Implicit::PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -583,8 +687,10 @@ TaskStatus Implicit::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
 
     // Debugging/diagnostic info about implicit solver
     if (flag_verbose > 0) {
-        Reductions::StartFlagReduce(md, "solve_fail", Implicit::status_names, IndexDomain::interior, false, 2);
-        Reductions::CheckFlagReduceAndPrintHits(md, "solve_fail", Implicit::status_names, IndexDomain::interior, false, 2);
+        Reductions::StartFlagReduce(
+            md, "solve_fail", Implicit::status_names, IndexDomain::interior, false, 2);
+        Reductions::CheckFlagReduceAndPrintHits(
+            md, "solve_fail", Implicit::status_names, IndexDomain::interior, false, 2);
     }
 
     return TaskStatus::complete;

--- a/kharma/implicit/implicit.hpp
+++ b/kharma/implicit/implicit.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: implicit.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,45 +36,46 @@
 #include "decs.hpp"
 #include "types.hpp"
 
-#include "emhd_sources.hpp"
 #include "emhd.hpp"
+#include "emhd_sources.hpp"
 #include "flux_functions.hpp"
 #include "grmhd_functions.hpp"
 
 // And an odd but useful loop for ex-iharm3d code
 // This requires nvar to be defined in caller!
 // It is not a const/global anymore.  So, use this loop carefully
-#define PLOOP for(int ip=0; ip < nvar; ++ip)
+#define PLOOP for (int ip = 0; ip < nvar; ++ip)
 
 // Version of PLOOP for just implicit ("fluid") variables
-#define FLOOP for(int ip=0; ip < nfvar; ++ip)
-#define FLOOP2 FLOOP for(int jp=0; jp < nfvar; ++jp)
+#define FLOOP for (int ip = 0; ip < nfvar; ++ip)
+#define FLOOP2 FLOOP for (int jp = 0; jp < nfvar; ++jp)
 
 namespace Implicit
 {
 
-// Denote implicit solver failures (solve_fail). 
+// Denote implicit solver failures (solve_fail).
 // Thrown from Implicit::Step
 // Status values:
 // `converged`: solver converged to prescribed tolerance
 // `fail`: manual backtracking wasn't good enough. FixSolve will be called
 // `beyond_tol`: solver didn't converge to prescribed tolerance but didn't fail
-// `backtrack`: step length of 1 gave negative rho/uu, but manual backtracking (0.1) sufficed
-enum class SolverStatus{converged=0, fail, beyond_tol, backtrack};
-namespace SolverStatusR {
-    static constexpr Real converged = 0.0;
-    static constexpr Real fail = 1.0;
-    static constexpr Real beyond_tol = 2.0;
-    static constexpr Real backtrack = 3.0;
+// `backtrack`: step length of 1 gave negative rho/uu, but manual backtracking (0.1)
+// sufficed
+enum class SolverStatus { converged = 0, fail, beyond_tol, backtrack };
+namespace SolverStatusR
+{
+static constexpr Real converged = 0.0;
+static constexpr Real fail = 1.0;
+static constexpr Real beyond_tol = 2.0;
+static constexpr Real backtrack = 3.0;
 }
 
 static const std::map<int, std::string> status_names = {
-    {(int) SolverStatus::fail, "failed"},
-    {(int) SolverStatus::beyond_tol, "beyond tolerance"},
-    {(int) SolverStatus::backtrack, "backtrack"}
-};
+    {(int)SolverStatus::fail, "failed"},
+    {(int)SolverStatus::beyond_tol, "beyond tolerance"},
+    {(int)SolverStatus::backtrack, "backtrack"}};
 
-template <typename T>
+template<typename T>
 KOKKOS_INLINE_FUNCTION bool failed(T status_flag)
 {
     // Return only zones which outright failed
@@ -84,11 +85,12 @@ KOKKOS_INLINE_FUNCTION bool failed(T status_flag)
 /**
  * Initialization.  Set parameters.
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * @brief take the per-zone implicit portion of a semi-implicit scheme
- * 
+ *
  * @param md_full_step_init the fluid state at the beginning of the step
  * @param md_sub_step_init the initial fluid state for this substep
  * @param md_flux_src the negative flux divergence plus explicit source terms
@@ -96,26 +98,29 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
  * @param md_linesearch should contain solver prims at start, updated in the linesearch
  * @param dt the timestep (current substep)
  */
-TaskStatus Step(MeshData<Real> *md_full_step_init, MeshData<Real> *md_sub_step_init, MeshData<Real> *md_flux_src,
-                MeshData<Real> *md_linesearch, MeshData<Real> *md_solver, const Real& dt);
+TaskStatus Step(MeshData<Real>* md_full_step_init, MeshData<Real>* md_sub_step_init,
+    MeshData<Real>* md_flux_src, MeshData<Real>* md_linesearch, MeshData<Real>* md_solver,
+    const Real& dt);
 
 /**
- * Get the names of all variables matching 'flag' in a deterministic order, placing implicitly-evolved variables first.
+ * Get the names of all variables matching 'flag' in a deterministic order, placing
+ * implicitly-evolved variables first.
  */
-std::vector<std::string> GetOrderedNames(MeshBlockData<Real> *rc, const MetadataFlag& flag, bool only_implicit=false);
-
+std::vector<std::string> GetOrderedNames(
+    MeshBlockData<Real>* rc, const MetadataFlag& flag, bool only_implicit = false);
 
 /**
- * @brief Fix bad zones that the implicit solver couldn't integrate. Similar to GRMHD::FixUtoP
- * 
+ * @brief Fix bad zones that the implicit solver couldn't integrate. Similar to
+ * GRMHD::FixUtoP
+ *
  * @param mbd relevant fluid state
- * @return TaskStatus 
+ * @return TaskStatus
  */
-TaskStatus FixSolve(MeshBlockData<Real> *mbd);
-inline TaskStatus MeshFixSolve(MeshData<Real> *md) {
+TaskStatus FixSolve(MeshBlockData<Real>* mbd);
+inline TaskStatus MeshFixSolve(MeshData<Real>* md)
+{
     Flag("MeshFixSolve");
-    for (int i=0; i < md->NumBlocks(); ++i)
-        FixSolve(md->GetBlockData(i).get());
+    for (int i = 0; i < md->NumBlocks(); ++i) FixSolve(md->GetBlockData(i).get());
     EndFlag();
     return TaskStatus::complete;
 }
@@ -123,44 +128,44 @@ inline TaskStatus MeshFixSolve(MeshData<Real> *md) {
 /**
  * Count up all nonzero solver flags on md.  Used for history file reductions.
  */
-int CountSolverFails(MeshData<Real> *md);
+int CountSolverFails(MeshData<Real>* md);
 
 /**
  * Print diagnostics about number of failed solves
  */
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md);
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md);
 
 /**
  * Calculate the residual generated by the trial primitives P_test
- * 
+ *
  * "Global" here are read-only input arrays addressed var(ip, k, j, i)
  * "Local" here is anything sliced (usually Scratch) addressable var(ip)
  */
 template<typename Global>
 KOKKOS_INLINE_FUNCTION void calc_residual(const GRCoordinates& G, const Global& P_test,
-                                          const Global& Pi, const Global& Ui, const Global& Ps,
-                                          const Global& dudt_explicit, const Global& dUi,
-                                          const VarMap& m_p, const VarMap& m_u, const EMHD::EMHD_parameters& emhd_params,
-                                          const EMHD::EMHD_parameters& emhd_params_s,const int& nfvar, 
-                                          const int& k, const int& j, const int& i, 
-                                          const Real& gam, const double& dt, Global& residual)
+    const Global& Pi, const Global& Ui, const Global& Ps, const Global& dudt_explicit,
+    const Global& dUi, const VarMap& m_p, const VarMap& m_u,
+    const EMHD::EMHD_parameters& emhd_params, const EMHD::EMHD_parameters& emhd_params_s,
+    const int& nfvar, const int& k, const int& j, const int& i, const Real& gam,
+    const double& dt, Global& residual)
 {
-    // These lines calculate res = (U_test - Ui)/dt - dudt_explicit - 0.5*(dU_new(ip) + dUi(ip)) - dU_time(ip) )
-    // Start with conserved vars corresponding to test P, U_test
+    // These lines calculate res = (U_test - Ui)/dt - dudt_explicit - 0.5*(dU_new(ip) +
+    // dUi(ip)) - dU_time(ip) ) Start with conserved vars corresponding to test P, U_test
     // Note this uses the Flux:: call, it needs *all* conserved vars!
     Real Utmp[MAX_VARS];
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P_test, m_p, k, j, i, Loci::center, Dtmp);
     Flux::prim_to_flux(G, P_test, m_p, Dtmp, emhd_params, gam, k, j, i, 0, Utmp, m_u);
     // (U_test - Ui)/dt - dudt_explicit ...
-    FLOOP residual(ip, k, j, i) = (Utmp[ip] - Ui(ip, k, j, i)) / dt - dudt_explicit(ip, k, j, i);
+    FLOOP residual(ip, k, j, i) =
+        (Utmp[ip] - Ui(ip, k, j, i)) / dt - dudt_explicit(ip, k, j, i);
 
     if (m_u.Q >= 0 || m_u.DP >= 0) {
         // Bind references for readability/flexibility and to avoid lots of ifs
         // If we're omitting q/dP we just write them to a throwaway
         Real throwaway;
-        Real &rq  = (m_u.Q >= 0) ? residual(m_u.Q, k, j, i) : throwaway;
-        Real &rdP = (m_u.DP >= 0) ? residual(m_u.DP, k, j, i) : throwaway;
+        Real& rq = (m_u.Q >= 0) ? residual(m_u.Q, k, j, i) : throwaway;
+        Real& rdP = (m_u.DP >= 0) ? residual(m_u.DP, k, j, i) : throwaway;
 
         // Compute the EMHD parameters, which we'll re-use
         Real tau, chi_e, nu_e;
@@ -171,15 +176,15 @@ KOKKOS_INLINE_FUNCTION void calc_residual(const GRCoordinates& G, const Global& 
         Real dUq, dUdP; // Don't need full array for these
         EMHD::implicit_sources(G, P_test, m_p, gam, tau, k, j, i, dUq, dUdP); // dU_new
         // ... - 0.5*(dU_new(ip) + dUi(ip)) ...
-        if (m_u.Q >= 0)  rq  -= 0.5*(dUq + dUi(m_u.Q, k, j, i));
-        if (m_u.DP >= 0) rdP -= 0.5*(dUdP + dUi(m_u.DP, k, j, i));
+        if (m_u.Q >= 0) rq -= 0.5 * (dUq + dUi(m_u.Q, k, j, i));
+        if (m_u.DP >= 0) rdP -= 0.5 * (dUdP + dUi(m_u.DP, k, j, i));
 
         // Note we're now getting tau/chi_e/nu_e with emhd_params_s!
-        // TODO(BSP) split out time-dependent parts of the params struct
+        // TODO(CEP) split out time-dependent parts of the params struct
         EMHD::set_parameters(G, Ps, m_p, emhd_params_s, gam, k, j, i, tau, chi_e, nu_e);
-        EMHD::time_derivative_sources(G, P_test, Pi, Ps, m_p,
-                tau, chi_e, nu_e, Dtmp, emhd_params_s.higher_order_terms, gam,
-                dt, k, j, i, dUq, dUdP); // dU_time
+        EMHD::time_derivative_sources(G, P_test, Pi, Ps, m_p, tau, chi_e, nu_e, Dtmp,
+            emhd_params_s.higher_order_terms, gam, dt, k, j, i, dUq,
+            dUdP); // dU_time
         // ... - dU_time(ip)
         rq -= dUq;
         rdP -= dUdP;
@@ -188,36 +193,35 @@ KOKKOS_INLINE_FUNCTION void calc_residual(const GRCoordinates& G, const Global& 
         rq *= tau;
         rdP *= tau;
         if (emhd_params.higher_order_terms) {
-            const Real &rho   = Ps(m_p.RHO, k, j, i);
-            const Real &uu    = Ps(m_p.UU, k, j, i);
+            const Real& rho = Ps(m_p.RHO, k, j, i);
+            const Real& uu = Ps(m_p.UU, k, j, i);
             Real Theta = (gam - 1.) * uu / rho;
 
             rq *= (chi_e != 0) ? m::sqrt(rho * chi_e * tau * Theta * Theta) / tau : 1.;
-            rdP *= (nu_e != 0)  ? m::sqrt(rho * nu_e * tau * Theta) / tau : 1.;
+            rdP *= (nu_e != 0) ? m::sqrt(rho * nu_e * tau * Theta) / tau : 1.;
         }
     }
-
 }
 
 /**
  * Evaluate the jacobian for the implicit iteration, in one zone
- * 
- * Local is anything addressable by (0:nvar-1), Local2 is the same for 2D (0:nvar-1, 0:nvar-1)
- * Usually these are Kokkos subviews
+ *
+ * Local is anything addressable by (0:nvar-1), Local2 is the same for 2D (0:nvar-1,
+ * 0:nvar-1) Usually these are Kokkos subviews
  */
 template<typename Global>
 KOKKOS_INLINE_FUNCTION void calc_jacobian(const GRCoordinates& G, const Global& P_solver,
-                                          const Global& P_full_step_init, const Global& U_full_step_init, const Global& P_sub_step_init,
-                                          const Global& flux_src, const Global& dU_implicit,
-                                          const VarMap& m_p, const VarMap& m_u, const EMHD::EMHD_parameters& emhd_params_solver,
-                                          const EMHD::EMHD_parameters& emhd_params_sub_step_init, const int& nvar, const int& nfvar,
-                                          const int& k, const int& j, const int& i,
-                                          const Real& jac_delta, const Real& gam, const double& dt,
-                                          Global& jacobian, Global& residual)
+    const Global& P_full_step_init, const Global& U_full_step_init,
+    const Global& P_sub_step_init, const Global& flux_src, const Global& dU_implicit,
+    const VarMap& m_p, const VarMap& m_u, const EMHD::EMHD_parameters& emhd_params_solver,
+    const EMHD::EMHD_parameters& emhd_params_sub_step_init, const int& nvar,
+    const int& nfvar, const int& k, const int& j, const int& i, const Real& jac_delta,
+    const Real& gam, const double& dt, Global& jacobian, Global& residual)
 {
     // Calculate residual of P, cache
-    calc_residual(G, P_solver, P_full_step_init, U_full_step_init, P_sub_step_init, flux_src, dU_implicit,
-                    m_p, m_u, emhd_params_solver, emhd_params_sub_step_init, nfvar, k, j, i, gam, dt, residual);
+    calc_residual(G, P_solver, P_full_step_init, U_full_step_init, P_sub_step_init,
+        flux_src, dU_implicit, m_p, m_u, emhd_params_solver, emhd_params_sub_step_init,
+        nfvar, k, j, i, gam, dt, residual);
 
     // These store the *original* residual and P values,
     // so we can mess with the *arrays* in the loop below.
@@ -225,13 +229,16 @@ KOKKOS_INLINE_FUNCTION void calc_jacobian(const GRCoordinates& G, const Global& 
     // it keeps the interface to calc_residual standard and cuts down temporaries
     // (i.e., P_solver is old P_delta, P_save is old P_solver)
     Real residual_save[MAX_VARS];
-    PLOOP residual_save[ip] = residual(ip, k, j, i);    
+    PLOOP
+        residual_save[ip] = residual(ip, k, j, i);
     Real P_save[MAX_VARS];
-    PLOOP P_save[ip] = P_solver(ip, k, j, i);
+    PLOOP
+        P_save[ip] = P_solver(ip, k, j, i);
 
     // Numerically evaluate the Jacobian
     for (int col = 0; col < nfvar; col++) {
-        // Compute P_delta, differently depending on whether the prims are small compared to eps
+        // Compute P_delta, differently depending on whether the prims are small compared
+        // to eps
         if (m::abs(P_save[col]) < (0.5 * jac_delta)) {
             P_solver(col, k, j, i) = P_save[col] + jac_delta;
         } else {
@@ -239,19 +246,23 @@ KOKKOS_INLINE_FUNCTION void calc_jacobian(const GRCoordinates& G, const Global& 
         }
 
         // Compute the residual for P_delta, OVERWRITES residual
-        calc_residual(G, P_solver, P_full_step_init, U_full_step_init, P_sub_step_init, flux_src, dU_implicit, 
-                    m_p, m_u, emhd_params_solver, emhd_params_sub_step_init, nfvar, k, j, i, gam, dt, residual);
+        calc_residual(G, P_solver, P_full_step_init, U_full_step_init, P_sub_step_init,
+            flux_src, dU_implicit, m_p, m_u, emhd_params_solver,
+            emhd_params_sub_step_init, nfvar, k, j, i, gam, dt, residual);
 
         // Compute forward derivatives of each residual vs the primitive col
         for (int row = 0; row < nfvar; row++) {
-            jacobian(row*nfvar+col, k, j, i) = (residual(row, k, j, i) - residual_save[row]) / (P_solver(col, k, j, i) - P_save[col] + SMALL_NUM);
+            jacobian(row * nfvar + col, k, j, i) =
+                (residual(row, k, j, i) - residual_save[row]) /
+                (P_solver(col, k, j, i) - P_save[col] + SMALL_NUM);
         }
 
         // Reset P_delta in this col
         P_solver(col, k, j, i) = P_save[col];
     }
     // Reset the residual to the original value
-    PLOOP residual(ip, k, j, i) = residual_save[ip];
+    PLOOP
+        residual(ip, k, j, i) = residual_save[ip];
 }
 
 } // namespace Implicit

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: fixup.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,9 +42,9 @@
 
 // Version of "PLOOP" guaranteeing specifically the 5 GRMHD fixup-amenable primitive vars
 #define NPRIM 5
-#define PRIMLOOP for(int p=0; p < NPRIM; ++p)
+#define PRIMLOOP for (int p = 0; p < NPRIM; ++p)
 
-TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
+TaskStatus Inverter::FixUtoP(MeshBlockData<Real>* rc)
 {
     // We expect primitives all the way out to 3 ghost zones on all sides.
     // But we can only fix primitives with their neighbors.
@@ -52,7 +52,8 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     // if we need to use only fixed zones.
     auto pmb = rc->GetBlockPointer();
     // Bail if we're not enabled
-    const bool fix_average = pmb->packages.Get("Inverter")->Param<bool>("fix_average_neighbors");
+    const bool fix_average =
+        pmb->packages.Get("Inverter")->Param<bool>("fix_average_neighbors");
     const bool fix_atmo = pmb->packages.Get("Inverter")->Param<bool>("fix_atmosphere");
     if (!fix_average && !fix_atmo) return TaskStatus::complete;
 
@@ -77,24 +78,27 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     const auto& G = pmb->coords;
 
     pmb->par_for("fix_U_to_P", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             if (failed(pflag(k, j, i))) {
                 double wsum = 0.;
                 double sum[NPRIM] = {0.};
                 if (fix_average) {
-                    // Luckily fixups are rare, so we don't have to worry about optimizing this *too* much
-                    // For all neighboring cells...
+                    // Luckily fixups are rare, so we don't have to worry about
+                    // optimizing this *too* much For all neighboring cells...
                     for (int n = -1; n <= 1; n++) {
                         for (int m = -1; m <= 1; m++) {
                             for (int l = -1; l <= 1; l++) {
                                 int ii = i + l, jj = j + m, kk = k + n;
                                 // If we haven't overstepped array bounds...
                                 if (KDomain::inside(kk, jj, ii, b)) {
-                                    // Count only the good cells (not failed AND not corner), if we can
-                                    // Note interpolated "fixed" cells stay flagged
+                                    // Count only the good cells (not failed AND
+                                    // not corner), if we can Note interpolated
+                                    // "fixed" cells stay flagged
                                     if (!failed(pflag(kk, jj, ii))) {
                                         // Weight by distance
-                                        double w = 1./(m::abs(l) + m::abs(m) + m::abs(n) + 1);
+                                        double w =
+                                            1. / (m::abs(l) + m::abs(m) + m::abs(n) + 1);
                                         wsum += w;
                                         PRIMLOOP sum[p] += w * P(p, kk, jj, ii);
                                     }
@@ -106,24 +110,29 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
 
                 // Set to atmosphere/floors, zero velocity
                 // Fallback fix if we're averaging, only fix if not
-                if(wsum < 1.e-10) {
+                if (wsum < 1.e-10) {
                     // We fill this with floor values below
                     PRIMLOOP P(p, k, j, i) = 0.;
                 } else {
-                    PRIMLOOP P(p, k, j, i) = sum[p]/wsum;
+                    PRIMLOOP P(p, k, j, i) = sum[p] / wsum;
                 }
             }
-        }
-    );
+        });
 
     // Re-apply floors to fixed zones
-    // Use values from floors package if it's enabled, otherwise any we've been asked to apply
-    const Floors::Prescription floors = pmb->packages.AllPackages().count("Floors") ?
-                                        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription") :
-                                        pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
-    const Floors::Prescription floors_inner = pmb->packages.AllPackages().count("Floors") ?
-                                        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner") :
-                                        pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
+    // Use values from floors package if it's enabled, otherwise any we've been asked to
+    // apply
+    const Floors::Prescription floors =
+        pmb->packages.AllPackages().count("Floors")
+            ? pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription")
+            : pmb->packages.Get("Inverter")
+                  ->Param<Floors::Prescription>("inverter_prescription");
+    const Floors::Prescription floors_inner =
+        pmb->packages.AllPackages().count("Floors")
+            ? pmb->packages.Get("Floors")->Param<Floors::Prescription>(
+                  "prescription_inner")
+            : pmb->packages.Get("Inverter")
+                  ->Param<Floors::Prescription>("inverter_prescription");
 
     // We need the full packs of prims/cons for p_to_u
     // Pack new variables
@@ -138,7 +147,8 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     GridScalar fflag = rc->Get("fflag").data;
 
     pmb->par_for("fix_U_to_P_floors", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             if (failed(pflag(k, j, i))) {
                 // Make sure all fixed values still abide by floors
                 // TODO Full floors instead of just geo?
@@ -148,8 +158,7 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
                 // This will only be run for GRMHD, so we can call its p_to_u
                 GRMHD::p_to_u(G, P, m_p, gam, k, j, i, U, m_u);
             }
-        }
-    );
+        });
 
     EndFlag();
     return TaskStatus::complete;

--- a/kharma/inverter/invert_template.hpp
+++ b/kharma/inverter/invert_template.hpp
@@ -43,36 +43,43 @@
 
 #include "floors.hpp"
 
-namespace Inverter {
+namespace Inverter
+{
 
 // Denote inverter types. Currently just one
-enum class Type{none=0, onedw, kastaun};
+enum class Type { none = 0, onedw, kastaun };
 
 // Denote inversion failures (pflags)
 // This enum should grow to cover any inversion algorithm
-enum class Status{success=0, neg_input, max_iter, bad_ut, bad_gamma,
-                  neg_rho, neg_u, neg_rhou, floor, bad_velocity};
-
-static const std::map<int, std::string> status_names = {
-    {(int) Status::neg_input, "Negative input"},
-    {(int) Status::max_iter, "Hit max iter"},
-    {(int) Status::bad_ut, "Velocity invalid"},
-    {(int) Status::bad_gamma, "Gamma invalid"},
-    {(int) Status::neg_rho, "Negative rho"},
-    {(int) Status::neg_u, "Negative U"},
-    {(int) Status::neg_rhou, "Negative rho & U"},
-    {(int) Status::floor, "Floor during inversion"},
-    {(int) Status::bad_velocity, "No velocity solution"}
+enum class Status {
+    success = 0,
+    neg_input,
+    max_iter,
+    bad_ut,
+    bad_gamma,
+    neg_rho,
+    neg_u,
+    neg_rhou,
+    floor,
+    bad_velocity
 };
 
-template <typename T>
+static const std::map<int, std::string> status_names = {
+    {(int)Status::neg_input, "Negative input"}, {(int)Status::max_iter, "Hit max iter"},
+    {(int)Status::bad_ut, "Velocity invalid"}, {(int)Status::bad_gamma, "Gamma invalid"},
+    {(int)Status::neg_rho, "Negative rho"}, {(int)Status::neg_u, "Negative U"},
+    {(int)Status::neg_rhou, "Negative rho & U"},
+    {(int)Status::floor, "Floor during inversion"},
+    {(int)Status::bad_velocity, "No velocity solution"}};
+
+template<typename T>
 KOKKOS_INLINE_FUNCTION bool failed(T status_flag)
 {
     // Return only values >0, among the failure flags
     return static_cast<int>(status_flag) > static_cast<int>(Status::success);
 }
 
-template <typename T>
+template<typename T>
 KOKKOS_INLINE_FUNCTION bool valid(T status_flag)
 {
     // Return only values >0, among the failure flags
@@ -80,24 +87,25 @@ KOKKOS_INLINE_FUNCTION bool valid(T status_flag)
 }
 
 /**
- * Recover local primitive variables, with a one-dimensional Newton-Raphson iterative solver.
- * Iteration starts from the current primitive values, and otherwse may *fail to converge*
+ * Recover local primitive variables, with a one-dimensional Newton-Raphson iterative
+ * solver. Iteration starts from the current primitive values, and otherwse may *fail to
+ * converge*
  *
  * Returns a code indicating whether the solver converged (success), failed (max_iter), or
- * indicating that the converged solution was unphysical (bad_ut, neg_rhou, neg_rho, neg_u)
+ * indicating that the converged solution was unphysical (bad_ut, neg_rhou, neg_rho,
+ * neg_u)
  *
- * On error, will not write replacement values, leaving the previous step's values in place
- * These are fixed later, in FixUtoP
+ * On error, will not write replacement values, leaving the previous step's values in
+ * place These are fixed later, in FixUtoP
  *
  * This is the function template: implementations are filled in in their own headers.
  * Be VERY CAREFUL to define any specializations by including those headers,
  * BEFORE you instantiate the template.
  */
- // TODO macro the arguments. Also can we set recover_velocity default false?
+// TODO macro the arguments. Also can we set recover_velocity default false?
 template<Type inverter>
-KOKKOS_INLINE_FUNCTION int u_to_p(const GRCoordinates& G, const VariablePack<Real>& U, const VarMap& m_u,
-                                              const Real& gam, const int& k, const int& j, const int& i,
-                                              const VariablePack<Real>& P, const VarMap& m_p,
-                                              const Loci& loc, const int& max_iterations, const Real& tol,
-                                              const bool recover_velocity);
+KOKKOS_INLINE_FUNCTION int u_to_p(const GRCoordinates& G, const VariablePack<Real>& U,
+    const VarMap& m_u, const Real& gam, const int& k, const int& j, const int& i,
+    const VariablePack<Real>& P, const VarMap& m_p, const Loci& loc,
+    const int& max_iterations, const Real& tol, const bool recover_velocity);
 } // namespace Inverter

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -40,20 +40,23 @@
 #include "flux.hpp"
 #include "reductions.hpp"
 
-int Inverter::CountPFlags(MeshData<Real> *md)
+int Inverter::CountPFlags(MeshData<Real>* md)
 {
-    return Reductions::CountFlags(md, "pflag", Inverter::status_names, IndexDomain::interior, false)[0];
+    return Reductions::CountFlags(
+        md, "pflag", Inverter::status_names, IndexDomain::interior, false)[0];
 }
 
-std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Inverter::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Inverter");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Inversion scheme.  Could be separate packages but they do share a lot,
     // and could share more e.g. inline floor applications
     std::vector<std::string> allowed_inverter_names = {"none", "onedw", "kastaun"};
-    std::string inverter_name = pin->GetOrAddString("inverter", "type", "kastaun", allowed_inverter_names);
+    std::string inverter_name =
+        pin->GetOrAddString("inverter", "type", "kastaun", allowed_inverter_names);
     bool use_kastaun = false;
     if (inverter_name == "onedw") {
         params.Add("inverter_type", Type::onedw);
@@ -65,43 +68,57 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     }
 
     // Solver options
-    // Any other Noble et al. implemented for fun should use lower tol/iter count, see Noble+06
+    // Any other Noble et al. implemented for fun should use lower tol/iter count, see
+    // Noble+06
     Real err_tol = pin->GetOrAddReal("inverter", "err_tol", (use_kastaun) ? 1e-12 : 1e-8);
     params.Add("err_tol", err_tol);
     int iter_max = pin->GetOrAddInteger("inverter", "iter_max", (use_kastaun) ? 25 : 8);
     params.Add("iter_max", iter_max);
 
     // Floor options
-    // Use a custom block for inverter floors to allow customization.  Not sure anyone *wants* that but...
+    // Use a custom block for inverter floors to allow customization.  Not sure anyone
+    // *wants* that but...
     if (!pin->DoesBlockExist("inverter_floors")) {
         params.Add("inverter_prescription", Floors::MakePrescription(pin, "floors"));
-            if (pin->DoesBlockExist("floors_inner"))
-                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
-            else
-                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
+        if (pin->DoesBlockExist("floors_inner"))
+            params.Add("inverter_prescription_inner",
+                Floors::MakePrescriptionInner(
+                    pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+        else
+            params.Add("inverter_prescription_inner",
+                Floors::MakePrescriptionInner(
+                    pin, Floors::MakePrescription(pin, "floors"), "floors"));
     } else {
-        params.Add("inverter_prescription", Floors::MakePrescription(pin, "inverter_floors"));
-        params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "inverter_floors"), "inverter_floors"));
+        params.Add(
+            "inverter_prescription", Floors::MakePrescription(pin, "inverter_floors"));
+        params.Add("inverter_prescription_inner",
+            Floors::MakePrescriptionInner(pin,
+                Floors::MakePrescription(pin, "inverter_floors"), "inverter_floors"));
     }
 
     // Fixup options
     // Whether to apply Normal frame floors right after the inversion
-    bool apply_floors_with_inversion = pin->GetOrAddBoolean("inverter", "apply_floors_with_inversion", use_kastaun);
+    bool apply_floors_with_inversion =
+        pin->GetOrAddBoolean("inverter", "apply_floors_with_inversion", use_kastaun);
     params.Add("apply_floors_with_inversion", apply_floors_with_inversion);
-    // Tolerance in the momenta before a zone is considered failed and the unsolvable velocity zeroed out
-    // Can't be set individually right now, set == 100*solver_tol
-    // Real bad_vel_tolerance = pin->GetOrAddReal("inverter", "bad_vel_tolerance", 1e-8);
+    // Tolerance in the momenta before a zone is considered failed and the unsolvable
+    // velocity zeroed out Can't be set individually right now, set == 100*solver_tol Real
+    // bad_vel_tolerance = pin->GetOrAddReal("inverter", "bad_vel_tolerance", 1e-8);
     // params.Add("bad_vel_tolerance", bad_vel_tolerance);
 
-    // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun failures are more dire
-    bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
+    // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun
+    // failures are more dire
+    bool fix_average_neighbors =
+        pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
     params.Add("fix_average_neighbors", fix_average_neighbors);
-    // Fix by zeroing the velocity, for particularly nasty zones.  Applied immediately rather than in fixup
-    // Generally you don't want this -- if you're eliminating velocity and therefore momentum, better to
-    // eliminate inertia too by setting floor density/temp
+    // Fix by zeroing the velocity, for particularly nasty zones.  Applied immediately
+    // rather than in fixup Generally you don't want this -- if you're eliminating
+    // velocity and therefore momentum, better to eliminate inertia too by setting floor
+    // density/temp
     bool fix_zero_velocity = pin->GetOrAddBoolean("inverter", "fix_zero_velocity", false);
     params.Add("fix_zero_velocity", fix_zero_velocity);
-    // Fix by replacing with floors, uvec=0. Backstop for states which are just impossible to use
+    // Fix by replacing with floors, uvec=0. Backstop for states which are just impossible
+    // to use
     bool fix_atmosphere = pin->GetOrAddBoolean("inverter", "fix_atmosphere", true);
     params.Add("fix_atmosphere", fix_atmosphere);
 
@@ -111,14 +128,17 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     bool sync_prims = packages->Get("Driver")->Param<bool>("sync_prims");
     Metadata m;
     if (sync_prims && fix_average_neighbors) {
-        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::FillGhost});
+        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
+            Metadata::OneCopy, Metadata::FillGhost});
     } else {
-        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+        m = Metadata(
+            {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
     }
     pkg->AddField("pflag", m);
 
     // When not using floors, we need to declare fflag for ourselves
-    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Overridable});
+    m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy,
+        Metadata::Overridable});
     pkg->AddField("fflag", m);
 
     // This package may be loaded even when evolving implicitly, e.g. for FOFC
@@ -126,10 +146,12 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     if (!pin->GetBoolean("GRMHD", "implicit") || pin->GetBoolean("emhd", "ideal_guess")) {
         // We exist basically to do this
         pkg->BlockUtoP = Inverter::BlockUtoP;
-        // We want to run U->P on most boundaries when we're synchronizing conserved variables
+        // We want to run U->P on most boundaries when we're synchronizing conserved
+        // variables
         pkg->BoundaryUtoP = Inverter::BlockUtoP;
         // However, we apply domain boundaries to primitives.
-        // Registering this additional function conveys that to the callers in `Packages` and `Boundaries`
+        // Registering this additional function conveys that to the callers in `Packages`
+        // and `Boundaries`
         pkg->DomainBoundaryPtoU = Flux::BlockPtoUMHD;
     }
 
@@ -138,9 +160,11 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     // List (vector) of HistoryOutputVars that will all be enrolled as output variables
     parthenon::HstVar_list hst_vars = {};
     // Count total floors as a history item
-    hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, CountPFlags, "PFlags"));
+    hst_vars.emplace_back(
+        parthenon::HistoryOutputVar(UserHistoryOperation::sum, CountPFlags, "PFlags"));
     // TODO entries for each individual flag?
-    // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
+    // add callbacks for HST output to the Params struct, identified by the
+    // `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
     return pkg;
@@ -151,7 +175,8 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
  * This is called with the correct template argument from BlockUtoP
  */
 template<Inverter::Type inverter>
-inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+inline void BlockPerformInversion(
+    MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -163,42 +188,48 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
     auto fflag = rc->PackVariables(std::vector<std::string>{"fflag"});
     auto pflag = rc->PackVariables(std::vector<std::string>{"pflag"});
 
-    if (U.GetDim(4) == 0 || pflag.GetDim(4) == 0)
-        return;
+    if (U.GetDim(4) == 0 || pflag.GetDim(4) == 0) return;
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
-    auto &pars = pmb->packages.Get("Inverter")->AllParams();
+    auto& pars = pmb->packages.Get("Inverter")->AllParams();
     const Real err_tol = pars.Get<Real>("err_tol");
     const int iter_max = pars.Get<int>("iter_max");
-    const bool apply_floors_with_inversion = pars.Get<bool>("apply_floors_with_inversion");
-    //const Real bad_vel_tolerance = pars.Get<Real>("bad_vel_tolerance");
+    const bool apply_floors_with_inversion =
+        pars.Get<bool>("apply_floors_with_inversion");
+    // const Real bad_vel_tolerance = pars.Get<Real>("bad_vel_tolerance");
     const bool fix_zero_velocity = pars.Get<bool>("fix_zero_velocity");
-    const Floors::Prescription inverter_floors       = pars.Get<Floors::Prescription>("inverter_prescription");
-    const Floors::Prescription inverter_floors_inner = pars.Get<Floors::Prescription>("inverter_prescription_inner");
+    const Floors::Prescription inverter_floors =
+        pars.Get<Floors::Prescription>("inverter_prescription");
+    const Floors::Prescription inverter_floors_inner =
+        pars.Get<Floors::Prescription>("inverter_prescription_inner");
 
     // If we set the floors package to use normal frame w/Kastaun inverter, *or*
     // if we disabled the floors package, go ahead and apply all floors in this function
-    const bool normal_frame_floors = (pmb->packages.AllPackages().count("Floors")) ?
-                                        pmb->packages.Get("Floors")->Param<Floors::InjectionFrame>("frame") ==
-                                            Floors::InjectionFrame::normal_kastaun :
-                                        true;
+    const bool normal_frame_floors =
+        (pmb->packages.AllPackages().count("Floors"))
+            ? pmb->packages.Get("Floors")->Param<Floors::InjectionFrame>("frame") ==
+                  Floors::InjectionFrame::normal_kastaun
+            : true;
 
     const auto& G = pmb->coords;
 
     // No floors/floors_inner distinction, TODO?
-    const Real rhoh_denom_max = SQR(inverter_floors.gamma_max) *
-                                m::sqrt(1 - 1 / SQR(inverter_floors.gamma_max));
+    const Real rhoh_denom_max =
+        SQR(inverter_floors.gamma_max) * m::sqrt(1 - 1 / SQR(inverter_floors.gamma_max));
 
     // Get the primitives from our conserved versions
-    // Notice by default, we recover variables for only the physical (interior or interior-ghost)
-    // zones!  These are the only ones which are filled at our point in the step
+    // Notice by default, we recover variables for only the physical (interior or
+    // interior-ghost) zones!  These are the only ones which are filled at our point in
+    // the step
     const IndexRange3 b = (domain == IndexDomain::entire)
-                          ? KDomain::GetPhysicalRange(rc) : KDomain::GetRange(rc, domain, coarse);
+                              ? KDomain::GetPhysicalRange(rc)
+                              : KDomain::GetRange(rc, domain, coarse);
     pmb->par_for("U_to_P", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-            int pflagl = Inverter::u_to_p<inverter>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                    iter_max, err_tol, false);
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
+            int pflagl = Inverter::u_to_p<inverter>(
+                G, U, m_u, gam, k, j, i, P, m_p, Loci::center, iter_max, err_tol, false);
 
             // Apply floors immediately, attempting to correct bad values
             // from either failed or "successful" inversions
@@ -206,44 +237,64 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
                 Real rhoflr_max, uflr_max;
                 int fflagl = 0; // There are no prior floors, reset
                 if (normal_frame_floors) {
-                    fflagl |= Floors::determine_floors(G, P, m_p, gam, k, j, i, inverter_floors, inverter_floors_inner,
-                        rhoflr_max, uflr_max);
+                    fflagl |= Floors::determine_floors(G, P, m_p, gam, k, j, i,
+                        inverter_floors, inverter_floors_inner, rhoflr_max, uflr_max);
                 } else {
-                    // Bare minimum floors for numerics, then we apply the rest in user-selected frame
+                    // Bare minimum floors for numerics, then we apply the rest in
+                    // user-selected frame
                     rhoflr_max = inverter_floors.rho_min_const;
                     uflr_max = inverter_floors.u_min_const;
-                    if (P(m_p.RHO, k, j, i) < rhoflr_max) fflagl |= Floors::FFlag::GEOM_RHO;
+                    if (P(m_p.RHO, k, j, i) < rhoflr_max)
+                        fflagl |= Floors::FFlag::GEOM_RHO;
                     if (P(m_p.UU, k, j, i) < uflr_max) fflagl |= Floors::FFlag::GEOM_U;
                 }
                 if (fflagl) {
                     // Add a floor to density which controls wayward velocities
                     bool used_rho_to_slow = false;
                     if (inverter_floors.use_rho_to_slow) {
-                        //const Real rho = std::max(P(m_p.RHO, k, j, i), rhoflr_max);
-                        //const Real u = std::max(P(m_p.UU, k, j, i), uflr_max);
+                        // const Real rho = std::max(P(m_p.RHO, k, j, i), rhoflr_max);
+                        // const Real u = std::max(P(m_p.UU, k, j, i), uflr_max);
                         const Real rho = P(m_p.RHO, k, j, i);
                         const Real u = P(m_p.UU, k, j, i);
                         const Real rhoh = rho + gam * u;
-                        const Real alpha  = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
+                        const Real alpha =
+                            1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
                         const Real a_over_g = alpha / G.gdet(Loci::center, j, i);
                         Real Scov[3] = {U(m_u.U1, k, j, i) * a_over_g,
-                                        U(m_u.U2, k, j, i) * a_over_g,
-                                        U(m_u.U3, k, j, i) * a_over_g};
+                            U(m_u.U2, k, j, i) * a_over_g, U(m_u.U3, k, j, i) * a_over_g};
                         Real Scon[3];
                         Real gupper[GR_DIM][GR_DIM], glower[GR_DIM][GR_DIM];
                         G.gcon(Loci::center, j, i, gupper);
                         G.gcov(Loci::center, j, i, glower);
-                        Scon[0] = ((gupper[1][1] - gupper[0][1]*gupper[0][1]/gupper[0][0])*Scov[0] +
-                                    (gupper[1][2] - gupper[0][1]*gupper[0][2]/gupper[0][0])*Scov[1] +
-                                    (gupper[1][3] - gupper[0][1]*gupper[0][3]/gupper[0][0])*Scov[2]);
+                        Scon[0] =
+                            ((gupper[1][1] - gupper[0][1] * gupper[0][1] / gupper[0][0]) *
+                                    Scov[0] +
+                                (gupper[1][2] -
+                                    gupper[0][1] * gupper[0][2] / gupper[0][0]) *
+                                    Scov[1] +
+                                (gupper[1][3] -
+                                    gupper[0][1] * gupper[0][3] / gupper[0][0]) *
+                                    Scov[2]);
 
-                        Scon[1] = ((gupper[2][1] - gupper[0][2]*gupper[0][1]/gupper[0][0])*Scov[0] +
-                                    (gupper[2][2] - gupper[0][2]*gupper[0][2]/gupper[0][0])*Scov[1] +
-                                    (gupper[2][3] - gupper[0][2]*gupper[0][3]/gupper[0][0])*Scov[2]);
+                        Scon[1] =
+                            ((gupper[2][1] - gupper[0][2] * gupper[0][1] / gupper[0][0]) *
+                                    Scov[0] +
+                                (gupper[2][2] -
+                                    gupper[0][2] * gupper[0][2] / gupper[0][0]) *
+                                    Scov[1] +
+                                (gupper[2][3] -
+                                    gupper[0][2] * gupper[0][3] / gupper[0][0]) *
+                                    Scov[2]);
 
-                        Scon[2] = ((gupper[3][1] - gupper[0][3]*gupper[0][1]/gupper[0][0])*Scov[0] +
-                                    (gupper[3][2] - gupper[0][3]*gupper[0][2]/gupper[0][0])*Scov[1] +
-                                    (gupper[3][3] - gupper[0][3]*gupper[0][3]/gupper[0][0])*Scov[2]);
+                        Scon[2] =
+                            ((gupper[3][1] - gupper[0][3] * gupper[0][1] / gupper[0][0]) *
+                                    Scov[0] +
+                                (gupper[3][2] -
+                                    gupper[0][3] * gupper[0][2] / gupper[0][0]) *
+                                    Scov[1] +
+                                (gupper[3][3] -
+                                    gupper[0][3] * gupper[0][3] / gupper[0][0]) *
+                                    Scov[2]);
                         Real Ssq = 0.0;
                         SPACELOOP(ii) Ssq += Scon[ii] * Scov[ii];
 
@@ -252,62 +303,68 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
                             fflagl |= Floors::FFlag::INVERTER_GAMMA;
                             // Proportional increases to rho,u preserve temperature
                             // TODO could play with this ratio
-                            P(m_p.RHO, k, j, i) = rho * rhoh_min/rhoh;
-                            P(m_p.UU, k, j, i) = u * rhoh_min/rhoh;
+                            P(m_p.RHO, k, j, i) = rho * rhoh_min / rhoh;
+                            P(m_p.UU, k, j, i) = u * rhoh_min / rhoh;
 
                             Real Bvec[] = {0.0, 0.0, 0.0};
                             SPACELOOP(ii) Bvec[ii] = P(m_u.B1 + ii, k, j, i) * alpha;
                             Real BdotS = 0.;
                             SPACELOOP(ii) BdotS += Bvec[ii] * Scov[ii];
                             Real Bsq = 0.;
-                            SPACELOOP2(ii, jj) Bsq += glower[ii + 1][jj + 1] * Bvec[ii] * Bvec[jj];
+                            SPACELOOP2(ii, jj)
+                            Bsq += glower[ii + 1][jj + 1] * Bvec[ii] * Bvec[jj];
                             Real Sparsq = BdotS * BdotS / Bsq;
                             Real Sperpsq = Ssq - Sparsq;
                             Real Spar[3], Sperp[3];
                             SPACELOOP(ii) Spar[ii] = BdotS * Bvec[ii] / Bsq;
                             SPACELOOP(ii) Sperp[ii] = Scon[ii] - Spar[ii];
 
-                            auto func_W = [&] (Real W) {
+                            auto func_W = [&](Real W)
+                            {
                                 const Real rhohW2 = rhoh_min * W * W;
                                 return Sparsq / SQR(rhohW2) +
-                                Sperpsq / SQR(rhohW2 + Bsq) +
-                                1. / (W * W) - 1.;
+                                       Sperpsq / SQR(rhohW2 + Bsq) + 1. / (W * W) - 1.;
                             };
 
                             Real zm = 1.;
                             Real zp = inverter_floors.gamma_max;
-                            Real z = 0.5*(zm + zp);
+                            Real z = 0.5 * (zm + zp);
 
                             Real fm = func_W(zm);
                             Real fp = func_W(zp);
 
                             bool vel_solve_failed = false;
                             for (int iter = 0; iter < 30; ++iter) {
-                                z =  (zm*fp - zp*fm) / (fp-fm);  // linear interpolation to point f(z)=0
+                                z = (zm * fp - zp * fm) /
+                                    (fp - fm); // linear interpolation to point f(z)=0
                                 Real f = func_W(z);
                                 // Quit if convergence reached
-                                if ((m::abs(f) < 1e-8) || (m::abs(zm-zp) < 1e-10)) {
-                                    // Return failure if 
+                                if ((m::abs(f) < 1e-8) || (m::abs(zm - zp) < 1e-10)) {
+                                    // Return failure if
                                     vel_solve_failed = m::abs(f) > 1e-8;
                                     break;
                                 }
                                 // assign zm-->zp if root bracketed by [z,zp]
-                                if (f*fp < 0.0) {
+                                if (f * fp < 0.0) {
                                     zm = zp;
                                     fm = fp;
                                     zp = z;
                                     fp = f;
-                                } else {  // assign zp-->z if root bracketed by [zm,z]
-                                    fm = 0.5*fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
+                                } else { // assign zp-->z if root bracketed by [zm,z]
+                                    fm = 0.5 * fm; // 1/2 comes from "Illinois algorithm"
+                                                   // to accelerate convergence
                                     zp = z;
                                     fp = f;
                                 }
                             }
 
                             if (!vel_solve_failed) {
-                                SPACELOOP(ii) P(m_p.U1+ii, k, j, i) = z * (Spar[ii] / (rhoh_min * z * z) +
-                                                                        Sperp[ii] / (rhoh_min * z * z + Bsq));
-                                // Even if Kastaun hit max_iter, we managed to reset everything correctly
+                                SPACELOOP(ii)
+                                P(m_p.U1 + ii, k, j, i) =
+                                    z * (Spar[ii] / (rhoh_min * z * z) +
+                                            Sperp[ii] / (rhoh_min * z * z + Bsq));
+                                // Even if Kastaun hit max_iter, we managed to reset
+                                // everything correctly
                                 pflagl = static_cast<int>(Inverter::Status::success);
                                 used_rho_to_slow = true;
                             } else {
@@ -321,9 +378,11 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
                     // If we haven't used floors to adjust the velocity, apply them in NOF
                     if (!used_rho_to_slow) {
                         // Apply floors to P -- this calls inversion again
-                        pflagl = Floors::apply_floors<Floors::InjectionFrame::normal_kastaun>(G, P, m_p, gam, k, j, i,
-                                rhoflr_max, uflr_max, U, m_u);
-                        apply_ceilings(G, P, m_p, gam, k, j, i, inverter_floors, inverter_floors_inner, U, m_u);
+                        pflagl =
+                            Floors::apply_floors<Floors::InjectionFrame::normal_kastaun>(
+                                G, P, m_p, gam, k, j, i, rhoflr_max, uflr_max, U, m_u);
+                        apply_ceilings(G, P, m_p, gam, k, j, i, inverter_floors,
+                            inverter_floors_inner, U, m_u);
                     }
                 }
 
@@ -331,8 +390,8 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
                 if (pflagl == static_cast<int>(Inverter::Status::floor)) {
                     fflagl |= Floors::FFlag::INVERTER_GAMMA;
                     pflagl = static_cast<int>(Inverter::Status::success);
-                // If we failed to recover the velocity, optionally zero it here
-                // otherwise it will just get set to atmosphere later
+                    // If we failed to recover the velocity, optionally zero it here
+                    // otherwise it will just get set to atmosphere later
                 } else if (fix_zero_velocity &&
                            pflagl == static_cast<int>(Inverter::Status::bad_velocity)) {
                     P(m_p.U1, k, j, i) = 0.;
@@ -342,8 +401,8 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
                 }
                 // If we applied floors but we won't fix later, update U
                 if (fflagl && !pflagl) {
-                    // This is explicitly a GRMHD-only function, we don't need to account for
-                    // EMHD here.  Also this is done next anyway in the KHARMA driver,
+                    // This is explicitly a GRMHD-only function, we don't need to account
+                    // for EMHD here.  Also this is done next anyway in the KHARMA driver,
                     // but we want to eventually remove that function.
                     GRMHD::p_to_u(G, P, m_p, gam, k, j, i, U, m_u, Loci::center);
                 }
@@ -351,31 +410,35 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
                 fflag(0, k, j, i) = fflagl;
             }
 
-            // If we're applying floors, record the *post-floor* flag since we only care if that failed
+            // If we're applying floors, record the *post-floor* flag since we only care
+            // if that failed
             pflag(0, k, j, i) = pflagl;
-        }
-    );
+        });
 }
 
-void Inverter::BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
+void Inverter::BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse)
 {
-    // This only chooses an implementation.  See BlockPerformInversion and implementations e.g. onedw.hpp
-    auto& type = rc->GetBlockPointer()->packages.Get("Inverter")->Param<Type>("inverter_type");
-    switch(type) {
-    case Type::onedw:
-        BlockPerformInversion<Type::onedw>(rc, domain, coarse);
-        break;
-    case Type::kastaun:
-        BlockPerformInversion<Type::kastaun>(rc, domain, coarse);
-        break;
-    case Type::none:
-        break;
+    // This only chooses an implementation.  See BlockPerformInversion and implementations
+    // e.g. onedw.hpp
+    auto& type =
+        rc->GetBlockPointer()->packages.Get("Inverter")->Param<Type>("inverter_type");
+    switch (type) {
+        case Type::onedw:
+            BlockPerformInversion<Type::onedw>(rc, domain, coarse);
+            break;
+        case Type::kastaun:
+            BlockPerformInversion<Type::kastaun>(rc, domain, coarse);
+            break;
+        case Type::none:
+            break;
     }
-    // This is dangerous since there are many blocks/packs and we need one reduction. For later.
-    //Reductions::StartFlagReduce(md, "pflag", Inverter::status_names, IndexDomain::interior, false, 1);
+    // This is dangerous since there are many blocks/packs and we need one reduction. For
+    // later.
+    // Reductions::StartFlagReduce(md, "pflag", Inverter::status_names,
+    // IndexDomain::interior, false, 1);
 }
 
-TaskStatus Inverter::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
+TaskStatus Inverter::PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md)
 {
     auto pmesh = md->GetMeshPointer();
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
@@ -387,14 +450,18 @@ TaskStatus Inverter::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)
     // TODO grab the total and die on too many
     if (flag_verbose >= 1) {
         // TODO this should move into UtoP when everything goes MeshData
-        Reductions::StartFlagReduce(md, "pflag", Inverter::status_names, IndexDomain::interior, false, 1);
-        Reductions::CheckFlagReduceAndPrintHits(md, "pflag", Inverter::status_names, IndexDomain::interior, false, 1);
+        Reductions::StartFlagReduce(
+            md, "pflag", Inverter::status_names, IndexDomain::interior, false, 1);
+        Reductions::CheckFlagReduceAndPrintHits(
+            md, "pflag", Inverter::status_names, IndexDomain::interior, false, 1);
 
         // If we're the only floors, print those too
         if (!pmesh->packages.AllPackages().count("Floors")) {
-            Reductions::StartFlagReduce(md, "fflag", Floors::FFlag::flag_names, IndexDomain::interior, true, 0);
+            Reductions::StartFlagReduce(
+                md, "fflag", Floors::FFlag::flag_names, IndexDomain::interior, true, 0);
             // Debugging/diagnostic info about floors
-            Reductions::CheckFlagReduceAndPrintHits(md, "fflag", Floors::FFlag::flag_names, IndexDomain::interior, true, 0);
+            Reductions::CheckFlagReduceAndPrintHits(
+                md, "fflag", Floors::FFlag::flag_names, IndexDomain::interior, true, 0);
         }
     }
 

--- a/kharma/inverter/inverter.hpp
+++ b/kharma/inverter/inverter.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: inverter.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,8 +39,8 @@
 // Implementation of u_to_p must be defined before instantiation below
 // Additionally, invert_template contains the Type and Status enums
 #include "invert_template.hpp"
-#include "onedw.hpp"
 #include "kastaun.hpp"
+#include "onedw.hpp"
 
 #include "pack.hpp"
 
@@ -51,39 +51,44 @@ using namespace parthenon;
  * Currently can only use the 1D_W scheme of Noble et al. (2006),
  * but this is the spot for alternate implementations
  */
-namespace Inverter {
+namespace Inverter
+{
 
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Get the primitive variables
  * This just computes P, and only for the GRHD fluid varaibles rho, u, uvec.
  *
- * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost zones.
- * 
+ * Defaults to entire domain, as the KHARMA algorithm relies on applying UtoP over ghost
+ * zones.
+ *
  * input: U, whatever form
  * output: U and P match down to inversion errors
  */
-void BlockUtoP(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse);
-inline TaskStatus MeshUtoP(MeshData<Real> *md, IndexDomain domain, bool coarse) {
+void BlockUtoP(MeshBlockData<Real>* rc, IndexDomain domain, bool coarse);
+inline TaskStatus MeshUtoP(MeshData<Real>* md, IndexDomain domain, bool coarse)
+{
     Flag("MeshUtoP");
-    for (int i=0; i < md->NumBlocks(); ++i)
+    for (int i = 0; i < md->NumBlocks(); ++i)
         BlockUtoP(md->GetBlockData(i).get(), domain, coarse);
     EndFlag();
     return TaskStatus::complete;
 }
 
 /**
- * Smooth over inversion failures, usually by averaging values of the primitive variables from each neighboring zone
- * a.k.a. Diffusion?  What diffusion?  There is no diffusion here.
- * 
+ * Smooth over inversion failures, usually by averaging values of the primitive variables
+ * from each neighboring zone a.k.a. Diffusion?  What diffusion?  There is no diffusion
+ * here.
+ *
  * LOCKSTEP: this function expects and should preserve P<->U
  */
-TaskStatus FixUtoP(MeshBlockData<Real> *rc);
-inline TaskStatus MeshFixUtoP(MeshData<Real> *md) {
+TaskStatus FixUtoP(MeshBlockData<Real>* rc);
+inline TaskStatus MeshFixUtoP(MeshData<Real>* md)
+{
     Flag("MeshFixUtoP");
-    for (int i=0; i < md->NumBlocks(); ++i)
-        FixUtoP(md->GetBlockData(i).get());
+    for (int i = 0; i < md->NumBlocks(); ++i) FixUtoP(md->GetBlockData(i).get());
     EndFlag();
     return TaskStatus::complete;
 }
@@ -91,11 +96,11 @@ inline TaskStatus MeshFixUtoP(MeshData<Real> *md) {
 /**
  * Count up all nonzero PFlags on md.  Used for history file reductions.
  */
-int CountPFlags(MeshData<Real> *md);
+int CountPFlags(MeshData<Real>* md);
 
 /**
  * Print details of any inversion failures or fixed zones
  */
-TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md);
+TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real>* md);
 
 }

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -53,16 +53,16 @@
 // Robust primitive variable recovery as described in Kastaun et al. (2020)
 // IMPORTANT: The following functions are stolen directly from:
 // Phoebus: https://github.com/lanl/phoebus (con2prim_robust.hpp)
-// AthenaK: https://gitlab.com/theias/hpc/jmstone/athena-parthenon/athenak (ideal_c2p_mhd.hpp)
-// They have been lightly adapted to fit into KHARMA,
-// and hopefully original authors should be clear from comments
+// AthenaK: https://gitlab.com/theias/hpc/jmstone/athena-parthenon/athenak
+// (ideal_c2p_mhd.hpp) They have been lightly adapted to fit into KHARMA, and hopefully
+// original authors should be clear from comments
 
 // General template
 // We define a specialization based on the Inverter::Type parameter
 #include "invert_template.hpp"
 
 #include "coordinate_utils.hpp"
-//#include "floors_functions.hpp"
+// #include "floors_functions.hpp"
 #include "grmhd_functions.hpp"
 #include "kharma_utils.hpp"
 
@@ -72,109 +72,118 @@
 #define SPACELOOP2(i, j) SPACELOOP(i) SPACELOOP(j)
 #define SPACETIMELOOP(mu) for (int mu = 0; mu < GR_DIM; mu++)
 
-namespace Inverter {
+namespace Inverter
+{
 
 /**
  * Residual class from Phoebus.
  * Caches function arguments which won't change during solve
  */
-class KastaunResidual {
-    public:
-        KOKKOS_FUNCTION
-        KastaunResidual(const Real &D, const Real &q, const Real &bsq, const Real &bsq_rpsq,
-                const Real &rsq, const Real &rbsq, const Real &v0sq, const Real &gam)
-            : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq),
-            rsq_(rsq), rbsq_(rbsq), v0sq_(v0sq), gam_(gam) {}
+class KastaunResidual
+{
+  public:
+    KOKKOS_FUNCTION
+    KastaunResidual(const Real& D, const Real& q, const Real& bsq, const Real& bsq_rpsq,
+        const Real& rsq, const Real& rbsq, const Real& v0sq, const Real& gam)
+        : D_(D)
+        , q_(q)
+        , bsq_(bsq)
+        , bsq_rpsq_(bsq_rpsq)
+        , rsq_(rsq)
+        , rbsq_(rbsq)
+        , v0sq_(v0sq)
+        , gam_(gam)
+    {}
 
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real x_mu(const Real mu)
-        {
-            return 1.0 / (1.0 + mu * bsq_);
-        }
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real rbarsq_mu(const Real mu, const Real x) {
-            return x * (x * rsq_ + mu * (1.0 + x) * rbsq_);
-        }
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real qbar_mu(const Real mu, const Real x) {
-            const Real mux = mu * x;
-            return q_ - 0.5 * (bsq_ + mux * mux * bsq_rpsq_);
-        }
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real vhatsq_mu(const Real mu, const Real rbarsq) {
-            return std::min(mu * mu * rbarsq, v0sq_);
-        }
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real iWhat_mu(const Real vhatsq)
-        {
-            return std::sqrt(1.0 - vhatsq);
-        }
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real rhohat_mu(const Real iWhat) {
-            return D_ * iWhat;
-        }
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
-                    const Real What)
-        {
-            return What * (qbar - mu * rbarsq) + vhatsq * What * What / (1.0 + What);
-        }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real x_mu(const Real mu) { return 1.0 / (1.0 + mu * bsq_); }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real rbarsq_mu(const Real mu, const Real x)
+    {
+        return x * (x * rsq_ + mu * (1.0 + x) * rbsq_);
+    }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real qbar_mu(const Real mu, const Real x)
+    {
+        const Real mux = mu * x;
+        return q_ - 0.5 * (bsq_ + mux * mux * bsq_rpsq_);
+    }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real vhatsq_mu(const Real mu, const Real rbarsq)
+    {
+        return std::min(mu * mu * rbarsq, v0sq_);
+    }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real iWhat_mu(const Real vhatsq) { return std::sqrt(1.0 - vhatsq); }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real rhohat_mu(const Real iWhat) { return D_ * iWhat; }
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
+        const Real What)
+    {
+        return What * (qbar - mu * rbarsq) + vhatsq * What * What / (1.0 + What);
+    }
 
-        // Evaluate residual at a value of mu.
-        // Kastaun eqn 44
-        KOKKOS_INLINE_FUNCTION
-        Real operator()(const Real mu) {
-            const Real x = x_mu(mu);
-            const Real rbarsq = rbarsq_mu(mu, x);
-            const Real qbar = qbar_mu(mu, x);
-            const Real vhatsq = vhatsq_mu(mu, rbarsq);
-            const Real iWhat = iWhat_mu(vhatsq);
-            const Real What = 1.0 / iWhat;
-            const Real rhohat = std::max(rhohat_mu(iWhat), 0.);
-            const Real ehat = std::max(ehat_mu(mu, qbar, rbarsq, vhatsq, What), 0.);
-            // TODO this is ideal-only
-            const Real Phat = ehat * rhohat * (gam_ - 1.0);
-            const Real ahat = Phat / (rhohat * (1.0 + ehat));
+    // Evaluate residual at a value of mu.
+    // Kastaun eqn 44
+    KOKKOS_INLINE_FUNCTION
+    Real operator()(const Real mu)
+    {
+        const Real x = x_mu(mu);
+        const Real rbarsq = rbarsq_mu(mu, x);
+        const Real qbar = qbar_mu(mu, x);
+        const Real vhatsq = vhatsq_mu(mu, rbarsq);
+        const Real iWhat = iWhat_mu(vhatsq);
+        const Real What = 1.0 / iWhat;
+        const Real rhohat = std::max(rhohat_mu(iWhat), 0.);
+        const Real ehat = std::max(ehat_mu(mu, qbar, rbarsq, vhatsq, What), 0.);
+        // TODO this is ideal-only
+        const Real Phat = ehat * rhohat * (gam_ - 1.0);
+        const Real ahat = Phat / (rhohat * (1.0 + ehat));
 
-            const Real nua = (1.0 + ahat) * (1.0 + ehat) * iWhat;
-            const Real nub = (1.0 + ahat) * (1.0 + qbar - mu * rbarsq);
-            const Real nuhat = std::max(nua, nub);
+        const Real nua = (1.0 + ahat) * (1.0 + ehat) * iWhat;
+        const Real nub = (1.0 + ahat) * (1.0 + qbar - mu * rbarsq);
+        const Real nuhat = std::max(nua, nub);
 
-            const Real muhat = 1.0 / (nuhat + mu * rbarsq);
-            return mu - muhat;
-        }
+        const Real muhat = 1.0 / (nuhat + mu * rbarsq);
+        return mu - muhat;
+    }
 
-        // Residual for finding bracket values
-        // Kastaun eqn 49
-        KOKKOS_FORCEINLINE_FUNCTION
-        Real aux_func(const Real mu) {
-            const Real x = 1.0 / (1.0 + mu * bsq_);
-            const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
-            return mu * std::sqrt(1.0 + rbarsq) - 1.0;
-        }
+    // Residual for finding bracket values
+    // Kastaun eqn 49
+    KOKKOS_FORCEINLINE_FUNCTION
+    Real aux_func(const Real mu)
+    {
+        const Real x = 1.0 / (1.0 + mu * bsq_);
+        const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
+        return mu * std::sqrt(1.0 + rbarsq) - 1.0;
+    }
 
-    private:
-        const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_, gam_;
+  private:
+    const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_, gam_;
 };
 
 /**
  * Robust inversion scheme from Kastaun et al. 2020
- * Unholy mashup of the transformation/equations from Phoebus (which are coordinate-general),
- * and the solver from AthenaK (which is easier to read and precomputes the bracket)
+ * Unholy mashup of the transformation/equations from Phoebus (which are
+ * coordinate-general), and the solver from AthenaK (which is easier to read and
+ * precomputes the bracket)
  * TODO keep mu between calls to speed up convergence
- * TODO better returns: be explicit about pre- and post-inversion floors, cat neg_input too
+ * TODO better returns: be explicit about pre- and post-inversion floors, cat neg_input
+ * too
  */
-template <>
-KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const VariablePack<Real>& U, const VarMap& m_u,
-                                              const Real& gam, const int& k, const int& j, const int& i,
-                                              const VariablePack<Real>& P, const VarMap& m_p,
-                                              const Loci& loc, const int& max_iterations, const Real& tol,
-                                              const bool recover_velocity)
+template<>
+KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G,
+    const VariablePack<Real>& U, const VarMap& m_u, const Real& gam, const int& k,
+    const int& j, const int& i, const VariablePack<Real>& P, const VarMap& m_p,
+    const Loci& loc, const int& max_iterations, const Real& tol,
+    const bool recover_velocity)
 {
     // Shouldn't need this, KHARMA should die on NaN
     // But it's here for debugging
-    // int num_nans = std::isnan(U(m_u.RHO, k, j, i)) + std::isnan(U(m_u.U1, k, j, i)) + std::isnan(U(m_u.UU, k, j, i));
-    // if (num_nans > 0) return static_cast<int>(Status::neg_input);
+    // int num_nans = std::isnan(U(m_u.RHO, k, j, i)) + std::isnan(U(m_u.U1, k, j, i)) +
+    // std::isnan(U(m_u.UU, k, j, i)); if (num_nans > 0) return
+    // static_cast<int>(Status::neg_input);
 
     // This exists only to keep the math stable on first call,
     // so we can add floors instead of failing outright
@@ -183,26 +192,24 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     }
 
     // Transform GRMHD variables for the SRMHD Kastaun solver
-    const Real alpha  = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
+    const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
     const Real a_over_g = alpha / G.gdet(loc, j, i);
 
-    const Real &Urho = U(m_u.RHO, k, j, i);
+    const Real& Urho = U(m_u.RHO, k, j, i);
     const Real D = Urho * a_over_g;
 
     Real Qcov[GR_DIM] = {(U(m_u.UU, k, j, i) - Urho) * a_over_g,
-                    U(m_u.U1, k, j, i) * a_over_g,
-                    U(m_u.U2, k, j, i) * a_over_g,
-                    U(m_u.U3, k, j, i) * a_over_g};
+        U(m_u.U1, k, j, i) * a_over_g, U(m_u.U2, k, j, i) * a_over_g,
+        U(m_u.U3, k, j, i) * a_over_g};
 
-    const Real ncov[GR_DIM] = {(Real) -alpha, 0., 0., 0.};
+    const Real ncov[GR_DIM] = {(Real)-alpha, 0., 0., 0.};
     Real ncon[GR_DIM];
     G.raise(ncov, ncon, k, j, i, loc);
     const Real q = (-dot(Qcov, ncon) - D) / D; // TODO floor on this?
 
     // r_i
-    Real rcov[3] = {U(m_u.U1, k, j, i) / Urho,
-                    U(m_u.U2, k, j, i) / Urho,
-                    U(m_u.U3, k, j, i) / Urho};
+    Real rcov[3] = {
+        U(m_u.U1, k, j, i) / Urho, U(m_u.U2, k, j, i) / Urho, U(m_u.U3, k, j, i) / Urho};
     Real rcon[3];
     Real gupper[GR_DIM][GR_DIM];
     G.gcon(loc, j, i, gupper);
@@ -212,20 +219,23 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     //       g^0i = beta^i/alpha^2
     //       g^00 = -1/ alpha^2
     // Hence gamma^ij =  g^ij - g^0i g^0j/g^00
-    rcon[0] = ((gupper[1][1] - gupper[0][1]*gupper[0][1]/gupper[0][0])*rcov[0] +
-                (gupper[1][2] - gupper[0][1]*gupper[0][2]/gupper[0][0])*rcov[1] +
-                (gupper[1][3] - gupper[0][1]*gupper[0][3]/gupper[0][0])*rcov[2]);  // (C26)
+    rcon[0] = ((gupper[1][1] - gupper[0][1] * gupper[0][1] / gupper[0][0]) * rcov[0] +
+               (gupper[1][2] - gupper[0][1] * gupper[0][2] / gupper[0][0]) * rcov[1] +
+               (gupper[1][3] - gupper[0][1] * gupper[0][3] / gupper[0][0]) *
+                   rcov[2]); // (C26)
 
-    rcon[1] = ((gupper[2][1] - gupper[0][2]*gupper[0][1]/gupper[0][0])*rcov[0] +
-                (gupper[2][2] - gupper[0][2]*gupper[0][2]/gupper[0][0])*rcov[1] +
-                (gupper[2][3] - gupper[0][2]*gupper[0][3]/gupper[0][0])*rcov[2]);  // (C26)
+    rcon[1] = ((gupper[2][1] - gupper[0][2] * gupper[0][1] / gupper[0][0]) * rcov[0] +
+               (gupper[2][2] - gupper[0][2] * gupper[0][2] / gupper[0][0]) * rcov[1] +
+               (gupper[2][3] - gupper[0][2] * gupper[0][3] / gupper[0][0]) *
+                   rcov[2]); // (C26)
 
-    rcon[2] = ((gupper[3][1] - gupper[0][3]*gupper[0][1]/gupper[0][0])*rcov[0] +
-                (gupper[3][2] - gupper[0][3]*gupper[0][2]/gupper[0][0])*rcov[1] +
-                (gupper[3][3] - gupper[0][3]*gupper[0][3]/gupper[0][0])*rcov[2]);  // (C26)
+    rcon[2] = ((gupper[3][1] - gupper[0][3] * gupper[0][1] / gupper[0][0]) * rcov[0] +
+               (gupper[3][2] - gupper[0][3] * gupper[0][2] / gupper[0][0]) * rcov[1] +
+               (gupper[3][3] - gupper[0][3] * gupper[0][3] / gupper[0][0]) *
+                   rcov[2]); // (C26)
 
     Real rsq = 0.0;
-    SPACELOOP(ii) rsq += rcon[ii]*rcov[ii];
+    SPACELOOP(ii) rsq += rcon[ii] * rcov[ii];
 
     Real bsq = 0.0;
     Real bsq_rpsq = 0.0;
@@ -236,7 +246,8 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     if (m_u.B1 >= 0) {
         const Real sD = 1.0 / m::sqrt(D);
         // b^i
-        SPACELOOP(ii) {
+        SPACELOOP(ii)
+        {
             bu[ii] = (U(m_u.B1 + ii, k, j, i) * a_over_g) * sD;
             bdotr += bu[ii] * rcov[ii];
         }
@@ -246,7 +257,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
         rbsq = bdotr * bdotr;
         bsq_rpsq = bsq * rsq - rbsq;
     }
-    //const Real zsq = rsq / h0sq_; // h0sq_ normalization set to 1 in Phoebus
+    // const Real zsq = rsq / h0sq_; // h0sq_ normalization set to 1 in Phoebus
     const Real zsq = rsq;
     const Real v0sq = std::min(zsq / (1.0 + zsq), 1.0 - 1.0 / SQR(51.));
 
@@ -254,7 +265,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     KastaunResidual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, gam);
 
     // SOLVE
-    // TODO(BSP) better or faster solver?  (Optionally) skip bracketing?
+    // TODO(CEP) better or faster solver?  (Optionally) skip bracketing?
     // Need to find initial bracket. Requires separate solve
     Real zm = 0.;
     Real zp = 1.; // This is the lowest specific enthalpy admitted by the EOS
@@ -266,28 +277,29 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     // For simplicity on the GPU, find roots using the false position method
     int iterations = max_iterations;
     // If bracket within tolerances, don't bother doing any iterations
-    if ((m::abs(zm-zp) < tol) || ((m::abs(fm) + m::abs(fp)) < 2.0*tol)) {
+    if ((m::abs(zm - zp) < tol) || ((m::abs(fm) + m::abs(fp)) < 2.0 * tol)) {
         iterations = -1;
     }
-    Real z = 0.5*(zm + zp);
+    Real z = 0.5 * (zm + zp);
 
     int iter;
     for (iter = 0; iter < iterations; ++iter) {
-        z =  (zm*fp - zp*fm)/(fp-fm);  // linear interpolation to point f(z)=0
+        z = (zm * fp - zp * fm) / (fp - fm); // linear interpolation to point f(z)=0
         Real f = res.aux_func(z);
         // Quit if convergence reached
         // NOTE(@ermost): both z and f are of order unity
-        if ((m::abs(zm-zp) < tol) || (m::abs(f) < tol)) {
+        if ((m::abs(zm - zp) < tol) || (m::abs(f) < tol)) {
             break;
         }
         // assign zm-->zp if root bracketed by [z,zp]
-        if (f*fp < 0.0) {
+        if (f * fp < 0.0) {
             zm = zp;
             fm = fp;
             zp = z;
             fp = f;
-        } else {  // assign zp-->z if root bracketed by [zm,z]
-            fm = 0.5*fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
+        } else { // assign zp-->z if root bracketed by [zm,z]
+            fm =
+                0.5 * fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
             zp = z;
             fp = f;
         }
@@ -303,27 +315,28 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     fp = res(zp);
 
     iterations = max_iterations;
-    if ((m::abs(zm-zp) < tol) || ((m::abs(fm) + m::abs(fp)) < 2.0*tol)) {
+    if ((m::abs(zm - zp) < tol) || ((m::abs(fm) + m::abs(fp)) < 2.0 * tol)) {
         iterations = -1;
     }
-    z = 0.5*(zm + zp);
+    z = 0.5 * (zm + zp);
 
     for (iter = 0; iter < iterations; ++iter) {
-        z = (zm*fp - zp*fm)/(fp-fm);  // linear interpolation to point f(z)=0
+        z = (zm * fp - zp * fm) / (fp - fm); // linear interpolation to point f(z)=0
         Real f = res(z);
         // Quit if convergence reached
         // NOTE: both z and f are of order unity
-        if ((m::abs(zm-zp) < tol) || (m::abs(f) < tol)) {
+        if ((m::abs(zm - zp) < tol) || (m::abs(f) < tol)) {
             break;
         }
         // assign zm-->zp if root bracketed by [z,zp]
-        if (f*fp < 0.0) {
+        if (f * fp < 0.0) {
             zm = zp;
             fm = fp;
             zp = z;
             fp = f;
-        } else {  // assign zp-->z if root bracketed by [zm,z]
-            fm = 0.5*fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
+        } else { // assign zp-->z if root bracketed by [zm,z]
+            fm =
+                0.5 * fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
             zp = z;
             fp = f;
         }
@@ -341,28 +354,39 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     // These values should be as *raw* as possible, whether or not they respect the floors
     // (or even physics).  We will add material and try again if they're bad
     P(m_p.RHO, k, j, i) = std::max(res.rhohat_mu(iW), 0.);
-    P(m_p.UU, k, j, i) = std::max(res.ehat_mu(mu, qbar, rbarsq, vsq, W) * P(m_p.RHO, k, j, i), 0.);
+    P(m_p.UU, k, j, i) =
+        std::max(res.ehat_mu(mu, qbar, rbarsq, vsq, W) * P(m_p.RHO, k, j, i), 0.);
     // TODO make sure W*mu*x really should be >0
     // Latter part is a vector/signed quantity, don't set a minimum at 0
-    SPACELOOP(ii) P(m_p.U1 + ii, k, j, i) = std::max(W * mu * x, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
+    SPACELOOP(ii)
+    P(m_p.U1 + ii, k, j, i) = std::max(W * mu * x, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
 
-    // If we should try to recover velocity, do it in this function to re-use the residual object
+    // If we should try to recover velocity, do it in this function to re-use the residual
+    // object
     if (!recover_velocity) {
-        // Mark for fix only if convergence is not established within max_iterations (should be *extremely* rare)
-        return (iter < max_iterations) ? static_cast<int>(Status::success) : static_cast<int>(Status::max_iter);
+        // Mark for fix only if convergence is not established within max_iterations
+        // (should be *extremely* rare)
+        return (iter < max_iterations) ? static_cast<int>(Status::success)
+                                       : static_cast<int>(Status::max_iter);
     } else {
         // Calculate P->U on the inverted values
         const Real rho = P(m_p.RHO, k, j, i);
         const Real u = P(m_p.UU, k, j, i);
-        const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
-        const Real B_P[NVEC] = {P(m_p.B1, k, j, i), P(m_p.B2, k, j, i), P(m_p.B3, k, j, i)};
+        const Real uvec[NVEC] = {
+            P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
+        const Real B_P[NVEC] = {
+            P(m_p.B1, k, j, i), P(m_p.B2, k, j, i), P(m_p.B3, k, j, i)};
         Real rho_ut = 0., T[GR_DIM] = {0.};
         GRMHD::p_to_u_mhd(G, rho, u, uvec, B_P, gam, k, j, i, rho_ut, T);
         const Real bad_vel_tolerance = 200 * tol;
-        // If we didn't conserve momentum within a loose tolerance based on the solver tol...
-        if ((std::abs((T[1] - U(m_u.U1, k, j, i)) / U(m_u.U1, k, j, i)) > bad_vel_tolerance) ||
-            (std::abs((T[2] - U(m_u.U2, k, j, i)) / U(m_u.U2, k, j, i)) > bad_vel_tolerance) ||
-            (std::abs((T[3] - U(m_u.U3, k, j, i)) / U(m_u.U3, k, j, i)) > bad_vel_tolerance)) {
+        // If we didn't conserve momentum within a loose tolerance based on the solver
+        // tol...
+        if ((std::abs((T[1] - U(m_u.U1, k, j, i)) / U(m_u.U1, k, j, i)) >
+                bad_vel_tolerance) ||
+            (std::abs((T[2] - U(m_u.U2, k, j, i)) / U(m_u.U2, k, j, i)) >
+                bad_vel_tolerance) ||
+            (std::abs((T[3] - U(m_u.U3, k, j, i)) / U(m_u.U3, k, j, i)) >
+                bad_vel_tolerance)) {
 
             // ...then solve so function ehat(mu) Kastaun matches the existing value,
             // and use that to reset the velocities.
@@ -370,15 +394,14 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
             // but dumps any extra back into the velocities to be less disruptive.
             // TODO either set this on better theory or redo the algebra and condense it
             const Real e_actual = P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
-            auto f = [&] (Real mu) {
+            auto f = [&](Real mu)
+            {
                 Real x = res.x_mu(mu);
                 Real rbarsq = res.rbarsq_mu(mu, x);
                 Real vsq = res.vhatsq_mu(mu, rbarsq);
                 Real W = 1. / res.iWhat_mu(vsq);
                 Real qbar = res.qbar_mu(mu, x);
-                return (W * (qbar - mu * rbarsq) + vsq * W * W /
-                            (1.0 + W))
-                        - e_actual;
+                return (W * (qbar - mu * rbarsq) + vsq * W * W / (1.0 + W)) - e_actual;
             };
 
             // Rootfind for mu that would have produced the current e
@@ -409,8 +432,11 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
             const Real vsq = res.vhatsq_mu(mu, rbarsq);
             const Real iW = res.iWhat_mu(vsq);
             const Real W = 1.0 / iW;
-            SPACELOOP(ii) P(m_p.U1 + ii, k, j, i) = std::max(W * mu * x, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
-            return (e_solve_failed) ? static_cast<int>(Status::bad_velocity) : static_cast<int>(Status::floor);
+            SPACELOOP(ii)
+            P(m_p.U1 + ii, k, j, i) =
+                std::max(W * mu * x, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
+            return (e_solve_failed) ? static_cast<int>(Status::bad_velocity)
+                                    : static_cast<int>(Status::floor);
         } else {
             return static_cast<int>(Status::success);
         }

--- a/kharma/inverter/onedw.hpp
+++ b/kharma/inverter/onedw.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: onedw.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,14 +40,16 @@
 #include "grmhd_functions.hpp"
 #include "kharma_utils.hpp"
 
-namespace Inverter {
+namespace Inverter
+{
 
 // Could put support fns in their own namespace, but I'm lazy
 /**
- * Fluid relativistic factor gamma in terms of inversion state variables of the Noble 1D_W inverter
+ * Fluid relativistic factor gamma in terms of inversion state variables of the Noble 1D_W
+ * inverter
  */
-KOKKOS_INLINE_FUNCTION Real lorentz_calc_w(const Real& Bsq, const Real& D, const Real& QdB,
-                                           const Real& Qtsq, const Real& Wp)
+KOKKOS_INLINE_FUNCTION Real lorentz_calc_w(
+    const Real& Bsq, const Real& D, const Real& QdB, const Real& Qtsq, const Real& Wp)
 {
     const Real QdBsq = QdB * QdB;
     const Real W = Wp + D;
@@ -55,7 +57,8 @@ KOKKOS_INLINE_FUNCTION Real lorentz_calc_w(const Real& Bsq, const Real& D, const
     const Real WB = W + Bsq;
 
     // This is basically inversion of eq. A7 of Mignone & McKinney
-    const Real utsq = -((W + WB) * QdBsq + W2 * Qtsq) / (QdBsq * (W + WB) + W2 * (Qtsq - WB * WB));
+    const Real utsq =
+        -((W + WB) * QdBsq + W2 * Qtsq) / (QdBsq * (W + WB) + W2 * (Qtsq - WB * WB));
 
     // Catch utsq < 0 and YELL
     // Latter number should be about ~1e3*GAMMAMAX^2, but obvs doesn't need to be precise
@@ -69,39 +72,38 @@ KOKKOS_INLINE_FUNCTION Real lorentz_calc_w(const Real& Bsq, const Real& D, const
 /**
  * Error metric for Newton-Raphson step in Noble 1D_W inverter
  */
-KOKKOS_INLINE_FUNCTION Real err_eqn(const Real& gam, const Real& Bsq, const Real& D, const Real& Ep, const Real& QdB,
-                                    const Real& Qtsq, const Real& Wp, Status& eflag)
+KOKKOS_INLINE_FUNCTION Real err_eqn(const Real& gam, const Real& Bsq, const Real& D,
+    const Real& Ep, const Real& QdB, const Real& Qtsq, const Real& Wp, Status& eflag)
 {
     const Real W = Wp + D;
     const Real gamma = lorentz_calc_w(Bsq, D, QdB, Qtsq, Wp);
     if (gamma < 1) eflag = Status::bad_ut;
-    const Real w = W / (gamma*gamma);
+    const Real w = W / (gamma * gamma);
     const Real rho = D / gamma;
     const Real p = (w - rho) * (gam - 1) / gam;
 
     return -Ep + Wp - p + 0.5 * Bsq + 0.5 * (Bsq * Qtsq - QdB * QdB) / SQR(Bsq + W);
-
 }
 
 /**
  * 1D_W inverter from Ressler et al. 2006.
  */
-template <>
-KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const VariablePack<Real>& U, const VarMap& m_u,
-                                              const Real& gam, const int& k, const int& j, const int& i,
-                                              const VariablePack<Real>& P, const VarMap& m_p,
-                                              const Loci& loc, const int& max_iterations, const Real& tol,
-                                              const bool recover_velocity)
+template<>
+KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G,
+    const VariablePack<Real>& U, const VarMap& m_u, const Real& gam, const int& k,
+    const int& j, const int& i, const VariablePack<Real>& P, const VarMap& m_p,
+    const Loci& loc, const int& max_iterations, const Real& tol,
+    const bool recover_velocity)
 {
     // TODO try inline floors in the old 1Dw?  Probably not relevant anymore
     // Catch negative density
-    // TODO(BSP) if we start to see this hit, fix it here by returning P=P_floors
+    // TODO(CEP) if we start to see this hit, fix it here by returning P=P_floors
     if (U(m_u.RHO, k, j, i) <= 0.) {
         return static_cast<int>(Status::neg_input);
     }
 
     // Convert from conserved variables to four-vectors
-    const Real alpha = 1./m::sqrt(-G.gcon(loc, j, i, 0, 0));
+    const Real alpha = 1. / m::sqrt(-G.gcon(loc, j, i, 0, 0));
     const Real gdet = G.gdet(loc, j, i);
     const Real a_over_g = alpha / gdet;
     const Real D = U(m_u.RHO, k, j, i) * a_over_g;
@@ -113,13 +115,11 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
         Bcon[3] = U(m_u.B3, k, j, i) * a_over_g;
     }
 
-    const Real Qcov[GR_DIM] =
-        {(U(m_u.UU, k, j, i) - U(m_u.RHO, k, j, i)) * a_over_g,
-          U(m_u.U1, k, j, i) * a_over_g,
-          U(m_u.U2, k, j, i) * a_over_g,
-          U(m_u.U3, k, j, i) * a_over_g};
+    const Real Qcov[GR_DIM] = {(U(m_u.UU, k, j, i) - U(m_u.RHO, k, j, i)) * a_over_g,
+        U(m_u.U1, k, j, i) * a_over_g, U(m_u.U2, k, j, i) * a_over_g,
+        U(m_u.U3, k, j, i) * a_over_g};
 
-    const Real ncov[GR_DIM] = {(Real) -alpha, 0., 0., 0.};
+    const Real ncov[GR_DIM] = {(Real)-alpha, 0., 0., 0.};
 
     // TODO faster with on-the-fly gcon/cov?
     Real Bcov[GR_DIM], Qcon[GR_DIM], ncon[GR_DIM];
@@ -131,14 +131,15 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
     const Real QdB = dot(Bcon, Qcov);
     const Real Qdotn = dot(Qcon, ncov);
 
-    // TODO(BSP) check, test if this gets hit unlike above
+    // TODO(CEP) check, test if this gets hit unlike above
     // if (U(m_u.UU, k, j, i) <= gdet*(1e-8) + gdet*Bsq/2) {
 
     // }
 
     Real Qtcon[GR_DIM];
-    DLOOP1 Qtcon[mu] = Qcon[mu] + ncon[mu] * Qdotn;
-    const Real Qtsq = dot(Qcon, Qcov) + Qdotn*Qdotn;
+    DLOOP1
+        Qtcon[mu] = Qcon[mu] + ncon[mu] * Qdotn;
+    const Real Qtsq = dot(Qcon, Qcov) + Qdotn * Qdotn;
 
     // Set up eqtn for W'; this is the energy density
     const Real Ep = -Qdotn - D;
@@ -171,11 +172,11 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
 
         // Attempt a Halley/Muller/Bailey/Press step
         const Real dedW = (errp - errm) / (Wpp - Wpm);
-        const Real dedW2 = (errp - 2. * err + errm) / (h*h);
+        const Real dedW2 = (errp - 2. * err + errm) / (h * h);
         // TODO look into changing these clipped values?
-        const Real f = clip(0.5 * err * dedW2 / (dedW*dedW), -0.3, 0.3);
+        const Real f = clip(0.5 * err * dedW2 / (dedW * dedW), -0.3, 0.3);
 
-        dW = clip(-err / dedW / (1. - f), -0.5*Wp, 2.0*Wp);
+        dW = clip(-err / dedW / (1. - f), -0.5 * Wp, 2.0 * Wp);
     }
 
     // Take the first step
@@ -187,7 +188,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
     // Not good enough?  apply secant method
     int iter = 0;
     for (iter = 0; iter < max_iterations; iter++) {
-        dW = clip((Wp1 - Wp) * err / (err - err1), (Real) -0.5*Wp, (Real) 2.0*Wp);
+        dW = clip((Wp1 - Wp) * err / (err - err1), (Real)-0.5 * Wp, (Real)2.0 * Wp);
 
         Wp1 = Wp;
         err1 = err;
@@ -210,14 +211,17 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
 
     const Real rho = D / gamma;
     const Real W = Wp + D;
-    const Real w = W / (gamma*gamma);
+    const Real w = W / (gamma * gamma);
     const Real p = (w - rho) * (gam - 1) / gam;
     const Real u = w - (rho + p);
 
     // Return without updating non-B primitives
-    if (rho < 0 && u < 0) return static_cast<int>(Status::neg_rhou);
-    else if (rho < 0) return static_cast<int>(Status::neg_rho);
-    else if (u < 0) return static_cast<int>(Status::neg_u);
+    if (rho < 0 && u < 0)
+        return static_cast<int>(Status::neg_rhou);
+    else if (rho < 0)
+        return static_cast<int>(Status::neg_rho);
+    else if (u < 0)
+        return static_cast<int>(Status::neg_u);
 
     // Set primitives
     P(m_p.RHO, k, j, i) = rho;

--- a/kharma/ismr/ismr.cpp
+++ b/kharma/ismr/ismr.cpp
@@ -38,44 +38,51 @@
 #include "kharma.hpp"
 #include <stdexcept>
 
-std::shared_ptr<KHARMAPackage> ISMR::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> ISMR::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("ISMR");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Parameters
     // TODO add "poles" specifically if we ever support other areas
-    uint nlevels = (uint) pin->GetOrAddInteger("ismr", "nlevels", 1);
+    uint nlevels = (uint)pin->GetOrAddInteger("ismr", "nlevels", 1);
     params.Add("nlevels", nlevels);
     if (nlevels < 1)
         throw std::runtime_error("Internal SMR requires a positive number of levels!");
 
     // ISMR cache: not evolved, immediately copied to fluid state after averaging
     // Must be total size of variable list
-    int nvar = StateDescriptor::CreateResolvedStateDescriptor(*packages)->GetPackDimension(Metadata::WithFluxes);
+    int nvar =
+        StateDescriptor::CreateResolvedStateDescriptor(*packages)->GetPackDimension(
+            Metadata::WithFluxes);
     std::vector<int> s_avg({nvar});
-    auto m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_avg);
+    auto m = Metadata(
+        {Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_avg);
     pkg->AddField("ismr.vars_avg", m);
 
     // Incompatible with B_FluxCT due to non-local divB, yell
     if (packages->AllPackages().count("B_FluxCT"))
-        throw std::runtime_error("Internal SMR is not compatible with Flux-CT magnetic field transport!");
+        throw std::runtime_error(
+            "Internal SMR is not compatible with Flux-CT magnetic field transport!");
     // Otherwise declare a face temporary
     if (packages->AllPackages().count("B_CT")) {
-        m = Metadata({Metadata::Real, Metadata::Face, Metadata::Derived, Metadata::OneCopy});
+        m = Metadata(
+            {Metadata::Real, Metadata::Face, Metadata::Derived, Metadata::OneCopy});
         pkg->AddField("ismr.fB_avg", m);
     }
 
     // Incompatible with 2D simulations
     if (pin->GetInteger("parthenon/meshblock", "nx3") == 1)
-        throw std::runtime_error("Internal SMR is not compatible with 2D blocks or meshes!");
+        throw std::runtime_error(
+            "Internal SMR is not compatible with 2D blocks or meshes!");
 
     // TODO register a split-operator callback?
 
     return pkg;
 }
 
-TaskStatus ISMR::DerefinePoles(MeshData<Real> *md)
+TaskStatus ISMR::DerefinePoles(MeshData<Real>* md)
 {
     Flag("ISMR_DerefinePoles");
     // TODO this routine only applies to polar boundaries for now.
@@ -84,16 +91,20 @@ TaskStatus ISMR::DerefinePoles(MeshData<Real> *md)
 
     // Figure out indices
     int ng = Globals::nghost;
-    for (int iblock=0; iblock < md->NumBlocks(); iblock++) {
+    for (int iblock = 0; iblock < md->NumBlocks(); iblock++) {
         auto& rc = md->GetBlockData(iblock);
         auto pmb = rc->GetBlockPointer();
         PackIndexMap cons_map, cons_map_utop;
-        auto vars = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell, Metadata::Independent}, cons_map);
+        auto vars = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved,
+                                          Metadata::Cell, Metadata::Independent},
+            cons_map);
         auto vars_avg = rc->PackVariables(std::vector<std::string>{"ismr.vars_avg"});
-        auto vars_utop = rc->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map_utop);
+        auto vars_utop = rc->PackVariables(
+            std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell},
+            cons_map_utop);
         const int nvar = vars.GetDim(4);
         for (int i = 0; i < BOUNDARY_NFACES; i++) {
-            BoundaryFace bface = (BoundaryFace) i;
+            BoundaryFace bface = (BoundaryFace)i;
             auto bdir = KBoundaries::BoundaryDirection(bface);
             auto domain = KBoundaries::BoundaryDomain(bface);
             auto binner = KBoundaries::BoundaryIsInner(bface);
@@ -105,13 +116,18 @@ TaskStatus ISMR::DerefinePoles(MeshData<Real> *md)
                 // start of the lowest level of derefinement
                 const int jps = (binner) ? j_f + (nlevels - 1) : j_f - (nlevels - 1);
                 // Range of x2 to be de-refined
-                const IndexRange j_p = IndexRange{(binner) ? j_f : jps, (binner) ? jps : j_f};
+                const IndexRange j_p =
+                    IndexRange{(binner) ? j_f : jps, (binner) ? jps : j_f};
 
                 // TODO the following could be done in 1 kernel w/nested parallelism
                 // fluid variables average
-                pmb->par_for("DerefinePoles_avg_fluid", 0, nvar-1, bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
-                        const int coarse_cell_len = m::pow(2, ((binner) ? jps - j : j - jps) + 1);
+                pmb->par_for("DerefinePoles_avg_fluid", 0, nvar - 1, bCC.ks, bCC.ke,
+                    j_p.s, j_p.e, bCC.is, bCC.ie,
+                             KOKKOS_LAMBDA(const int& v, const int& k, const int& j,
+                                           const int& i)
+                    {
+                        const int coarse_cell_len =
+                            m::pow(2, ((binner) ? jps - j : j - jps) + 1);
                         // cell center
                         const int j_c = j + ((binner) ? 0 : -1);
                         // this fine cell's k-index within the coarse cell
@@ -120,45 +136,56 @@ TaskStatus ISMR::DerefinePoles(MeshData<Real> *md)
                         const int k_start = k - k_fine;
 
                         // average each var over next `coarse_cell_len` cells
-                        // Lots of repeated ops but we don't care, this is applied over a small region
+                        // Lots of repeated ops but we don't care, this is
+                        // applied over a small region
                         Real avg = 0.;
                         for (int ktemp = 0; ktemp < coarse_cell_len; ++ktemp)
                             avg += vars(v, k_start + ktemp, j_c, i);
                         avg /= coarse_cell_len;
                         vars_avg(v, k, j_c, i) = avg;
-                    }
-                );
+                    });
                 // fluid variables write
-                pmb->par_for("DerefinePoles_write_fluid", 0, nvar-1, bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &v, const int &k, const int &j, const int &i) {
+                pmb->par_for("DerefinePoles_write_fluid", 0, nvar - 1, bCC.ks, bCC.ke,
+                    j_p.s, j_p.e, bCC.is, bCC.ie,
+                             KOKKOS_LAMBDA(const int& v, const int& k, const int& j,
+                                           const int& i)
+                    {
                         const int j_c = j + ((binner) ? 0 : -1); // cell center
                         vars(v, k, j_c, i) = vars_avg(v, k, j_c, i);
-                    }
-                );
+                    });
 
                 // UtoP for the GRMHD variables
                 PackIndexMap prims_map;
-                auto P = rc->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
+                auto P = rc->PackVariables(
+                    std::vector<MetadataFlag>{
+                        Metadata::GetUserFlag("Primitive"), Metadata::Cell},
+                    prims_map);
                 VarMap m_u(cons_map_utop, true), m_p(prims_map, false);
                 const auto& G = pmb->coords;
                 const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
-                const Floors::Prescription floors = pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription");
-                pmb->par_for("DerefinePoles_UtoP", bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is, bCC.ie,
-                    KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                const Floors::Prescription floors =
+                    pmb->packages.Get("Floors")->Param<Floors::Prescription>(
+                        "prescription");
+                pmb->par_for("DerefinePoles_UtoP", bCC.ks, bCC.ke, j_p.s, j_p.e, bCC.is,
+                    bCC.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         const int j_c = j + ((binner) ? 0 : -1); // cell center
-                        // The usual inverter is not EMHD-aware, so it's going to dump all of T into the
-                        // ideal GRMHD fluid variables
-                        Inverter::u_to_p<Inverter::Type::kastaun>(G, vars_utop, m_u, gam, k, j_c, i, P, m_p,
-                                                                  Loci::center, 8, 1e-8, false);
-                        // Consistent with that, we zero out the EMHD extra variables.  This switches theories to
-                        // evolving ideal GRMHD in ISMR region, but conserves the components of T themselves
+                        // The usual inverter is not EMHD-aware, so it's going to
+                        // dump all of T into the ideal GRMHD fluid variables
+                        Inverter::u_to_p<Inverter::Type::kastaun>(G, vars_utop, m_u, gam,
+                            k, j_c, i, P, m_p, Loci::center, 8, 1e-8, false);
+                        // Consistent with that, we zero out the EMHD extra
+                        // variables. This switches theories to evolving ideal
+                        // GRMHD in ISMR region, but conserves the components of
+                        // T themselves
                         if (m_u.Q >= 0) vars_utop(m_u.Q, k, j_c, i) = 0.;
                         if (m_p.Q >= 0) P(m_p.Q, k, j_c, i) = 0.;
                         if (m_u.DP >= 0) vars_utop(m_u.DP, k, j_c, i) = 0.;
                         if (m_p.DP >= 0) P(m_p.DP, k, j_c, i) = 0.;
-                    }
-                );
-                // TODO there SHOULD be no need for floors here. Should test or prove this is always true
+                    });
+                // TODO there SHOULD be no need for floors here. Should test or prove this
+                // is always true
             }
         }
     }

--- a/kharma/ismr/ismr.hpp
+++ b/kharma/ismr/ismr.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: ismr.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,31 +39,34 @@
 #include <parthenon/parthenon.hpp>
 
 /**
- * This package implements internal static mesh de-refinement by averaging variables next to the coordinate
- * poles, creating effective "larger zones" and allowing increases to the timestep, without any modification
- * to the existing data structures or block layout.
- * Currently it is limited to spherical coordinates: use Parthenon's block-based refinement otherwise.
- * Also note that the averaging operation corresponds to a first-order refinement/derefinement, possibly
- * compromising overall second-order convergence in the very near-polar region.
- * 
- * The operator averages variables only in the phi-direction nearing the pole, mapping 1:2 zones
- * for each of several levels.  In this way, zones near the pole can be much wider in phi without losing
- * resolution in r, theta.
- * 
+ * This package implements internal static mesh de-refinement by averaging variables next
+ * to the coordinate poles, creating effective "larger zones" and allowing increases to
+ * the timestep, without any modification to the existing data structures or block layout.
+ * Currently it is limited to spherical coordinates: use Parthenon's block-based
+ * refinement otherwise. Also note that the averaging operation corresponds to a
+ * first-order refinement/derefinement, possibly compromising overall second-order
+ * convergence in the very near-polar region.
+ *
+ * The operator averages variables only in the phi-direction nearing the pole, mapping 1:2
+ * zones for each of several levels.  In this way, zones near the pole can be much wider
+ * in phi without losing resolution in r, theta.
+ *
  * Idea is taken from Matthew Liska/H-AMR (Liska+ 2022)
- * Implementation credit Hyerin Cho, please cite Cho+ 2024b (in prep) with description and first
- * use of this implementation.
+ * Implementation credit Hyerin Cho, please cite Cho+ 2024b (in prep) with description and
+ * first use of this implementation.
  */
-namespace ISMR {
+namespace ISMR
+{
 
 /**
  * Initialize ISMR parameters
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
- * Derefinement operation for fluid/cell-centered variables 
+ * Derefinement operation for fluid/cell-centered variables
  */
-TaskStatus DerefinePoles(MeshData<Real> *md);
+TaskStatus DerefinePoles(MeshData<Real>* md);
 
 }

--- a/kharma/kharma.hpp
+++ b/kharma/kharma.hpp
@@ -83,7 +83,7 @@ void FixParameters(ParameterInput *pin, bool is_parthenon_restart);
  */
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput>& pin);
 
-// TODO(BSP) not sure where to put these
+// TODO(CEP) not sure where to put these
 
 /**
  * Check whether a given field is anywhere in outputs.

--- a/kharma/kharma_package.cpp
+++ b/kharma/kharma_package.cpp
@@ -211,7 +211,7 @@ TaskStatus Packages::MeshApplyFloors(MeshData<Real> *md, IndexDomain domain)
         }
     }
     // Then everything else i.e. block versions
-    // TODO(BSP) allow Mesh versions and fallback
+    // TODO(CEP) allow Mesh versions and fallback
     for (int i=0; i < md->NumBlocks(); ++i) {
         auto mbd = md->GetBlockData(i).get();
         auto pmb = mbd->GetBlockPointer();

--- a/kharma/main.cpp
+++ b/kharma/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 
     if(MPIRank0()) {
         // Always print the version header, because it's fun
-        // TODO(BSP) proper banner w/refs, names
+        // TODO(CEP) proper banner w/refs, names
         const std::string &version = KHARMA::Version::GIT_VERSION;
         const std::string &branch = KHARMA::Version::GIT_REFSPEC;
         const std::string &sha1 = KHARMA::Version::GIT_SHA1;
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
     // PostInitialize: Add magnetic field to the problem, initialize ghost zones.
     // Any init which may be run even when restarting, or requires all
     // MeshBlocks to be initialized already.
-    // TODO(BSP) split to package hooks
+    // TODO(CEP) split to package hooks
     auto prob = pin->GetString("parthenon/job", "problem_id");
     bool is_restart = (prob == "resize_restart") || Globals::is_restart;
     if(MPIRank0() && verbose > 0) {

--- a/kharma/prob/bondi.cpp
+++ b/kharma/prob/bondi.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: bondi.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,47 +39,48 @@
 #include "flux.hpp"
 #include "flux_functions.hpp"
 
-void AddBondiParameters(ParameterInput *pin, Packages_t &packages)
+void AddBondiParameters(ParameterInput* pin, Packages_t& packages)
 {
     const Real mdot = pin->GetOrAddReal("bondi", "mdot", 1.0);
     const Real rs = pin->GetOrAddReal("bondi", "rs", 8.0);
     const Real ur_frac = pin->GetOrAddReal("bondi", "ur_frac", 1.);
-    const Real uphi = pin->GetOrAddReal("bondi", "uphi", 0.); 
+    const Real uphi = pin->GetOrAddReal("bondi", "uphi", 0.);
 
     // Set the innermost radius to apply the Bondi problem initialization
     // By default, stay away from the outer BL coordinate singularity
     const Real a = pin->GetReal("coordinates", "a");
-    const Real rin_bondi_default = 1 + m::sqrt(1 - a*a) + 0.1;
+    const Real rin_bondi_default = 1 + m::sqrt(1 - a * a) + 0.1;
     const Real rin_bondi = pin->GetOrAddReal("bondi", "r_in_bondi", rin_bondi_default);
     const Real bondi_clear_angle = pin->GetOrAddReal("bondi", "bondi_clear_angle", 0.);
 
     const bool fill_interior = pin->GetOrAddBoolean("bondi", "fill_interior", false);
-    const bool diffinit = pin->GetOrAddBoolean("bondi", "diffinit", false); // uses r^-1 density initialization instead
+    const bool diffinit = pin->GetOrAddBoolean("bondi", "diffinit",
+        false); // uses r^-1 density initialization instead
 
     // Add these to package properties, since they continue to be needed on boundaries
     // TODO Problems NEED params
-    if(! packages.Get("GRMHD")->AllParams().hasKey("mdot"))
+    if (!packages.Get("GRMHD")->AllParams().hasKey("mdot"))
         packages.Get("GRMHD")->AddParam<Real>("mdot", mdot);
-    if(! packages.Get("GRMHD")->AllParams().hasKey("rs"))
+    if (!packages.Get("GRMHD")->AllParams().hasKey("rs"))
         packages.Get("GRMHD")->AddParam<Real>("rs", rs);
-    if(! packages.Get("GRMHD")->AllParams().hasKey("rin_bondi"))
+    if (!packages.Get("GRMHD")->AllParams().hasKey("rin_bondi"))
         packages.Get("GRMHD")->AddParam<Real>("rin_bondi", rin_bondi);
-    if(! packages.Get("GRMHD")->AllParams().hasKey("bondi_clear_angle"))
+    if (!packages.Get("GRMHD")->AllParams().hasKey("bondi_clear_angle"))
         packages.Get("GRMHD")->AddParam<Real>("bondi_clear_angle", bondi_clear_angle);
-    if(! packages.Get("GRMHD")->AllParams().hasKey("fill_interior_bondi"))
+    if (!packages.Get("GRMHD")->AllParams().hasKey("fill_interior_bondi"))
         packages.Get("GRMHD")->AddParam<Real>("fill_interior_bondi", fill_interior);
-    if(! packages.Get("GRMHD")->AllParams().hasKey("diffinit_bondi"))
+    if (!packages.Get("GRMHD")->AllParams().hasKey("diffinit_bondi"))
         packages.Get("GRMHD")->AddParam<Real>("diffinit_bondi", diffinit);
-    if(! (packages.Get("GRMHD")->AllParams().hasKey("ur_frac")))
+    if (!(packages.Get("GRMHD")->AllParams().hasKey("ur_frac")))
         packages.Get("GRMHD")->AddParam<Real>("ur_frac", ur_frac);
-    if(! (packages.Get("GRMHD")->AllParams().hasKey("uphi")))
+    if (!(packages.Get("GRMHD")->AllParams().hasKey("uphi")))
         packages.Get("GRMHD")->AddParam<Real>("uphi", uphi);
 }
 
 /**
  * Initialization of a Bondi problem with specified sonic point & accretion rate
  */
-TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -88,7 +89,8 @@ TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterIn
 
     // We need these two
     const Real rin_bondi = pmb->packages.Get("GRMHD")->Param<Real>("rin_bondi");
-    const bool fill_interior = pmb->packages.Get("GRMHD")->Param<Real>("fill_interior_bondi");
+    const bool fill_interior =
+        pmb->packages.Get("GRMHD")->Param<Real>("fill_interior_bondi");
 
     // Set this problem to control the outer X1 boundary by default
     // remember to disable inflow_check in parameter file!
@@ -106,7 +108,8 @@ TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterIn
     }
 
     // Default Bondi boundary conditions: reset the outer boundary using our set function.
-    // Register the callback to replace value from boundaries.cpp, & record the change in pin.
+    // Register the callback to replace value from boundaries.cpp, & record the change in
+    // pin.
     auto bound_pkg = pmb->packages.Get<KHARMAPackage>("Boundaries");
     if (pin->GetOrAddBoolean("bondi", "set_outer_bound", !outer_dirichlet)) {
         pin->SetString("boundaries", "outer_x1", "bondi");
@@ -119,8 +122,9 @@ TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterIn
     }
 
     // Apply floors to initialize the any part of the domain we didn't
-    // Bondi's BL coordinates do not like the EH, so we replace the zeros with something reasonable
-    // Note this ignores whether the "Floors" package is loaded, since it's necessary for initialization
+    // Bondi's BL coordinates do not like the EH, so we replace the zeros with something
+    // reasonable Note this ignores whether the "Floors" package is loaded, since it's
+    // necessary for initialization
     if (rin_bondi > pin->GetReal("coordinates", "r_in") && !(fill_interior)) {
         Floors::ApplyInitialFloors(pin, rc.get(), IndexDomain::interior);
     }
@@ -128,11 +132,14 @@ TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterIn
     return TaskStatus::complete;
 }
 
-TaskStatus SetBondiImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
+TaskStatus SetBondiImpl(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
-    //std::cout << "Setting bondi on domain: " << KBoundaries::BoundaryName(KBoundaries::BoundaryFaceOf(domain)) << " coarse: " << coarse << std::endl;
+    // std::cout << "Setting bondi on domain: " <<
+    // KBoundaries::BoundaryName(KBoundaries::BoundaryFaceOf(domain)) << " coarse: " <<
+    // coarse << std::endl;
 
     PackIndexMap prims_map, cons_map;
     auto P = GRMHD::PackMHDPrims(rc.get(), prims_map);
@@ -151,8 +158,10 @@ TaskStatus SetBondiImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain do
     const Real ur_frac = pmb->packages.Get("GRMHD")->Param<Real>("ur_frac");
     const Real uphi = pmb->packages.Get("GRMHD")->Param<Real>("uphi");
     const Real rin_bondi = pmb->packages.Get("GRMHD")->Param<Real>("rin_bondi");
-    const Real bondi_clear_angle = pmb->packages.Get("GRMHD")->Param<Real>("bondi_clear_angle");
-    const bool fill_interior = pmb->packages.Get("GRMHD")->Param<Real>("fill_interior_bondi");
+    const Real bondi_clear_angle =
+        pmb->packages.Get("GRMHD")->Param<Real>("bondi_clear_angle");
+    const bool fill_interior =
+        pmb->packages.Get("GRMHD")->Param<Real>("fill_interior_bondi");
     const bool diffinit = pmb->packages.Get("GRMHD")->Param<Real>("diffinit_bondi");
 
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
@@ -166,51 +175,53 @@ TaskStatus SetBondiImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain do
     const IndexRange jb = bounds.GetBoundsJ(domain);
     const IndexRange kb = bounds.GetBoundsK(domain);
 
-    //std::cout << "Setting Bondi on range: (" << ib.s << " " << ib.e << " " << jb.s << " " << jb.e << " " << kb.s << " " << kb.e << ")" << std::endl;
-    //std::cout << "nghost is " << Globals::nghost << std::endl;
+    // std::cout << "Setting Bondi on range: (" << ib.s << " " << ib.e << " " << jb.s << "
+    // " << jb.e << " " << kb.s << " " << kb.e << ")" << std::endl; std::cout << "nghost
+    // is " << Globals::nghost << std::endl;
 
     pmb->par_for("bondi_boundary", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real rho, u;
             Real u_prim[NVEC];
-            get_prim_bondi(G, diffinit, rs, mdot, gam, ur_frac, uphi, rin_bondi, bondi_clear_angle, fill_interior, rho, u, u_prim, k, j, i);
+            get_prim_bondi(G, diffinit, rs, mdot, gam, ur_frac, uphi, rin_bondi,
+                bondi_clear_angle, fill_interior, rho, u, u_prim, k, j, i);
 
-            // Note that NaN guards, including these, are ignored (!) under -ffast-math flag.
-            // Thus we stay away from initializing at EH where this could happen
-            if(!m::isnan(rho)) P(m_p.RHO, k, j, i) = rho;
-            if(!m::isnan(u)) P(m_p.UU, k, j, i) = u;
-            if(!m::isnan(u_prim[0])) P(m_p.U1, k, j, i) = u_prim[0];
-            if(!m::isnan(u_prim[1])) P(m_p.U2, k, j, i) = u_prim[1];
-            if(!m::isnan(u_prim[2])) P(m_p.U3, k, j, i) = u_prim[2];
-        }
-    );
+            // Note that NaN guards, including these, are ignored (!) under
+            // -ffast-math flag. Thus we stay away from initializing at EH where
+            // this could happen
+            if (!m::isnan(rho)) P(m_p.RHO, k, j, i) = rho;
+            if (!m::isnan(u)) P(m_p.UU, k, j, i) = u;
+            if (!m::isnan(u_prim[0])) P(m_p.U1, k, j, i) = u_prim[0];
+            if (!m::isnan(u_prim[1])) P(m_p.U2, k, j, i) = u_prim[1];
+            if (!m::isnan(u_prim[2])) P(m_p.U3, k, j, i) = u_prim[2];
+        });
 
     // Generally I avoid this, but the viscous Bondi test problem has very unique
     // boundary requirements to converge.  The GRMHD vars must be held constant,
     // but the pressure anisotropy allowed to change as necessary with outflow conditions
-    // TODO(BSP) this doesn't properly support face_ct, yell if enabled?
+    // TODO(CEP) this doesn't properly support face_ct, yell if enabled?
     if (pmb->packages.Get("Globals")->Param<std::string>("problem") == "bondi_viscous") {
         BoundaryFace bface = KBoundaries::BoundaryFaceOf(domain);
         bool inner = KBoundaries::BoundaryIsInner(bface);
         IndexRange ib_i = bounds.GetBoundsI(domain);
         int ref = inner ? ib_i.s : ib_i.e;
         pmb->par_for("bondi_viscous_boundary", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 GReal Xembed[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, Xembed);
                 GReal r = Xembed[1];
                 // TODO more general?
                 if (m_p.B1 >= 0) {
-                    P(m_p.B1, k, j, i) = 1/(r*r*r);
+                    P(m_p.B1, k, j, i) = 1 / (r * r * r);
                     P(m_p.B2, k, j, i) = 0.;
                     P(m_p.B3, k, j, i) = 0.;
                 }
                 if (m_p.DP >= 0) {
                     P(m_p.DP, k, j, i) = P(m_p.DP, k, j, ref);
                 }
-            }
-        );
+            });
     }
 
     return TaskStatus::complete;

--- a/kharma/prob/bondi.hpp
+++ b/kharma/prob/bondi.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: bondi.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,61 +35,67 @@
 
 #include "decs.hpp"
 
-#include "gr_coordinates.hpp"
-#include "flux_functions.hpp"
-#include "grmhd_functions.hpp"
-#include "pack.hpp"
 #include "coordinate_utils.hpp"
-#include "types.hpp"
+#include "flux_functions.hpp"
+#include "gr_coordinates.hpp"
+#include "grmhd_functions.hpp"
 #include "hdf5_utils.h"
+#include "pack.hpp"
+#include "types.hpp"
 
 #include <parthenon/parthenon.hpp>
 
 /**
  * Initialize a Bondi problem over the domain
  */
-TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+TaskStatus InitializeBondi(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);
 
 /**
  * Record parameters Bondi problem (or boundaries!) will need throughout the run
- * Currently uses "GRMHD" package as convenient proxy (TODO fix that with problem-packages)
+ * Currently uses "GRMHD" package as convenient proxy (TODO fix that with
+ * problem-packages)
  */
-void AddBondiParameters(ParameterInput *pin, Packages_t &packages);
+void AddBondiParameters(ParameterInput* pin, Packages_t& packages);
 
 /**
  * Set all values on a given domain to the Bondi inflow analytic steady-state solution.
  * Use the template version when possible, which just calls through
  */
-TaskStatus SetBondiImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse);
+TaskStatus SetBondiImpl(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse);
 
 template<IndexDomain domain>
-TaskStatus SetBondi(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse=false) {
+TaskStatus SetBondi(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse = false)
+{
     return SetBondiImpl(rc, domain, coarse);
 }
 
 /**
  * Supporting functions for Bondi flow calculations
- * 
+ *
  * Adapted from M. Chandra
  * Modified by Hyerin Cho and Ramesh Narayan
  */
-KOKKOS_INLINE_FUNCTION Real get_Tfunc(const Real T, const GReal r, const Real C1, const Real C2, const Real n)
+KOKKOS_INLINE_FUNCTION Real get_Tfunc(
+    const Real T, const GReal r, const Real C1, const Real C2, const Real n)
 {
     const Real A = 1. + (1. + n) * T;
     const Real B = C1 / (r * r * m::pow(T, n));
     return A * A * (1. - 2. / r + B * B) - C2;
 }
 
-KOKKOS_INLINE_FUNCTION Real get_T(const GReal r, const Real C1, const Real C2, const Real n, const Real rs)
+KOKKOS_INLINE_FUNCTION Real get_T(
+    const GReal r, const Real C1, const Real C2, const Real n, const Real rs)
 {
     Real rtol = 1.e-12;
     Real ftol = 1.e-14;
     Real Tinf = (m::sqrt(C2) - 1.) / (n + 1); // temperature at infinity
-    Real Tnear = m::pow(C1 * m::sqrt(2. / (r*r*r)), 1. / n); // temperature near the BH
+    Real Tnear =
+        m::pow(C1 * m::sqrt(2. / (r * r * r)), 1. / n); // temperature near the BH
 
-    // There are two branches of solutions (see Michel et al. 1971) and the two branches cross at rs.
-    // These bounds are set to select the inflowing solution only.
-    Real Tmin = (r < rs) ? Tinf  : m::max(Tnear,Tinf);
+    // There are two branches of solutions (see Michel et al. 1971) and the two branches
+    // cross at rs. These bounds are set to select the inflowing solution only.
+    Real Tmin = (r < rs) ? Tinf : m::max(Tnear, Tinf);
     Real Tmax = (r < rs) ? Tnear : 1.0;
 
     Real f0, f1, fh;
@@ -98,14 +104,13 @@ KOKKOS_INLINE_FUNCTION Real get_T(const GReal r, const Real C1, const Real C2, c
     f0 = get_Tfunc(T0, r, C1, C2, n);
     T1 = Tmax;
     f1 = get_Tfunc(T1, r, C1, C2, n);
-    // TODO(BSP) where does this trigger an error?  Can we make it clearer?
+    // TODO(CEP) where does this trigger an error?  Can we make it clearer?
     if (f0 * f1 > 0) return -1.;
 
     Th = (T0 + T1) / 2.; // a simple bisection method which is stable and fast
     fh = get_Tfunc(Th, r, C1, C2, n);
     Real epsT = rtol * (Tmin + Tmax);
-    while (m::abs(Th - T0) > epsT && m::abs(Th - T1) > epsT && m::abs(fh) > ftol)
-    {
+    while (m::abs(Th - T0) > epsT && m::abs(Th - T1) > epsT && m::abs(fh) > ftol) {
         if (fh * f0 > 0.) {
             T0 = Th;
             f0 = fh;
@@ -114,15 +119,15 @@ KOKKOS_INLINE_FUNCTION Real get_T(const GReal r, const Real C1, const Real C2, c
             f1 = fh;
         }
 
-        Th = (T0 + T1) / 2.; 
+        Th = (T0 + T1) / 2.;
         fh = get_Tfunc(Th, r, C1, C2, n);
     }
 
     return Th;
 }
 
-KOKKOS_INLINE_FUNCTION void get_bondi_soln(const Real &r, const Real &rs, const Real &mdot, const Real &gam,
-                                            Real &rho, Real &u, Real &ur)
+KOKKOS_INLINE_FUNCTION void get_bondi_soln(const Real& r, const Real& rs,
+    const Real& mdot, const Real& gam, Real& rho, Real& u, Real& ur)
 {
     // Solution constants
     // These don't depend on which zone we're calculating
@@ -133,7 +138,7 @@ KOKKOS_INLINE_FUNCTION void get_bondi_soln(const Real &r, const Real &rs, const 
     const Real C1 = uc * rs * rs * m::pow(Tc, n);
     const Real A = 1. + (1. + n) * Tc;
     const Real C2 = A * A * (1. - 2. / rs + uc * uc);
-    const Real K  = m::pow(4 * M_PI * C1 / mdot, 1/n);
+    const Real K = m::pow(4 * M_PI * C1 / mdot, 1 / n);
     const Real Kn = m::pow(K, n);
 
     const Real T = get_T(r, C1, C2, n, rs);
@@ -144,10 +149,11 @@ KOKKOS_INLINE_FUNCTION void get_bondi_soln(const Real &r, const Real &rs, const 
     ur = -C1 / (Tn * r * r);
 }
 
-KOKKOS_INLINE_FUNCTION void get_prim_bondi(const GRCoordinates& G, const bool diffinit, const Real &rs, const Real &mdot, const Real &gam,
-                                            const Real ur_frac, const Real uphi, const Real rin_bondi, const Real bondi_clear_angle,
-                                            const bool fill_interior, Real &rho, Real &u, Real u_prim[NVEC], 
-                                            const int& k, const int& j, const int& i)
+KOKKOS_INLINE_FUNCTION void get_prim_bondi(const GRCoordinates& G, const bool diffinit,
+    const Real& rs, const Real& mdot, const Real& gam, const Real ur_frac,
+    const Real uphi, const Real rin_bondi, const Real bondi_clear_angle,
+    const bool fill_interior, Real& rho, Real& u, Real u_prim[NVEC], const int& k,
+    const int& j, const int& i)
 {
     // Get primitive values initialized
     GReal Xnative[GR_DIM], Xembed[GR_DIM];
@@ -165,11 +171,12 @@ KOKKOS_INLINE_FUNCTION void get_prim_bondi(const GRCoordinates& G, const bool di
         u_prim[2] = 0.;
         return;
     } else if (r < rin_bondi) {
-        // Optionally fill the interior region with the innermost analytically computed value
+        // Optionally fill the interior region with the innermost analytically computed
+        // value
         if (fill_interior) {
             // just match at the rin_bondi value
             r = rin_bondi;
-            // TODO(BSP) previous impl could also do values at inf, restore that?
+            // TODO(CEP) previous impl could also do values at inf, restore that?
         } else {
             rho = 0.;
             u = 0.;
@@ -189,10 +196,12 @@ KOKKOS_INLINE_FUNCTION void get_prim_bondi(const GRCoordinates& G, const bool di
     Real rho0, u0, ur0;
     if (diffinit) {
         // Get r^{-1} density initialization instead
-    
+
         // values at infinity (obtained by putting r = 100 rb)
-        if (m::abs(n - 1.5) < 0.01) rb = rs * rs * 80. / (27. * gam);
-        else rb = (4 * (n + 1)) / (2 * (n + 3) - 9) * rs;
+        if (m::abs(n - 1.5) < 0.01)
+            rb = rs * rs * 80. / (27. * gam);
+        else
+            rb = (4 * (n + 1)) / (2 * (n + 3) - 9) * rs;
         get_bondi_soln(100 * rb, rs, mdot, gam, rho0, u0, ur0);
 
         // interpolation between inner and outer regimes
@@ -205,9 +214,8 @@ KOKKOS_INLINE_FUNCTION void get_prim_bondi(const GRCoordinates& G, const bool di
     }
     Real ur = ur_tmp; // Bondi radial velocity solution
 
-
     // Get the native-coordinate 4-vector corresponding to ur
-    const Real ucon_bl[GR_DIM] = {0, ur * ur_frac, 0, uphi * m::pow(r,-3./2.)};
+    const Real ucon_bl[GR_DIM] = {0, ur * ur_frac, 0, uphi * m::pow(r, -3. / 2.)};
     Real ucon_native[GR_DIM];
     G.coords.bl_fourvel_to_native(Xnative, ucon_bl, ucon_native);
 

--- a/kharma/prob/elec/driven_turbulence.hpp
+++ b/kharma/prob/elec/driven_turbulence.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: driven_turbulence.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,7 +41,8 @@
 
 using namespace parthenon;
 
-TaskStatus InitializeDrivenTurbulence(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeDrivenTurbulence(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -54,36 +55,38 @@ TaskStatus InitializeDrivenTurbulence(std::shared_ptr<MeshBlockData<Real>>& rc, 
     const Real dt_kick = pin->GetOrAddReal("driven_turbulence", "dt_kick", 1);
     const Real edot_frac = pin->GetOrAddReal("driven_turbulence", "edot_frac", 0.5);
     const Real x1min = pin->GetOrAddReal("parthenon/mesh", "x1min", 0);
-    const Real x1max = pin->GetOrAddReal("parthenon/mesh", "x1max",  1);
+    const Real x1max = pin->GetOrAddReal("parthenon/mesh", "x1max", 1);
     const Real x2min = pin->GetOrAddReal("parthenon/mesh", "x2min", 0);
-    const Real x2max = pin->GetOrAddReal("parthenon/mesh", "x2max",  1);
+    const Real x2max = pin->GetOrAddReal("parthenon/mesh", "x2max", 1);
     const Real x3min = pin->GetOrAddReal("parthenon/mesh", "x3min", -1);
-    const Real x3max = pin->GetOrAddReal("parthenon/mesh", "x3max",  1);
+    const Real x3max = pin->GetOrAddReal("parthenon/mesh", "x3max", 1);
 
-    const Real edot = edot_frac * rho0 * pow(cs0, 3); const Real counter = 0.;
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("drive_edot")))
+    const Real edot = edot_frac * rho0 * pow(cs0, 3);
+    const Real counter = 0.;
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("drive_edot")))
         pmb->packages.Get("GRMHD")->AddParam<Real>("drive_edot", edot);
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("counter")))
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("counter")))
         pmb->packages.Get("GRMHD")->AddParam<Real>("counter", counter, true);
-    const Real lx1 = x1max-x1min;   const Real lx2 = x2max-x2min;
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("lx1")))
+    const Real lx1 = x1max - x1min;
+    const Real lx2 = x2max - x2min;
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("lx1")))
         pmb->packages.Get("GRMHD")->AddParam<Real>("lx1", lx1);
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("lx2")))
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("lx2")))
         pmb->packages.Get("GRMHD")->AddParam<Real>("lx2", lx2);
-    //adding for later use in create_grf
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("dt_kick")))
+    // adding for later use in create_grf
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("dt_kick")))
         pmb->packages.Get("GRMHD")->AddParam<Real>("dt_kick", dt_kick);
 
-    const Real u0 = cs0 * cs0 * rho0 / (gam - 1) / gam; //from flux_functions.hpp
+    const Real u0 = cs0 * cs0 * rho0 / (gam - 1) / gam; // from flux_functions.hpp
     IndexRange myib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
     IndexRange myjb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
     IndexRange mykb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);
     pmb->par_for("driven_turb_rho_u_init", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             rho(k, j, i) = rho0;
             u(k, j, i) = u0;
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }
@@ -93,7 +96,7 @@ TaskStatus InitializeDrivenTurbulence(std::shared_ptr<MeshBlockData<Real>>& rc, 
  * It is only called after the last sub-step, so this splits nicely with the fluid
  * evolution operator.
  */
-void ApplyDrivingTurbulence(MeshBlockData<Real> *rc)
+void ApplyDrivingTurbulence(MeshBlockData<Real>* rc)
 {
     auto pmb = rc->GetBlockPointer();
     const IndexRange myib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
@@ -108,97 +111,137 @@ void ApplyDrivingTurbulence(MeshBlockData<Real> *rc)
     GridVector grf_normalized = rc->Get("grf_normalized").data;
     const Real t = pmb->packages.Get("Globals")->Param<Real>("time");
     Real counter = pmb->packages.Get("GRMHD")->Param<Real>("counter");
-    const Real dt_kick=  pmb->packages.Get("GRMHD")->Param<Real>("dt_kick");
+    const Real dt_kick = pmb->packages.Get("GRMHD")->Param<Real>("dt_kick");
     if (counter < t) {
         counter += dt_kick;
         pmb->packages.Get("GRMHD")->UpdateParam<Real>("counter", counter);
         printf("Kick applied at time %.32f\n", t);
 
-        const Real lx1=  pmb->packages.Get("GRMHD")->Param<Real>("lx1");
-        const Real lx2=  pmb->packages.Get("GRMHD")->Param<Real>("lx2");
-        const Real edot= pmb->packages.Get("GRMHD")->Param<Real>("drive_edot");
+        const Real lx1 = pmb->packages.Get("GRMHD")->Param<Real>("lx1");
+        const Real lx2 = pmb->packages.Get("GRMHD")->Param<Real>("lx2");
+        const Real edot = pmb->packages.Get("GRMHD")->Param<Real>("drive_edot");
         GridScalar alfven_speed = rc->Get("alfven_speed").data;
-        
+
         int Nx1 = pmb->cellbounds.ncellsi(IndexDomain::interior);
         int Nx2 = pmb->cellbounds.ncellsj(IndexDomain::interior);
-        Real *dv0 =  (Real*) malloc(sizeof(Real)*Nx1*Nx2);
-        Real *dv1 =  (Real*) malloc(sizeof(Real)*Nx1*Nx2);
+        Real* dv0 = (Real*)malloc(sizeof(Real) * Nx1 * Nx2);
+        Real* dv1 = (Real*)malloc(sizeof(Real) * Nx1 * Nx2);
         create_grf(Nx1, Nx2, lx1, lx2, dv0, dv1);
 
-        Real mean_velocity_num0 = 0;    Kokkos::Sum<Real> mean_velocity_num0_reducer(mean_velocity_num0);
-        Real mean_velocity_num1 = 0;    Kokkos::Sum<Real> mean_velocity_num1_reducer(mean_velocity_num1);
-        Real tot_mass = 0;              Kokkos::Sum<Real> tot_mass_reducer(tot_mass);
-        pmb->par_reduce("forced_mhd_normal_kick_centering_mean_vel0", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+        Real mean_velocity_num0 = 0;
+        Kokkos::Sum<Real> mean_velocity_num0_reducer(mean_velocity_num0);
+        Real mean_velocity_num1 = 0;
+        Kokkos::Sum<Real> mean_velocity_num1_reducer(mean_velocity_num1);
+        Real tot_mass = 0;
+        Kokkos::Sum<Real> tot_mass_reducer(tot_mass);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_centering_mean_vel0", mykb.s, mykb.e, myjb.s, myjb.e,
+            myib.s, myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                local_result += cell_mass * dv0[(i-4)*Nx1+(j-4)];
-            }
-        , mean_velocity_num0_reducer);
-        pmb->par_reduce("forced_mhd_normal_kick_centering_mean_vel1", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+                local_result += cell_mass * dv0[(i - 4) * Nx1 + (j - 4)];
+            },
+            mean_velocity_num0_reducer);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_centering_mean_vel1", mykb.s, mykb.e, myjb.s, myjb.e,
+            myib.s, myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                local_result += cell_mass * dv1[(i-4)*Nx1+(j-4)];
-            }
-        , mean_velocity_num1_reducer);
-        pmb->par_reduce("forced_mhd_normal_kick_centering_tot_mass", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+                local_result += cell_mass * dv1[(i - 4) * Nx1 + (j - 4)];
+            },
+            mean_velocity_num1_reducer);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_centering_tot_mass", mykb.s, mykb.e, myjb.s, myjb.e,
+            myib.s, myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 local_result += (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
+            },
+            tot_mass_reducer);
+        Real mean_velocity0 = mean_velocity_num0 / tot_mass;
+        Real mean_velocity1 = mean_velocity_num1 / tot_mass;
+#pragma omp parallel for simd collapse(2)
+        for (size_t i = 0; i < Nx1; i++) {
+            for (size_t j = 0; j < Nx2; j++) {
+                dv0[i * Nx1 + j] -= mean_velocity0;
+                dv1[i * Nx1 + j] -= mean_velocity1;
             }
-        , tot_mass_reducer);
-        Real mean_velocity0 = mean_velocity_num0/tot_mass;
-        Real mean_velocity1 = mean_velocity_num1/tot_mass;
-        #pragma omp parallel for simd collapse(2)
-        for (size_t i = 0; i < Nx1 ; i ++) {
-            for (size_t j = 0; j < Nx2 ; j ++) {
-                dv0[i*Nx1+j] -= mean_velocity0;
-                dv1[i*Nx1+j] -= mean_velocity1;
-            }
-        } 
+        }
 
-        Real Bhalf = 0; Real A = 0; Real init_e = 0; 
-        Kokkos::Sum<Real> Bhalf_reducer(Bhalf); Kokkos::Sum<Real> A_reducer(A); Kokkos::Sum<Real> init_e_reducer(init_e);
-        pmb->par_reduce("forced_mhd_normal_kick_normalization_Bhalf", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+        Real Bhalf = 0;
+        Real A = 0;
+        Real init_e = 0;
+        Kokkos::Sum<Real> Bhalf_reducer(Bhalf);
+        Kokkos::Sum<Real> A_reducer(A);
+        Kokkos::Sum<Real> init_e_reducer(init_e);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_normalization_Bhalf", mykb.s, mykb.e, myjb.s, myjb.e,
+            myib.s, myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                local_result += cell_mass * (dv0[(i-4)*Nx1+(j-4)]*uvec(0, k, j, i) + dv1[(i-4)*Nx1+(j-4)]*uvec(1, k, j, i));
-            }
-        , Bhalf_reducer);
-        pmb->par_reduce("forced_mhd_normal_kick_normalization_A", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+                local_result +=
+                    cell_mass * (dv0[(i - 4) * Nx1 + (j - 4)] * uvec(0, k, j, i) +
+                                    dv1[(i - 4) * Nx1 + (j - 4)] * uvec(1, k, j, i));
+            },
+            Bhalf_reducer);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_normalization_A", mykb.s, mykb.e, myjb.s, myjb.e,
+            myib.s, myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                local_result += cell_mass * (pow(dv0[(i-4)*Nx1+(j-4)], 2) + pow(dv1[(i-4)*Nx1+(j-4)], 2));
-            }
-        , A_reducer);
-        pmb->par_reduce("forced_mhd_normal_kick_init_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+                local_result += cell_mass * (pow(dv0[(i - 4) * Nx1 + (j - 4)], 2) +
+                                                pow(dv1[(i - 4) * Nx1 + (j - 4)], 2));
+            },
+            A_reducer);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_init_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s,
+            myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                local_result += 0.5 * cell_mass * (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
-            }
-        , init_e_reducer);
+                local_result += 0.5 * cell_mass *
+                                (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
+            },
+            init_e_reducer);
 
-        Real norm_const = (-Bhalf + pow(pow(Bhalf,2) + A*2*dt_kick*edot, 0.5))/A;  // going from k:(0, 0), j:(4, 515), i:(4, 515) inclusive
-        pmb->par_for("forced_mhd_normal_kick_setting", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                grf_normalized(0, k, j, i) = (dv0[(i-4)*Nx1+(j-4)]*norm_const);
-                grf_normalized(1, k, j, i) = (dv1[(i-4)*Nx1+(j-4)]*norm_const);
+        Real norm_const = (-Bhalf + pow(pow(Bhalf, 2) + A * 2 * dt_kick * edot, 0.5)) /
+                          A; // going from k:(0, 0), j:(4, 515), i:(4, 515) inclusive
+        pmb->par_for("forced_mhd_normal_kick_setting", mykb.s, mykb.e, myjb.s, myjb.e,
+            myib.s, myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
+                grf_normalized(0, k, j, i) = (dv0[(i - 4) * Nx1 + (j - 4)] * norm_const);
+                grf_normalized(1, k, j, i) = (dv1[(i - 4) * Nx1 + (j - 4)] * norm_const);
                 uvec(0, k, j, i) += grf_normalized(0, k, j, i);
                 uvec(1, k, j, i) += grf_normalized(1, k, j, i);
                 FourVectors Dtmp;
                 GRMHD::calc_4vecs(G, uvec, B_P, k, j, i, Loci::center, Dtmp);
                 Real bsq = dot(Dtmp.bcon, Dtmp.bcov);
-                alfven_speed(k,j,i) = bsq/rho(k, j, i); //saving alfven speed for analysis purposes
-            }
-        );
+                alfven_speed(k, j, i) =
+                    bsq / rho(k, j, i); // saving alfven speed for analysis purposes
+            });
 
-        Real finl_e = 0;    Kokkos::Sum<Real> finl_e_reducer(finl_e);
-        pmb->par_reduce("forced_mhd_normal_kick_finl_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s, myib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i, double &local_result) {
+        Real finl_e = 0;
+        Kokkos::Sum<Real> finl_e_reducer(finl_e);
+        pmb->par_reduce(
+            "forced_mhd_normal_kick_finl_e", mykb.s, mykb.e, myjb.s, myjb.e, myib.s,
+            myib.e,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i, double& local_result)
+            {
                 Real cell_mass = (rho(k, j, i) * G.Dxc<3>(k) * G.Dxc<2>(j) * G.Dxc<1>(i));
-                local_result += 0.5 * cell_mass * (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
-            }
-        , finl_e_reducer);
-        printf("%.32f\n", A); printf("%.32f\n", Bhalf); printf("%.32f\n", norm_const);
-        printf("%.32f\n", (finl_e-init_e)/dt_kick);
-        free(dv0); free(dv1);
+                local_result += 0.5 * cell_mass *
+                                (pow(uvec(0, k, j, i), 2) + pow(uvec(1, k, j, i), 2));
+            },
+            finl_e_reducer);
+        printf("%.32f\n", A);
+        printf("%.32f\n", Bhalf);
+        printf("%.32f\n", norm_const);
+        printf("%.32f\n", (finl_e - init_e) / dt_kick);
+        free(dv0);
+        free(dv1);
     }
 }

--- a/kharma/prob/elec/hubble.cpp
+++ b/kharma/prob/elec/hubble.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: hubble.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,7 +36,7 @@
 #include "pack.hpp"
 #include "types.hpp"
 
-TaskStatus InitializeHubble(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeHubble(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -48,23 +48,25 @@ TaskStatus InitializeHubble(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
     bool context_boundaries = pin->GetOrAddBoolean("hubble", "context_boundaries", false);
     Real dyntimes = pin->GetOrAddReal("hubble", "dyntimes", 1.0);
 
-    // Add everything to package parameters, since they continue to be needed on boundaries
+    // Add everything to package parameters, since they continue to be needed on
+    // boundaries
     int counter = -5.0;
     Params& g_params = pmb->packages.Get("GRMHD")->AllParams();
     const Real gam = g_params.Get<Real>("gamma");
-    if(!g_params.hasKey("counter")) g_params.Add("counter", counter, true);
-    Real rho0 = (mach/v0) * sqrt(gam*(gam-1));
-    Real ug0  = (v0/mach) / sqrt(gam*(gam-1));
-    if(!g_params.hasKey("rho0")) g_params.Add("rho0", rho0);
-    if(!g_params.hasKey("v0"))  g_params.Add("v0", v0);
-    if(!g_params.hasKey("ug0")) g_params.Add("ug0", ug0);
-    if(!g_params.hasKey("cooling")) g_params.Add("cooling", cooling);
-    if(!g_params.hasKey("context_boundaries")) g_params.Add("context_boundaries", context_boundaries);
+    if (!g_params.hasKey("counter")) g_params.Add("counter", counter, true);
+    Real rho0 = (mach / v0) * sqrt(gam * (gam - 1));
+    Real ug0 = (v0 / mach) / sqrt(gam * (gam - 1));
+    if (!g_params.hasKey("rho0")) g_params.Add("rho0", rho0);
+    if (!g_params.hasKey("v0")) g_params.Add("v0", v0);
+    if (!g_params.hasKey("ug0")) g_params.Add("ug0", ug0);
+    if (!g_params.hasKey("cooling")) g_params.Add("cooling", cooling);
+    if (!g_params.hasKey("context_boundaries"))
+        g_params.Add("context_boundaries", context_boundaries);
 
     // This is how we will initialize kel values later
     if (pmb->packages.AllPackages().count("Electrons")) {
         const Real fel0 = pmb->packages.Get("Electrons")->Param<Real>("fel_0");
-        if(!g_params.hasKey("ue0")) g_params.Add("ue0", fel0 * ug0);
+        if (!g_params.hasKey("ue0")) g_params.Add("ue0", fel0 * ug0);
     }
 
     // Override end time to be 1 dynamical time L/max(v@t=0)
@@ -84,7 +86,8 @@ TaskStatus InitializeHubble(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
     return TaskStatus::complete;
 }
 
-TaskStatus SetHubbleImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
+TaskStatus SetHubbleImpl(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -95,15 +98,17 @@ TaskStatus SetHubbleImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain d
     const Real rho0 = pmb->packages.Get("GRMHD")->Param<Real>("rho0");
     const Real v0 = pmb->packages.Get("GRMHD")->Param<Real>("v0");
     const bool cooling = pmb->packages.Get("GRMHD")->Param<bool>("cooling");
-    const bool context_boundaries = pmb->packages.Get("GRMHD")->Param<bool>("context_boundaries");
+    const bool context_boundaries =
+        pmb->packages.Get("GRMHD")->Param<bool>("context_boundaries");
     const Real ug0 = pmb->packages.Get("GRMHD")->Param<Real>("ug0");
-    // first time this is called in boundary conditions inside the time stepping cycle is when counter == 0
+    // first time this is called in boundary conditions inside the time stepping cycle is
+    // when counter == 0
     int counter = pmb->packages.Get("GRMHD")->Param<int>("counter");
     const Real tt = pmb->packages.Get("Globals")->Param<Real>("time");
     const Real dt = pmb->packages.Get("Globals")->Param<Real>("dt_last");
 
-    Real t = tt + 0.5*dt;
-    if ((counter%4) > 1)   t = tt + dt;
+    Real t = tt + 0.5 * dt;
+    if ((counter % 4) > 1) t = tt + dt;
 
     const auto& G = pmb->coords;
 
@@ -113,71 +118,78 @@ TaskStatus SetHubbleImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain d
 
     if (!context_boundaries || counter < 0) {
         // Setting as in equation 37
-        Real toberho = rho0 / (1. + v0*t);
-        Real tobeu  = ug0 / pow(1 + v0*t, 2);
-        if (!cooling) tobeu  = ug0 / pow(1 + v0*t, gam);
+        Real toberho = rho0 / (1. + v0 * t);
+        Real tobeu = ug0 / pow(1 + v0 * t, 2);
+        if (!cooling) tobeu = ug0 / pow(1 + v0 * t, gam);
         pmb->par_for("hubble_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 Real X[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, X);
                 rho(k, j, i) = toberho;
                 u(k, j, i) = tobeu;
-                uvec(0, k, j, i) = v0 * X[1] / (1 + v0*t);
+                uvec(0, k, j, i) = v0 * X[1] / (1 + v0 * t);
                 uvec(1, k, j, i) = 0.0;
                 uvec(2, k, j, i) = 0.0;
-            }
-        );
+            });
 
         if (pmb->packages.AllPackages().count("Electrons")) {
             GridScalar ktot = rc->Get("prims.Ktot").data;
             GridScalar kel_const = rc->Get("prims.Kel_Constant").data;
             const Real game = pmb->packages.Get("Electrons")->Param<Real>("gamma_e");
             const Real ue0 = pmb->packages.Get("GRMHD")->Param<Real>("ue0");
-            Real tobeke = (gam - 2) * (game - 1)/(game - 2) * ue0/pow(rho0, game) * pow(1 + v0*t, game-2);
-            // Without cooling, the entropy of electrons should stay the same, analytic solution.
-            if (!cooling) tobeke = (gam - 2) * (game - 1)/(game - 2) * ue0/pow(rho0, game);
+            Real tobeke = (gam - 2) * (game - 1) / (game - 2) * ue0 / pow(rho0, game) *
+                          pow(1 + v0 * t, game - 2);
+            // Without cooling, the entropy of electrons should stay the same, analytic
+            // solution.
+            if (!cooling)
+                tobeke = (gam - 2) * (game - 1) / (game - 2) * ue0 / pow(rho0, game);
             pmb->par_for("hubble_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     ktot(k, j, i) = tobeke;
-                    kel_const(k, j, i) = tobeke; //Since we are using fel = 1
-                }
-            );
+                    kel_const(k, j, i) = tobeke; // Since we are using fel = 1
+                });
         }
-    } else { // We assume the fluid is following the solution so we set the boundaries from the real zones
+    } else { // We assume the fluid is following the solution so we set the boundaries
+             // from the real zones
         // Left zone is first one to be called and counter starts at zero
-        bool left_zone = !(counter%2);
+        bool left_zone = !(counter % 2);
         int context_index = 0;
-        if (left_zone) context_index = ib.e + 1;
-        else context_index = ib.s - 1;
+        if (left_zone)
+            context_index = ib.e + 1;
+        else
+            context_index = ib.s - 1;
 
         Real context_X[GR_DIM];
         G.coord_embed(0, 0, context_index, Loci::center, context_X);
-        Real context_t = (v0*context_X[1] - uvec(0, 0, context_index))/(uvec(0, 0, context_index)*v0);
-        
+        Real context_t = (v0 * context_X[1] - uvec(0, 0, context_index)) /
+                         (uvec(0, 0, context_index) * v0);
+
         pmb->par_for("hubble_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 Real X[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, X);
                 rho(k, j, i) = rho(k, j, context_index);
                 u(k, j, i) = u(k, j, context_index);
-                uvec(0, k, j, i) = v0 * X[1] / (1 + v0*context_t);
-            }
-        );
+                uvec(0, k, j, i) = v0 * X[1] / (1 + v0 * context_t);
+            });
         if (pmb->packages.AllPackages().count("Electrons")) {
             GridScalar kel_const = rc->Get("prims.Kel_Constant").data;
             pmb->par_for("hubble_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     kel_const(k, j, i) = kel_const(k, j, context_index);
-                }
-            );
+                });
         }
     }
     pmb->packages.Get("GRMHD")->UpdateParam<int>("counter", ++counter);
     return TaskStatus::complete;
 }
 
-// TODO(BSP) Add MeshApplySource callback & convert this
-void ApplyHubbleHeating(MeshBlockData<Real> *mbase)
+// TODO(CEP) Add MeshApplySource callback & convert this
+void ApplyHubbleHeating(MeshBlockData<Real>* mbase)
 {
     auto pmb0 = mbase->GetBlockPointer();
 
@@ -186,8 +198,9 @@ void ApplyHubbleHeating(MeshBlockData<Real> *mbase)
     const VarMap m_p(prims_map, false);
 
     Real Q = 0;
-    const Real dt = pmb0->packages.Get("Globals")->Param<Real>("dt_last");  // Close enough?
-    const Real t = pmb0->packages.Get("Globals")->Param<Real>("time") + 0.5*dt;
+    const Real dt =
+        pmb0->packages.Get("Globals")->Param<Real>("dt_last"); // Close enough?
+    const Real t = pmb0->packages.Get("Globals")->Param<Real>("time") + 0.5 * dt;
     const Real v0 = pmb0->packages.Get("GRMHD")->Param<Real>("v0");
     const Real ug0 = pmb0->packages.Get("GRMHD")->Param<Real>("ug0");
     const Real gam = pmb0->packages.Get("GRMHD")->Param<Real>("gamma");
@@ -196,11 +209,11 @@ void ApplyHubbleHeating(MeshBlockData<Real> *mbase)
     auto ib = mbase->GetBoundsI(domain);
     auto jb = mbase->GetBoundsJ(domain);
     auto kb = mbase->GetBoundsK(domain);
-    auto block = IndexRange{0, P_mbase.GetDim(5)-1};
-    
+    auto block = IndexRange{0, P_mbase.GetDim(5) - 1};
+
     pmb0->par_for("heating_substep", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-            P_mbase(m_p.UU, k, j, i) += Q*dt*0.5;
-        }
-    );
+                  KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
+            P_mbase(m_p.UU, k, j, i) += Q * dt * 0.5;
+        });
 }

--- a/kharma/prob/elec/hubble.hpp
+++ b/kharma/prob/elec/hubble.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: hubble.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -47,23 +47,26 @@ using namespace parthenon;
  * Test of "Electrons" package
  * See Ressler+ 2015
  */
-TaskStatus InitializeHubble(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+TaskStatus InitializeHubble(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);
 
 /**
  * Set all values on a given domain to the Hubble flow solution,
  * for both initialization and boundary conditions.
  * Use template version when posible, which just calls through to "impl" implementation
  */
-TaskStatus SetHubbleImpl(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse);
+TaskStatus SetHubbleImpl(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse);
 
 template<IndexDomain domain>
-TaskStatus SetHubble(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse=false)
+TaskStatus SetHubble(std::shared_ptr<MeshBlockData<Real>>& rc, bool coarse = false)
 {
     return SetHubbleImpl(rc, domain, coarse);
 }
 
 /**
- * Apply the source term.  Registered as ApplyPrimSource to run at end of step, once per step operator-split
- * TODO(BSP) NAMESPACE. Needs problems as packages?
+ * Apply the source term.  Registered as ApplyPrimSource to run at end of step, once per
+ * step operator-split
+ * TODO(CEP) NAMESPACE. Needs problems as packages?
  */
-void ApplyHubbleHeating(MeshBlockData<Real> *mbase);
+void ApplyHubbleHeating(MeshBlockData<Real>* mbase);

--- a/kharma/prob/elec/noh.hpp
+++ b/kharma/prob/elec/noh.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: noh.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,14 +40,14 @@ using namespace parthenon;
 /**
  * Noh shock tube test.
  */
-TaskStatus InitializeNoh(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeNoh(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
     GridScalar u = rc->Get("prims.u").data;
     GridVector uvec = rc->Get("prims.uvec").data;
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
-    
+
     const Real mach = pin->GetOrAddReal("noh", "mach", 49.);
     const Real rho0 = pin->GetOrAddReal("noh", "rho", 1.0);
     const Real v0 = pin->GetOrAddReal("noh", "v0", 1.e-3);
@@ -62,10 +62,10 @@ TaskStatus InitializeNoh(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInpu
     // Given Mach and knowing that v = 1e-3 and rho = 1, we calculate u
     double cs2 = m::pow(v0, 2) / m::pow(mach, 2);
     double gamma = 1. / m::sqrt(1. - m::pow(v0, 2)); // Since we are in flat space
-    const Real P = (zero_ug) ? 0. : rho0 * cs2 / (gam*(gam-1) - cs2*gam);
+    const Real P = (zero_ug) ? 0. : rho0 * cs2 / (gam * (gam - 1) - cs2 * gam);
 
     if (set_tlim) {
-        pin->SetReal("parthenon/time", "tlim", 0.6*(x1max - x1min)/v0);
+        pin->SetReal("parthenon/time", "tlim", 0.6 * (x1max - x1min) / v0);
     }
 
     IndexDomain domain = IndexDomain::interior;
@@ -73,30 +73,30 @@ TaskStatus InitializeNoh(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInpu
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("noh_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             rho(k, j, i) = rho0;
-            u(k, j, i) = P/(gam - 1.);
+            u(k, j, i) = P / (gam - 1.);
             uvec(1, k, j, i) = 0.0;
             uvec(2, k, j, i) = 0.0;
-        }
-    );
+        });
     const auto& G = pmb->coords;
     if (centered) {
         pmb->par_for("noh_cent", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 Real X[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, X);
                 const bool lhs = X[1] < center;
                 uvec(0, k, j, i) = ((lhs) ? v0 : -v0) * gamma;
-            }
-        );
+            });
     } else {
         pmb->par_for("noh_left", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                u(k, j, i) = P/(gam - 1.);
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
+                u(k, j, i) = P / (gam - 1.);
                 uvec(0, k, j, i) = -v0 * gamma;
-            }
-        );
+            });
     }
 
     return TaskStatus::complete;

--- a/kharma/prob/emhd/anisotropic_conduction.hpp
+++ b/kharma/prob/emhd/anisotropic_conduction.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: anisotropic_conduction.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,7 +42,8 @@ using namespace parthenon;
 /**
  * Anisotropic heat conduction problem, see Chandra+ 2017
  */
-TaskStatus InitializeAnisotropicConduction(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeAnisotropicConduction(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -67,13 +68,14 @@ TaskStatus InitializeAnisotropicConduction(std::shared_ptr<MeshBlockData<Real>>&
     pin->GetOrAddReal("b_field", "B10", B0);
     // Amp & wavenumber of sin() for B2
     pin->GetOrAddReal("b_field", "amp2_B2", B0);
-    pin->GetOrAddReal("b_field", "k1", 2*M_PI*k0);
+    pin->GetOrAddReal("b_field", "k1", 2 * M_PI * k0);
 
     IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
     IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
     IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
     pmb->par_for("anisotropic_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
             GReal r = m::sqrt(m::pow((X[1] - 0.5), 2) + m::pow((X[2] - 0.5), 2));
@@ -86,8 +88,7 @@ TaskStatus InitializeAnisotropicConduction(std::shared_ptr<MeshBlockData<Real>>&
             uvec(2, k, j, i) = 0.;
             q(k, j, i) = 0.;
             dP(k, j, i) = 0.;
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/prob/emhd/conducting_atmosphere.cpp
+++ b/kharma/prob/emhd/conducting_atmosphere.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: conducting_atmosphere.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,12 +44,13 @@ using namespace parthenon;
 
 /**
  * Initialization of the hydrostatic conducting atmosphere test
- * 
- * The ODE solution (kharma/prob/emhd/conducting_atmosphere_${RES}_default) is the input to the code.
- * Since the ODE solution is a steady-state solution of the EMHD equations,
+ *
+ * The ODE solution (kharma/prob/emhd/conducting_atmosphere_${RES}_default) is the input
+ * to the code. Since the ODE solution is a steady-state solution of the EMHD equations,
  * the code should maintain the solution.
  */
-TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeAtmosphere(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -59,7 +60,7 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
 
     // Obtain GRMHD params
     const auto& grmhd_pars = pmb->packages.Get("GRMHD")->AllParams();
-    const Real& gam        = grmhd_pars.Get<Real>("gamma");
+    const Real& gam = grmhd_pars.Get<Real>("gamma");
 
     // Get all primitive variables (GRMHD+EMHD if in use)
     PackIndexMap prims_map;
@@ -69,7 +70,8 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     const auto& G = pmb->coords;
 
     // Type of input to the problem
-    const std::string input = pin->GetOrAddString("conducting_atmosphere", "input", "ODE");
+    const std::string input =
+        pin->GetOrAddString("conducting_atmosphere", "input", "ODE");
 
     // Set default B field parameters
     pin->GetOrAddString("b_field", "type", "monopole_cube");
@@ -84,15 +86,16 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     // TODO store as single file table. HDF5?
     char fode_rCoords[STRLEN], fode_rho[STRLEN], fode_u[STRLEN], fode_q[STRLEN];
     sprintf(fode_rCoords, "atmosphere_soln_rCoords.txt");
-    sprintf(fode_rho,     "atmosphere_soln_rho.txt");
-    sprintf(fode_u,       "atmosphere_soln_u.txt");
-    sprintf(fode_q,       "atmosphere_soln_phi.txt");
+    sprintf(fode_rho, "atmosphere_soln_rho.txt");
+    sprintf(fode_u, "atmosphere_soln_u.txt");
+    sprintf(fode_q, "atmosphere_soln_phi.txt");
 
     // Assign file pointers
-    FILE *fp_r, *fp_rho, *fp_u, *fp_q;;
-    fp_r   = fopen(fode_rCoords, "r");
+    FILE *fp_r, *fp_rho, *fp_u, *fp_q;
+    ;
+    fp_r = fopen(fode_rCoords, "r");
     fp_rho = fopen(fode_rho, "r");
-    fp_u   = fopen(fode_u,   "r");
+    fp_u = fopen(fode_u, "r");
     if (fp_r == NULL || fp_rho == NULL || fp_u == NULL) {
         throw std::runtime_error("Could not open conducting atmosphere solution!");
     }
@@ -104,15 +107,16 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     }
 
     // Get primitives individually, so we can use GetHostMirror()
-    // TODO implement VariablePack::GetHostMirror, or mirror a temporary and dump into a pack device-side
-    GridScalar rho  = rc->Get("prims.rho").data; 
-    GridScalar u    = rc->Get("prims.u").data; 
+    // TODO implement VariablePack::GetHostMirror, or mirror a temporary and dump into a
+    // pack device-side
+    GridScalar rho = rc->Get("prims.rho").data;
+    GridScalar u = rc->Get("prims.u").data;
     GridVector uvec = rc->Get("prims.uvec").data;
 
     // Host side mirror of primitives
-    auto rho_host   = rho.GetHostMirror();
-    auto u_host     = u.GetHostMirror();
-    auto uvec_host  = uvec.GetHostMirror();
+    auto rho_host = rho.GetHostMirror();
+    auto u_host = u.GetHostMirror();
+    auto uvec_host = uvec.GetHostMirror();
 
     // Then for EMHD if enabled
     const bool use_conduction = pmb->packages.Get("EMHD")->Param<bool>("conduction");
@@ -120,11 +124,11 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     GridScalar q;
     GridScalar dP;
     // Temporary initializations are necessary for auto type
-    auto q_host     = rho.GetHostMirror();
-    auto dP_host    = rho.GetHostMirror();
+    auto q_host = rho.GetHostMirror();
+    auto dP_host = rho.GetHostMirror();
     if (use_emhd && use_conduction) {
-        q  = rc->Get("prims.q").data;
-        q_host  = q.GetHostMirror();
+        q = rc->Get("prims.q").data;
+        q_host = q.GetHostMirror();
     }
     if (use_emhd && use_viscosity) {
         dP = rc->Get("prims.dP").data;
@@ -142,7 +146,10 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
         G.coord_embed(0, jb_in.s, i, Loci::center, Xembed);
         error = m::abs(Xembed[1] - rCoords[i]);
         if (error > 1.e-10) {
-            fprintf(stdout, "Error at radial zone i = %d, Error = %8.5e KHARMA: %8.7e, sage nb: %8.7e\n", i, error, Xembed[1], rCoords[i]);
+            fprintf(stdout,
+                "Error at radial zone i = %d, Error = %8.5e KHARMA: %8.7e, sage nb: "
+                "%8.7e\n",
+                i, error, Xembed[1], rCoords[i]);
             exit(-1);
         }
     }
@@ -153,32 +160,29 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
 
     for (int i = ib.s; i <= ib.e; i++) {
         fscanf(fp_rho, "%lf", &(rho_temp));
-        fscanf(fp_u,   "%lf", &(u_temp));
-        if (use_emhd)
-            fscanf(fp_q, "%lf", &(q_temp));
+        fscanf(fp_u, "%lf", &(u_temp));
+        if (use_emhd) fscanf(fp_q, "%lf", &(q_temp));
 
         for (int j = jb.s; j <= jb.e; j++) {
             for (int k = kb.s; k <= kb.e; k++) {
 
-                GReal Xnative[GR_DIM], Xembed[GR_DIM]; 
+                GReal Xnative[GR_DIM], Xembed[GR_DIM];
                 G.coord(k, j, i, Loci::center, Xnative);
                 G.coord_embed(k, j, i, Loci::center, Xembed);
 
                 // First initialize primitives that are read from .txt files
-                rho_host(k, j, i)   = rho_temp;
-                u_host(k, j, i)     = u_temp;
-                if (use_emhd)
-                    q_host(k, j, i) = q_temp;
+                rho_host(k, j, i) = rho_temp;
+                u_host(k, j, i) = u_temp;
+                if (use_emhd) q_host(k, j, i) = q_temp;
 
                 // Now the remaining primitives
-                if (use_emhd && use_viscosity)
-                    dP_host(k, j, i)   = 0.;
+                if (use_emhd && use_viscosity) dP_host(k, j, i) = 0.;
 
                 // Note that the velocity primitives defined up there aren't quite right.
-                // For a fluid at rest wrt. the normal observer, ucon = {-1/g_tt,0,0,0}. 
+                // For a fluid at rest wrt. the normal observer, ucon = {-1/g_tt,0,0,0}.
                 // We need to use this info to obtain the correct values for U1, U2 and U3
 
-                Real ucon[GR_DIM]         = {0};
+                Real ucon[GR_DIM] = {0};
                 Real gcov[GR_DIM][GR_DIM] = {0};
                 Real gcon[GR_DIM][GR_DIM] = {0};
                 // Use functions because we're host-side
@@ -198,15 +202,21 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
                 uvec_host(V3, k, j, i) = u_prim[V3];
 
                 if (use_emhd && emhd_params.higher_order_terms) {
-                    // Update q_host (and dP_host, which is zero in this problem). These are now q_tilde and dP_tilde
+                    // Update q_host (and dP_host, which is zero in this problem). These
+                    // are now q_tilde and dP_tilde
                     Real tau, chi_e, nu_e;
                     // Zeros are q, dP, and bsq, only needed for torus closure
-                    EMHD::set_parameters(G, rho_temp, u_temp, 0., 0., 0., emhd_params, gam, j, i, tau, chi_e, nu_e);
+                    EMHD::set_parameters(G, rho_temp, u_temp, 0., 0., 0., emhd_params,
+                        gam, j, i, tau, chi_e, nu_e);
                     const Real Theta = (gam - 1.) * u_temp / rho_temp;
                     if (use_conduction)
-                        q_host(k, j, i)  *= (chi_e != 0) ? m::sqrt(tau / (chi_e * rho_temp * Theta * Theta)) : 0;
+                        q_host(k, j, i) *=
+                            (chi_e != 0)
+                                ? m::sqrt(tau / (chi_e * rho_temp * Theta * Theta))
+                                : 0;
                     if (use_viscosity)
-                        dP_host(k, j, i) *= (nu_e  != 0) ? m::sqrt(tau / (nu_e * rho_temp * Theta)) : 0;
+                        dP_host(k, j, i) *=
+                            (nu_e != 0) ? m::sqrt(tau / (nu_e * rho_temp * Theta)) : 0;
                 }
             }
         }
@@ -216,18 +226,15 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     fclose(fp_r);
     fclose(fp_rho);
     fclose(fp_u);
-    if (use_emhd)
-        fclose(fp_q);
+    if (use_emhd) fclose(fp_q);
 
     // Deep copy to device
     Kokkos::fence();
     rho.DeepCopy(rho_host);
     u.DeepCopy(u_host);
     uvec.DeepCopy(uvec_host);
-    if (use_emhd && use_conduction)
-        q.DeepCopy(q_host);
-    if (use_emhd && use_viscosity)
-        dP.DeepCopy(dP_host);
+    if (use_emhd && use_conduction) q.DeepCopy(q_host);
+    if (use_emhd && use_viscosity) dP.DeepCopy(dP_host);
     Kokkos::fence();
 
     // Also fill cons
@@ -237,5 +244,4 @@ TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     KBoundaries::FreezeDirichletBlock(rc.get());
 
     return TaskStatus::complete;
-
 }

--- a/kharma/prob/emhd/conducting_atmosphere.hpp
+++ b/kharma/prob/emhd/conducting_atmosphere.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: conducting_atmosphere.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,16 +33,16 @@
  */
 #pragma once
 
+#include "coordinate_utils.hpp"
 #include "decs.hpp"
 #include "emhd.hpp"
-#include "gr_coordinates.hpp"
 #include "flux_functions.hpp"
+#include "gr_coordinates.hpp"
 #include "grmhd_functions.hpp"
 #include "pack.hpp"
-#include "coordinate_utils.hpp"
 #include "types.hpp"
 
 #include <parthenon/parthenon.hpp>
 
-TaskStatus InitializeAtmosphere(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
-
+TaskStatus InitializeAtmosphere(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);

--- a/kharma/prob/emhd/emhdmodes.hpp
+++ b/kharma/prob/emhd/emhdmodes.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhdmodes.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,25 +37,26 @@
 
 #include "decs.hpp"
 
-
 using namespace std::literals::complex_literals;
 using namespace parthenon;
 
 /**
- * Initialization of analytic wave modes in magnetized plasma w/viscosity and heat conduction
- * 
+ * Initialization of analytic wave modes in magnetized plasma w/viscosity and heat
+ * conduction
+ *
  * Note the end time is not set -- even after exactly 1 period, EMHD modes will
  * have lost amplitude due to having viscosity, which is kind of the point
  */
-TaskStatus InitializeEMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeEMHDModes(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
-    GridScalar rho  = rc->Get("prims.rho").data;
-    GridScalar u    = rc->Get("prims.u").data;
+    GridScalar rho = rc->Get("prims.rho").data;
+    GridScalar u = rc->Get("prims.u").data;
     GridVector uvec = rc->Get("prims.uvec").data;
     // It is well and good this problem should cry if EMHD is disabled.
-    GridVector q   = rc->Get("prims.q").data;
-    GridVector dP  = rc->Get("prims.dP").data;
+    GridVector q = rc->Get("prims.q").data;
+    GridVector dP = rc->Get("prims.dP").data;
 
     const auto& G = pmb->coords;
 
@@ -66,8 +67,10 @@ TaskStatus InitializeEMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     const Real& gam = grmhd_pars.Get<Real>("gamma");
 
     // TODO actually calculate the mode?  Figure something out
-    const Real omega_real = pin->GetOrAddReal("emhdmodes", "omega_real", -0.5533585207638141);
-    const Real omega_imag = pin->GetOrAddReal("emhdmodes", "omega_imag", -3.6262571286888425);
+    const Real omega_real =
+        pin->GetOrAddReal("emhdmodes", "omega_real", -0.5533585207638141);
+    const Real omega_imag =
+        pin->GetOrAddReal("emhdmodes", "omega_imag", -3.6262571286888425);
 
     // START POSSIBLE ARGS: take all these as parameters in pin?
     // Also note this is 2D only for now
@@ -80,7 +83,7 @@ TaskStatus InitializeEMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     const Real B10 = 0.1;
     const Real B20 = 0.3;
     const Real B30 = 0.;
-    const Real q0   = 0.;
+    const Real q0 = 0.;
     const Real delta_p0 = 0.;
 
     // Wavevector
@@ -107,20 +110,26 @@ TaskStatus InitializeEMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("emhdmodes_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
-            const Real cos_phi = m::cos(k1*X[1] + k2*X[2]);
-            const Real sin_phi = m::sin(k1*X[1] + k2*X[2]);
+            const Real cos_phi = m::cos(k1 * X[1] + k2 * X[2]);
+            const Real sin_phi = m::sin(k1 * X[1] + k2 * X[2]);
 
             // Perturbations: no higher-order terms
-            const Real drho     = amp * (((-0.518522524082246)*cos_phi) + ((0.1792647678001878)*sin_phi));
-            const Real du       = amp * ((0.5516170736393813)*cos_phi);
-            const Real du1      = amp * (((0.008463122479547856)*cos_phi) + ((-0.011862022608466367)*sin_phi));
-            const Real du2      = amp * (((-0.16175466371870734)*cos_phi) + ((0.034828080823603294)*sin_phi));
-            const Real du3      = 0.;
-            const Real dq       = amp * (((0.5233486841539436)*cos_phi) - ((0.04767672501939603)*sin_phi));
-            const Real ddelta_p = amp * (((0.2909106062057657)*cos_phi) - ((0.02159452055336572)*sin_phi));
+            const Real drho = amp * (((-0.518522524082246) * cos_phi) +
+                                        ((0.1792647678001878) * sin_phi));
+            const Real du = amp * ((0.5516170736393813) * cos_phi);
+            const Real du1 = amp * (((0.008463122479547856) * cos_phi) +
+                                       ((-0.011862022608466367) * sin_phi));
+            const Real du2 = amp * (((-0.16175466371870734) * cos_phi) +
+                                       ((0.034828080823603294) * sin_phi));
+            const Real du3 = 0.;
+            const Real dq = amp * (((0.5233486841539436) * cos_phi) -
+                                      ((0.04767672501939603) * sin_phi));
+            const Real ddelta_p = amp * (((0.2909106062057657) * cos_phi) -
+                                            ((0.02159452055336572) * sin_phi));
 
             // Initialize primitives
             rho(k, j, i) = rho0 + drho;
@@ -134,13 +143,16 @@ TaskStatus InitializeEMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
             if (emhd_params.higher_order_terms) {
                 Real tau, chi_e, nu_e;
                 // Zeros are q, dP, and bsq, only needed for torus closure
-                EMHD::set_parameters(G, rho(k, j, i), u(k, j, i), 0., 0., 0., emhd_params, gam, j, i, tau, chi_e, nu_e);
+                EMHD::set_parameters(G, rho(k, j, i), u(k, j, i), 0., 0., 0., emhd_params,
+                    gam, j, i, tau, chi_e, nu_e);
                 Real Theta = (gam - 1) * u(k, j, i) / rho(k, j, i);
-                q(k, j, i)  *= (chi_e != 0) ? m::sqrt(tau / (chi_e * rho(k, j, i) * Theta * Theta)) : 0.;
-                dP(k, j, i) *= (nu_e  != 0) ? m::sqrt(tau / (nu_e * rho(k, j, i) * Theta)) : 0.;
+                q(k, j, i) *= (chi_e != 0)
+                                  ? m::sqrt(tau / (chi_e * rho(k, j, i) * Theta * Theta))
+                                  : 0.;
+                dP(k, j, i) *=
+                    (nu_e != 0) ? m::sqrt(tau / (nu_e * rho(k, j, i) * Theta)) : 0.;
             }
-        }
-    );
+        });
 
     Flux::BlockPtoU(rc.get(), IndexDomain::interior, false);
 

--- a/kharma/prob/emhd/emhdshock.hpp
+++ b/kharma/prob/emhd/emhdshock.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: emhdshock.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -42,27 +42,31 @@ using namespace parthenon;
 #define STRLEN 2048
 
 /**
- * Initialization of the EMHD shock test in magnetized plasma w/viscosity and heat conduction
- * 
+ * Initialization of the EMHD shock test in magnetized plasma w/viscosity and heat
+ * conduction
+ *
  * The BVP solution (kharma/prob/emhd/shock_soln_${RES}_default) is the input to the code.
- * Since the BVP solution is a steady-state, time-independent solution of the EMHD equations,
- * the code should maintain the solution.
- * 
- * An alternate option is to initialize with the ideal MHD Rankine-Hugoniot jump condition.
- * If higher order terms have been implemented correctly, the primitives should relax to the
- * steady state solution. However, they may differ by a translation to the BVP solution.
- * 
- * Therefore, to quantitatively check the EMHD implementation, we prefer the BVP solution as the input.
+ * Since the BVP solution is a steady-state, time-independent solution of the EMHD
+ * equations, the code should maintain the solution.
+ *
+ * An alternate option is to initialize with the ideal MHD Rankine-Hugoniot jump
+ * condition. If higher order terms have been implemented correctly, the primitives should
+ * relax to the steady state solution. However, they may differ by a translation to the
+ * BVP solution.
+ *
+ * Therefore, to quantitatively check the EMHD implementation, we prefer the BVP solution
+ * as the input.
  */
-TaskStatus InitializeEMHDShock(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeEMHDShock(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
-    GridScalar rho  = rc->Get("prims.rho").data;
-    GridScalar u    = rc->Get("prims.u").data;
+    GridScalar rho = rc->Get("prims.rho").data;
+    GridScalar u = rc->Get("prims.u").data;
     GridVector uvec = rc->Get("prims.uvec").data;
-    GridVector q    = rc->Get("prims.q").data;
-    GridVector dP   = rc->Get("prims.dP").data;
+    GridVector q = rc->Get("prims.q").data;
+    GridVector dP = rc->Get("prims.dP").data;
 
     const auto& G = pmb->coords;
 
@@ -77,8 +81,8 @@ TaskStatus InitializeEMHDShock(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     // Obtain EMHD params
     const EMHD::EMHD_parameters& emhd_params = EMHD::GetEMHDParameters(pmb->packages);
     // Obtain GRMHD params
-    const auto& grmhd_pars                   = pmb->packages.Get("GRMHD")->AllParams();
-    const Real& gam                          = grmhd_pars.Get<Real>("gamma");
+    const auto& grmhd_pars = pmb->packages.Get("GRMHD")->AllParams();
+    const Real& gam = grmhd_pars.Get<Real>("gamma");
 
     // Bounds of the domain
     IndexDomain domain = IndexDomain::interior;
@@ -86,47 +90,49 @@ TaskStatus InitializeEMHDShock(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
 
-    if (input == "BVP"){
+    if (input == "BVP") {
 
         // Load file names into strings
-        char fbvp_rho[STRLEN], fbvp_u[STRLEN], fbvp_u1[STRLEN], fbvp_q[STRLEN], fbvp_dP[STRLEN];
+        char fbvp_rho[STRLEN], fbvp_u[STRLEN], fbvp_u1[STRLEN], fbvp_q[STRLEN],
+            fbvp_dP[STRLEN];
         sprintf(fbvp_rho, "shock_soln_rho.txt");
-        sprintf(fbvp_u,   "shock_soln_u.txt");
-        sprintf(fbvp_u1,  "shock_soln_u1.txt");
-        sprintf(fbvp_q,   "shock_soln_q.txt");
-        sprintf(fbvp_dP,  "shock_soln_dP.txt");
+        sprintf(fbvp_u, "shock_soln_u.txt");
+        sprintf(fbvp_u1, "shock_soln_u1.txt");
+        sprintf(fbvp_q, "shock_soln_q.txt");
+        sprintf(fbvp_dP, "shock_soln_dP.txt");
 
         // Assign file pointers
         FILE *fp_rho, *fp_u, *fp_u1, *fp_q, *fp_dP;
         fp_rho = fopen(fbvp_rho, "r");
-        fp_u   = fopen(fbvp_u,   "r");
-        fp_u1  = fopen(fbvp_u1,  "r");
-        fp_q   = fopen(fbvp_q,   "r");
-        fp_dP  = fopen(fbvp_dP,  "r");
+        fp_u = fopen(fbvp_u, "r");
+        fp_u1 = fopen(fbvp_u1, "r");
+        fp_q = fopen(fbvp_q, "r");
+        fp_dP = fopen(fbvp_dP, "r");
 
-        if (fp_rho == NULL || fp_u == NULL || fp_u1 == NULL || fp_q == NULL || fp_dP == NULL) {
+        if (fp_rho == NULL || fp_u == NULL || fp_u1 == NULL || fp_q == NULL ||
+            fp_dP == NULL) {
             throw std::runtime_error("Could not open conducting atmosphere solution!");
         }
 
-        auto rho_host   = rho.GetHostMirror();
-        auto u_host     = u.GetHostMirror();
-        auto uvec_host  = uvec.GetHostMirror();
-        auto q_host     = q.GetHostMirror();
-        auto dP_host    = dP.GetHostMirror();
+        auto rho_host = rho.GetHostMirror();
+        auto u_host = u.GetHostMirror();
+        auto uvec_host = uvec.GetHostMirror();
+        auto q_host = q.GetHostMirror();
+        auto dP_host = dP.GetHostMirror();
 
         for (int k = kb.s; k <= kb.e; k++) {
             for (int j = jb.s; j <= jb.e; j++) {
-                for (int i = ib.s; i <= ib.e; i++) { 
+                for (int i = ib.s; i <= ib.e; i++) {
 
                     Real X[GR_DIM];
                     G.coord_embed(k, j, i, Loci::center, X);
 
                     // First initialize primitives that are read from .txt files
                     fscanf(fp_rho, "%lf", &(rho_host(k, j, i)));
-                    fscanf(fp_u,   "%lf", &(u_host(k, j, i)));
-                    fscanf(fp_u1,  "%lf", &(uvec_host(0, k, j, i)));
-                    fscanf(fp_q,   "%lf", &(q_host(k, j, i)));
-                    fscanf(fp_dP,  "%lf", &(dP_host(k, j, i)));
+                    fscanf(fp_u, "%lf", &(u_host(k, j, i)));
+                    fscanf(fp_u1, "%lf", &(uvec_host(0, k, j, i)));
+                    fscanf(fp_q, "%lf", &(q_host(k, j, i)));
+                    fscanf(fp_dP, "%lf", &(dP_host(k, j, i)));
 
                     // Now the remaining primitives
                     uvec_host(1, k, j, i) = 0.;
@@ -135,23 +141,29 @@ TaskStatus InitializeEMHDShock(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
                     if (emhd_params.higher_order_terms) {
 
                         // Initialize local variables (for improved readability)
-                        const Real rho_temp   = rho_host(k, j, i);
-                        const Real u_temp     = u_host(k, j, i);
-                        const Real Theta      = (gam - 1.) * u_temp / rho_temp;
+                        const Real rho_temp = rho_host(k, j, i);
+                        const Real u_temp = u_host(k, j, i);
+                        const Real Theta = (gam - 1.) * u_temp / rho_temp;
 
                         // Set EMHD parameters
                         Real tau, chi_e, nu_e;
                         // Zeros are q, dP, and bsq, only needed for torus closure
-                        EMHD::set_parameters(G, rho_temp, u_temp, 0., 0., 0., emhd_params, gam, j, i, tau, chi_e, nu_e);
+                        EMHD::set_parameters(G, rho_temp, u_temp, 0., 0., 0., emhd_params,
+                            gam, j, i, tau, chi_e, nu_e);
 
                         // Update q and dP (which now are q_tilde and dP_tilde)
-                        Real q_tilde  = q_host(k, j, i);
+                        Real q_tilde = q_host(k, j, i);
                         Real dP_tilde = dP_host(k, j, i);
                         if (emhd_params.higher_order_terms) {
-                            q_tilde  *= (chi_e != 0) ? m::sqrt(tau / (chi_e * rho_temp * Theta * Theta)) : 0.;
-                            dP_tilde *= (nu_e  != 0) ? m::sqrt(tau / (nu_e * rho_temp * Theta)) : 0.;
+                            q_tilde *=
+                                (chi_e != 0)
+                                    ? m::sqrt(tau / (chi_e * rho_temp * Theta * Theta))
+                                    : 0.;
+                            dP_tilde *= (nu_e != 0)
+                                            ? m::sqrt(tau / (nu_e * rho_temp * Theta))
+                                            : 0.;
                         }
-                        q_host(k, j, i)  = q_tilde;
+                        q_host(k, j, i) = q_tilde;
                         dP_host(k, j, i) = dP_tilde;
                     }
                 }
@@ -180,35 +192,33 @@ TaskStatus InitializeEMHDShock(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
         const Real x1max = pin->GetReal("parthenon/mesh", "x1max");
 
         // Left and right states
-        double rhoL = 1.,     rhoR = 3.08312999;
-        double uL   = 1.,     uR   = 4.94577705;
-        double u1L  = 1.,     u1R  = 0.32434571;
-        double u2L  = 0.,     u2R  = 0.;
-        double u3L  = 0.,     u3R  = 0.;
+        double rhoL = 1., rhoR = 3.08312999;
+        double uL = 1., uR = 4.94577705;
+        double u1L = 1., u1R = 0.32434571;
+        double u2L = 0., u2R = 0.;
+        double u3L = 0., u3R = 0.;
         const GReal x1_center = (x1min + x1max) / 2.;
 
         pmb->par_for("emhdshock_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 Real X[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, X);
 
                 bool lhs = X[1] < x1_center;
 
                 // Initialize primitives
-                rho(k, j, i)      = (lhs) ? rhoL : rhoR;
-                u(k, j, i)        = (lhs) ? uL : uR;
+                rho(k, j, i) = (lhs) ? rhoL : rhoR;
+                u(k, j, i) = (lhs) ? uL : uR;
                 uvec(V1, k, j, i) = (lhs) ? u1L : u1R;
                 uvec(V2, k, j, i) = (lhs) ? u2L : u2R;
                 uvec(V3, k, j, i) = (lhs) ? u3L : u3R;
-                q(k ,j, i)       = 0.;   
-                dP(k ,j, i)      = 0.;   
-
+                q(k, j, i) = 0.;
+                dP(k, j, i) = 0.;
             }
 
         );
     }
 
     return TaskStatus::complete;
-
 }

--- a/kharma/prob/explosion.hpp
+++ b/kharma/prob/explosion.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: explosion.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,18 +37,18 @@
 
 #include "decs.hpp"
 
-
 using namespace std::literals::complex_literals;
 using namespace parthenon;
 
 /**
  * Initialization of the strong cylindrical explosion of Komissarov 1999 section 7.3
- * 
+ *
  * Note the problem setup assumes gamma=4/3
- * 
+ *
  * Originally run on 2D Cartesian domain -6.0, 6.0 with a 200x200 grid, to tlim=4.0
  */
-TaskStatus InitializeExplosion(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeExplosion(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -62,9 +62,9 @@ TaskStatus InitializeExplosion(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
 
     // All options are runtime options!
     const bool linear_ramp = pin->GetOrAddBoolean("explosion", "linear_ramp", false);
-    const Real u_out = pin->GetOrAddReal("explosion", "u_out", 3.e-5 / (gam-1));
+    const Real u_out = pin->GetOrAddReal("explosion", "u_out", 3.e-5 / (gam - 1));
     const Real rho_out = pin->GetOrAddReal("explosion", "rho_out", 1.e-4);
-    const Real u_in = pin->GetOrAddReal("explosion", "u_in", 1.0 / (gam-1));
+    const Real u_in = pin->GetOrAddReal("explosion", "u_in", 1.0 / (gam - 1));
     const Real rho_in = pin->GetOrAddReal("explosion", "rho_in", 1.e-2);
 
     // One buffer zone of linear decline, r_in -> r_out
@@ -80,12 +80,13 @@ TaskStatus InitializeExplosion(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("explosion_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
             const GReal rx = X[1] - xoff;
             const GReal ry = X[2] - yoff;
-            const Real r = m::sqrt(rx*rx + ry*ry);
+            const Real r = m::sqrt(rx * rx + ry * ry);
 
             if (r < r_in) {
                 rho(k, j, i) = rho_in;
@@ -108,8 +109,7 @@ TaskStatus InitializeExplosion(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
                 rho(k, j, i) = rho_out;
                 u(k, j, i) = u_out;
             }
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/prob/fm_torus.cpp
+++ b/kharma/prob/fm_torus.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: fm_torus.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,23 +34,24 @@
 
 #include "fm_torus.hpp"
 
-#include "floors.hpp"
 #include "coordinate_utils.hpp"
+#include "floors.hpp"
 #include "types.hpp"
 
-TaskStatus InitializeFMTorus(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeFMTorus(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
-    auto pmb        = rc->GetBlockPointer();
-    GridScalar rho  = rc->Get("prims.rho").data;
-    GridScalar u    = rc->Get("prims.u").data;
+    auto pmb = rc->GetBlockPointer();
+    GridScalar rho = rc->Get("prims.rho").data;
+    GridScalar u = rc->Get("prims.u").data;
     GridVector uvec = rc->Get("prims.uvec").data;
 
-    const GReal rin      = pin->GetOrAddReal("torus", "rin", 6.0);
-    const GReal rmax     = pin->GetOrAddReal("torus", "rmax", 12.0);
-    const Real kappa     = pin->GetOrAddReal("torus", "kappa", 1.e-3);
+    const GReal rin = pin->GetOrAddReal("torus", "rin", 6.0);
+    const GReal rmax = pin->GetOrAddReal("torus", "rmax", 12.0);
+    const Real kappa = pin->GetOrAddReal("torus", "kappa", 1.e-3);
     const GReal tilt_deg = pin->GetOrAddReal("torus", "tilt", 0.0);
-    const GReal tilt     = tilt_deg / 180. * M_PI;
-    const Real gam       = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
+    const GReal tilt = tilt_deg / 180. * M_PI;
+    const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
     IndexDomain domain = IndexDomain::interior;
     const int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
@@ -69,14 +70,15 @@ TaskStatus InitializeFMTorus(std::shared_ptr<MeshBlockData<Real>>& rc, Parameter
     Real l = lfish_calc(a, rmax);
 
     pmb->par_for("fm_torus_init", ks, ke, js, je, is, ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             GReal Xnative[GR_DIM], Xembed[GR_DIM], Xmidplane[GR_DIM];
             G.coord(k, j, i, Loci::center, Xnative);
             G.coord_embed(k, j, i, Loci::center, Xembed);
             // What are our corresponding "midplane" values for evaluating the function?
             rotate_polar(Xembed, tilt, Xmidplane);
 
-            GReal r   = Xmidplane[1], th = Xmidplane[2];
+            GReal r = Xmidplane[1], th = Xmidplane[2];
             GReal sth = sin(th);
             GReal cth = cos(th);
 
@@ -87,22 +89,22 @@ TaskStatus InitializeFMTorus(std::shared_ptr<MeshBlockData<Real>>& rc, Parameter
             // so it needs to be transformed at the end
             // everything outside is left 0 to be added by the floors
             if (lnh >= 0. && r >= rin) {
-                Real r2 = r*r;
-                Real a2 = a*a;
+                Real r2 = r * r;
+                Real a2 = a * a;
                 Real DD = r2 - 2. * r + a2;
                 Real AA = m::pow(r2 + a2, 2) - DD * a2 * sth * sth;
                 Real SS = r2 + a2 * cth * cth;
 
                 // Calculate rho and u
-                Real hm1   = m::exp(lnh) - 1.;
+                Real hm1 = m::exp(lnh) - 1.;
                 Real rho_l = m::pow(hm1 * (gam - 1.) / (kappa * gam), 1. / (gam - 1.));
-                Real u_l   = kappa * m::pow(rho_l, gam) / (gam - 1.);
+                Real u_l = kappa * m::pow(rho_l, gam) / (gam - 1.);
 
                 // Calculate u^phi
                 Real expm2chi = SS * SS * DD / (AA * AA * sth * sth);
-                Real up1      = m::sqrt((-1. + m::sqrt(1. + 4. * l * l * expm2chi)) / 2.);
-                Real up       = 2. * a * r * m::sqrt(1. + up1 * up1) / m::sqrt(AA * SS * DD) +
-                                m::sqrt(SS / AA) * up1 / sth;
+                Real up1 = m::sqrt((-1. + m::sqrt(1. + 4. * l * l * expm2chi)) / 2.);
+                Real up = 2. * a * r * m::sqrt(1. + up1 * up1) / m::sqrt(AA * SS * DD) +
+                          m::sqrt(SS / AA) * up1 / sth;
 
                 const Real ucon_tilt[GR_DIM] = {0., 0., 0., up};
                 Real ucon_bl[GR_DIM];
@@ -124,72 +126,75 @@ TaskStatus InitializeFMTorus(std::shared_ptr<MeshBlockData<Real>>& rc, Parameter
                 uvec(1, k, j, i) = u_prim[1];
                 uvec(2, k, j, i) = u_prim[2];
             }
-        }
-    );
+        });
 
-    // Find rho_max "analytically" by looking over the whole mesh domain for the maximum in the midplane
-    // Done device-side for speed (for large 2D meshes this may get bad) but may work fine in HostSpace
-    // Note this covers the full domain on each rank: it doesn't need a grid so it's not a memory problem,
-    // and an MPI synch as is done for beta_min would be a headache
-    GReal x1min = pmb->pmy_mesh->mesh_size.xmin(X1DIR); // TODO probably could get domain from GRCoords
+    // Find rho_max "analytically" by looking over the whole mesh domain for the maximum
+    // in the midplane Done device-side for speed (for large 2D meshes this may get bad)
+    // but may work fine in HostSpace Note this covers the full domain on each rank: it
+    // doesn't need a grid so it's not a memory problem, and an MPI synch as is done for
+    // beta_min would be a headache
+    GReal x1min = pmb->pmy_mesh->mesh_size.xmin(
+        X1DIR); // TODO probably could get domain from GRCoords
     GReal x1max = pmb->pmy_mesh->mesh_size.xmax(X1DIR);
     // Add back 2D if torus solution may not be largest in midplane (before tilt ofc)
-    //GReal x2min = pmb->pmy_mesh->mesh_size.x2min;
-    //GReal x2max = pmb->pmy_mesh->mesh_size.x2max;
+    // GReal x2min = pmb->pmy_mesh->mesh_size.x2min;
+    // GReal x2max = pmb->pmy_mesh->mesh_size.x2max;
     GReal dx = 0.001;
     int nx1 = (x1max - x1min) / dx;
-    //int nx2 = (x2max - x2min) / dx;
+    // int nx2 = (x2max - x2min) / dx;
 
-    // If we print diagnostics, do so only from block 0 as the others do exactly the same thing
-    // Since this is initialization, we are guaranteed to have a block 0
+    // If we print diagnostics, do so only from block 0 as the others do exactly the same
+    // thing Since this is initialization, we are guaranteed to have a block 0
     if (pmb->gid == 0 && pmb->packages.Get("Globals")->Param<int>("verbose") > 0) {
         std::cout << "Calculating maximum density:" << std::endl;
         std::cout << "a = " << a << std::endl;
         std::cout << "dx = " << dx << std::endl;
         std::cout << "x1min->x1max: " << x1min << " " << x1max << std::endl;
         std::cout << "nx1 = " << nx1 << std::endl;
-        //cout << "x2min->x2max: " << x2min << " " << x2max << std::endl;
-        //cout << "nx2 = " << nx2 << std::endl;
+        // cout << "x2min->x2max: " << x2min << " " << x2max << std::endl;
+        // cout << "nx2 = " << nx2 << std::endl;
     }
 
     // TODO split this out
     Real rho_max = 0;
     Kokkos::Max<Real> max_reducer(rho_max);
-    pmb->par_reduce("fm_torus_maxrho", 0, nx1,
-        KOKKOS_LAMBDA (const int &i, parthenon::Real &local_result) {
-            GReal x1 = x1min + i*dx;
-            //GReal x2 = x2min + j*dx;
-            GReal Xnative[GR_DIM] = {0,x1,0,0};
+    pmb->par_reduce(
+        "fm_torus_maxrho", 0, nx1,
+        KOKKOS_LAMBDA(const int& i, parthenon::Real& local_result)
+        {
+            GReal x1 = x1min + i * dx;
+            // GReal x2 = x2min + j*dx;
+            GReal Xnative[GR_DIM] = {0, x1, 0, 0};
             GReal Xembed[GR_DIM];
             G.coords.coord_to_embed(Xnative, Xembed);
             const GReal r = Xembed[1];
             // Regardless of native coordinate shenanigans,
             // set th=pi/2 since the midplane is densest in the solution
-            const GReal rho = fm_torus_rho(a, rin, rmax, gam, kappa, r, M_PI/2.);
+            const GReal rho = fm_torus_rho(a, rin, rmax, gam, kappa, r, M_PI / 2.);
             // TODO umax for printing/recording?
 
             // Record max
             if (rho > local_result) local_result = rho;
-        }
-    , max_reducer);
+        },
+        max_reducer);
 
     // Record and print normalization factor
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("rho_norm")))
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("rho_norm")))
         pmb->packages.Get("GRMHD")->AllParams().Add("rho_norm", rho_max);
     if (pmb->gid == 0 && pmb->packages.Get("Globals")->Param<int>("verbose") > 0) {
         std::cout << "Initial maximum density is " << rho_max << std::endl;
     }
 
     pmb->par_for("fm_torus_normalize", ks, ke, js, je, is, ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             rho(k, j, i) /= rho_max;
             u(k, j, i) /= rho_max;
-        }
-    );
+        });
 
-    // Apply floors to initialize the rest of the domain (regardless whether we'll use them later)
-    // Since the conserved vars U are not initialized, this is effectively done in *fluid frame*,
-    // even if NOF frame is chosen (iharm3d does the same iiuc)
+    // Apply floors to initialize the rest of the domain (regardless whether we'll use
+    // them later) Since the conserved vars U are not initialized, this is effectively
+    // done in *fluid frame*, even if NOF frame is chosen (iharm3d does the same iiuc)
     // This is probably not a huge issue, just good to state explicitly
     Floors::ApplyInitialFloors(pin, rc.get(), IndexDomain::interior);
 

--- a/kharma/prob/fm_torus.hpp
+++ b/kharma/prob/fm_torus.hpp
@@ -10,21 +10,23 @@
  * @param rin is the torus innermost radius, in r_g
  * @param rmax is the radius of maximum density of the F-M torus in r_g
  */
-TaskStatus InitializeFMTorus(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+TaskStatus InitializeFMTorus(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);
 
 /**
- * Torus solution for ln h, See Fishbone and Moncrief eqn. 3.6. 
+ * Torus solution for ln h, See Fishbone and Moncrief eqn. 3.6.
  */
-KOKKOS_INLINE_FUNCTION Real lnh_calc(const GReal a, const Real l, const GReal rin, const GReal r, const GReal th)
+KOKKOS_INLINE_FUNCTION Real lnh_calc(
+    const GReal a, const Real l, const GReal rin, const GReal r, const GReal th)
 {
     // TODO this isn't faster than splitting into two evaluations of a sub-function,
     // and it doesn't matter anyway.  Make it clearer
     Real sth = m::sin(th);
     Real cth = m::cos(th);
 
-    Real r2 = r*r;
-    Real a2 = a*a;
-    // Metric 
+    Real r2 = r * r;
+    Real a2 = a * a;
+    // Metric
     Real DD = r2 - 2. * r + a2;
     Real AA = m::pow(r2 + a2, 2) - DD * a2 * sth * sth;
     Real SS = r2 + a2 * cth * cth;
@@ -39,25 +41,17 @@ KOKKOS_INLINE_FUNCTION Real lnh_calc(const GReal a, const Real l, const GReal ri
     Real SSin = rin2 + a2 * cthin * cthin;
 
     if (r >= rin) {
-        return
-            0.5 *
-                m::log((1. +
-                        m::sqrt(1. +
-                            4. * (l * l * SS * SS) * DD / (AA * AA * sth * sth))) /
-                    (SS * DD / AA)) -
-            0.5 * m::sqrt(1. +
-                        4. * (l * l * SS * SS) * DD /
-                            (AA * AA * sth * sth)) -
-            2. * a * r * l / AA -
-                (0.5 *
-                    m::log((1. +
-                        m::sqrt(1. +
-                            4. * (l * l * SSin * SSin) * DDin /
-                                (AAin * AAin * sthin * sthin))) /
-                        (SSin * DDin / AAin)) -
-                0.5 * m::sqrt(1. +
-                        4. * (l * l * SSin * SSin) * DDin / (AAin * AAin * sthin * sthin)) -
-                2. * a * rin * l / AAin);
+        return 0.5 * m::log((1. + m::sqrt(1. + 4. * (l * l * SS * SS) * DD /
+                                                   (AA * AA * sth * sth))) /
+                            (SS * DD / AA)) -
+               0.5 * m::sqrt(1. + 4. * (l * l * SS * SS) * DD / (AA * AA * sth * sth)) -
+               2. * a * r * l / AA -
+               (0.5 * m::log((1. + m::sqrt(1. + 4. * (l * l * SSin * SSin) * DDin /
+                                                    (AAin * AAin * sthin * sthin))) /
+                             (SSin * DDin / AAin)) -
+                   0.5 * m::sqrt(1. + 4. * (l * l * SSin * SSin) * DDin /
+                                          (AAin * AAin * sthin * sthin)) -
+                   2. * a * rin * l / AAin);
     } else {
         return 1.;
     }
@@ -73,33 +67,31 @@ KOKKOS_INLINE_FUNCTION Real lnh_calc(const GReal a, const Real l, const GReal ri
 KOKKOS_INLINE_FUNCTION Real lfish_calc(const GReal a, const GReal r)
 {
     GReal sqtr = m::sqrt(r);
-    return ((a*a - 2. * a * sqtr + r*r) *
-             ((-2. * a * r * (a*a - 2. * a * sqtr + r*r)) /
-                  m::sqrt(2. * a * sqtr + (-3. + r) * r) +
-              ((a + (-2. + r) * sqtr) * (r*r*r + a*a * (2. + r))) /
-                  m::sqrt(1 + (2. * a) / m::pow(r, 1.5) - 3. / r))) /
-            (r*r*r * m::sqrt(2. * a * sqtr + (-3. + r) * r) *
-             (a*a + (-2. + r) * r));
+    return ((a * a - 2. * a * sqtr + r * r) *
+               ((-2. * a * r * (a * a - 2. * a * sqtr + r * r)) /
+                       m::sqrt(2. * a * sqtr + (-3. + r) * r) +
+                   ((a + (-2. + r) * sqtr) * (r * r * r + a * a * (2. + r))) /
+                       m::sqrt(1 + (2. * a) / m::pow(r, 1.5) - 3. / r))) /
+           (r * r * r * m::sqrt(2. * a * sqtr + (-3. + r) * r) * (a * a + (-2. + r) * r));
 }
 
 /**
  * Torus solution for density at a given location.
- * 
+ *
  * This function is *not* used for the actual initialization (where rho is calculated
  * alongside the other primitive variables).  Rather, it is for:
  * 1. Normalization, in which the max of this function over the domain is calculated.
  * 2. B field initialization, which requires density of the untilted disk for simplicity
  */
-KOKKOS_INLINE_FUNCTION Real fm_torus_rho(const GReal a, const GReal rin, const GReal rmax, const Real gam,
-                                         const Real kappa, const GReal r, const GReal th)
+KOKKOS_INLINE_FUNCTION Real fm_torus_rho(const GReal a, const GReal rin, const GReal rmax,
+    const Real gam, const Real kappa, const GReal r, const GReal th)
 {
     Real l = lfish_calc(a, rmax);
     Real lnh = lnh_calc(a, l, rin, r, th);
     if (lnh >= 0. && r >= rin) {
         // Calculate rho
         Real hm1 = m::exp(lnh) - 1.;
-        return m::pow(hm1 * (gam - 1.) / (kappa * gam),
-                            1. / (gam - 1.));
+        return m::pow(hm1 * (gam - 1.) / (kappa * gam), 1. / (gam - 1.));
     } else {
         return 0;
     }

--- a/kharma/prob/gizmo.cpp
+++ b/kharma/prob/gizmo.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: bondi.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,9 +39,9 @@
 
 /**
  * Initialization of domain from output of cosmological simulation code GIZMO
- * Note this requires 
+ * Note this requires
  */
-TaskStatus InitializeGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -50,29 +50,31 @@ TaskStatus InitializeGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterIn
 
     // Set the innermost radius to apply the initialization
     const Real a = pin->GetReal("coordinates", "a");
-    const Real rin_default = 1 + m::sqrt(1 - a*a) + 0.1;
+    const Real rin_default = 1 + m::sqrt(1 - a * a) + 0.1;
     const Real rin_init = pin->GetOrAddReal("gizmo", "r_in", rin_default);
 
     auto datfn = pin->GetOrAddString("gizmo", "datfn", "none");
 
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("gizmo_dat")))
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("gizmo_dat")))
         pmb->packages.Get("GRMHD")->AddParam<std::string>("gizmo_dat", datfn);
-    if(! (pmb->packages.Get("GRMHD")->AllParams().hasKey("rin_init")))
+    if (!(pmb->packages.Get("GRMHD")->AllParams().hasKey("rin_init")))
         pmb->packages.Get("GRMHD")->AddParam<Real>("rin_init", rin_init);
 
     // Set the interior domain to the analytic solution to begin
-    // This tests that PostInitialize will correctly fill ghost zones with the boundary we set
+    // This tests that PostInitialize will correctly fill ghost zones with the boundary we
+    // set
     SetGIZMO(rc, IndexDomain::interior);
 
     return TaskStatus::complete;
 }
 
-TaskStatus SetGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
+TaskStatus SetGIZMO(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse)
 {
     auto pmb = rc->GetBlockPointer();
 
-    //std::cerr << "GIZMO on domain: " << BoundaryName(domain) << std::endl;
-    // Don't apply GIZMO initialization to X1 boundaries
+    // std::cerr << "GIZMO on domain: " << BoundaryName(domain) << std::endl;
+    //  Don't apply GIZMO initialization to X1 boundaries
     if (domain == IndexDomain::outer_x1 || domain == IndexDomain::inner_x1) {
         return TaskStatus::complete;
     }
@@ -101,27 +103,30 @@ TaskStatus SetGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain
     const IndexRange ib = bounds.GetBoundsI(domain);
     const IndexRange jb = bounds.GetBoundsJ(domain);
     const IndexRange kb = bounds.GetBoundsK(domain);
-    
+
     // GIZMO shell
     // Read the gizmo data file
-    FILE *fptr = fopen(datfn.c_str(),"r");
+    FILE* fptr = fopen(datfn.c_str(), "r");
     const int datlen = 100000;
-    Real *rarr = new double[datlen];
-    Real *rhoarr = new double[datlen]; 
-    Real *Tarr = new double[datlen]; 
-    Real *vrarr = new double[datlen]; 
-    Real *Mencarr = new double[datlen]; 
-    int length=0, itemp=0;
-    while (fscanf(fptr,"%lf %lf %lf %lf %lf\n", &(rarr[itemp]), &(rhoarr[itemp]), &(Tarr[itemp]), &(vrarr[itemp]), &(Mencarr[itemp])) == 5) { // assign the read value to variable, and enter it in array
-            itemp++;
+    Real* rarr = new double[datlen];
+    Real* rhoarr = new double[datlen];
+    Real* Tarr = new double[datlen];
+    Real* vrarr = new double[datlen];
+    Real* Mencarr = new double[datlen];
+    int length = 0, itemp = 0;
+    while (fscanf(fptr, "%lf %lf %lf %lf %lf\n", &(rarr[itemp]), &(rhoarr[itemp]),
+               &(Tarr[itemp]), &(vrarr[itemp]),
+               &(Mencarr[itemp])) ==
+           5) { // assign the read value to variable, and enter it in array
+        itemp++;
     }
     fclose(fptr);
     length = itemp;
 
-    GridVector r_device("r_device", length); 
-    GridVector rho_device("rho_device", length); 
-    GridVector T_device("T_device", length); 
-    GridVector vr_device("vr_device", length); 
+    GridVector r_device("r_device", length);
+    GridVector rho_device("rho_device", length);
+    GridVector T_device("T_device", length);
+    GridVector vr_device("vr_device", length);
     auto r_host = r_device.GetHostMirror();
     auto rho_host = rho_device.GetHostMirror();
     auto T_host = T_device.GetHostMirror();
@@ -136,24 +141,27 @@ TaskStatus SetGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain
     rho_device.DeepCopy(rho_host);
     T_device.DeepCopy(T_host);
     vr_device.DeepCopy(vr_host);
-        
+
     Kokkos::fence();
 
     pmb->par_for("gizmo_shell", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             // same vacuum conditions at rin_init
             GReal Xshell[GR_DIM] = {0, rin_init, 0, 0};
             int i_sh;
             GReal del_sh;
             XtoindexGIZMO(Xshell, r_device, length, i_sh, del_sh);
             Real vacuum_rho, vacuum_u_over_rho;
-            vacuum_rho = rho_device(i_sh)*(1.-del_sh)+rho_device(i_sh+1)*del_sh;
-            vacuum_u_over_rho = (T_device(i_sh)*(1.-del_sh)+T_device(i_sh+1)*del_sh)/(gam-1.);
+            vacuum_rho = rho_device(i_sh) * (1. - del_sh) + rho_device(i_sh + 1) * del_sh;
+            vacuum_u_over_rho =
+                (T_device(i_sh) * (1. - del_sh) + T_device(i_sh + 1) * del_sh) /
+                (gam - 1.);
 
-            get_prim_gizmo_shell(G, cs, P, m_p, gam, rin_init, rs, vacuum_rho, vacuum_u_over_rho, 
-                r_device, rho_device, T_device, vr_device, length, k, j, i);
-        }
-    );
+            get_prim_gizmo_shell(G, cs, P, m_p, gam, rin_init, rs, vacuum_rho,
+                vacuum_u_over_rho, r_device, rho_device, T_device, vr_device, length, k,
+                j, i);
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/prob/gizmo.hpp
+++ b/kharma/prob/gizmo.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: bondi.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,11 +36,11 @@
 #include "decs.hpp"
 
 #include "bondi.hpp"
-#include "gr_coordinates.hpp"
+#include "coordinate_utils.hpp"
 #include "flux_functions.hpp"
+#include "gr_coordinates.hpp"
 #include "grmhd_functions.hpp"
 #include "pack.hpp"
-#include "coordinate_utils.hpp"
 #include "types.hpp"
 
 #include <parthenon/parthenon.hpp>
@@ -48,20 +48,21 @@
 /**
  * Initialize a Bondi problem over the domain
  */
-TaskStatus InitializeGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+TaskStatus InitializeGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);
 
 /**
  * Set all values on a given domain to the Bondi inflow analytic steady-state solution
- * 
+ *
  * Used for initialization and boundary conditions
  */
-TaskStatus SetGIZMO(std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse=false);
+TaskStatus SetGIZMO(
+    std::shared_ptr<MeshBlockData<Real>>& rc, IndexDomain domain, bool coarse = false);
 
-KOKKOS_INLINE_FUNCTION void XtoindexGIZMO(const GReal XG[GR_DIM],
-                                    const GridScalar& rarr, const int length, int& i, GReal& del)
+KOKKOS_INLINE_FUNCTION void XtoindexGIZMO(
+    const GReal XG[GR_DIM], const GridScalar& rarr, const int length, int& i, GReal& del)
 {
     Real dx2, dx2_min;
-    dx2_min = m::pow(XG[1]-rarr(0),2); //100000.; //arbitrarily large number
+    dx2_min = m::pow(XG[1] - rarr(0), 2); // 100000.; //arbitrarily large number
 
     i = 0; // initialize
 
@@ -70,34 +71,37 @@ KOKKOS_INLINE_FUNCTION void XtoindexGIZMO(const GReal XG[GR_DIM],
             dx2 = m::pow(XG[1] - rarr(itemp), 2);
 
             // simplest interpolation (Hyerin 07/26/22)
-            if (dx2 < dx2_min){
+            if (dx2 < dx2_min) {
                 dx2_min = dx2;
                 i = itemp;
             }
         }
     }
-    
-    // interpolation (11/14/2022) TODO: write a case where indices hit the boundaries of the data file
-    del = (XG[1]-rarr(i))/(rarr(i+1)-rarr(i));
+
+    // interpolation (11/14/2022) TODO: write a case where indices hit the boundaries of
+    // the data file
+    del = (XG[1] - rarr(i)) / (rarr(i + 1) - rarr(i));
 
 #ifndef KOKKOS_ENABLE_SYCL
-    if (m::abs(dx2_min/m::pow(XG[1],2))>1.e-8) printf("XtoindexGizmo: dx2 pretty large = %g at r= %g \n",dx2_min, XG[1]);
+    if (m::abs(dx2_min / m::pow(XG[1], 2)) > 1.e-8)
+        printf("XtoindexGizmo: dx2 pretty large = %g at r= %g \n", dx2_min, XG[1]);
 #endif
 }
 /**
  * Get the GIZMO output values at a particular zone
  * Note this assumes that there are ghost zones!
  */
-KOKKOS_INLINE_FUNCTION void get_prim_gizmo_shell(const GRCoordinates& G, const CoordinateEmbedding& coords, const VariablePack<Real>& P, const VarMap& m_p,
-                                           const Real& gam,
-                                           const Real rin_init, const Real rs, Real vacuum_rho, Real vacuum_u_over_rho,
-                                           const GridScalar& rarr, const GridScalar& rhoarr, const GridScalar& Tarr, const GridScalar& vrarr, const int length,
-                                           const int& k, const int& j, const int& i)
+KOKKOS_INLINE_FUNCTION void get_prim_gizmo_shell(const GRCoordinates& G,
+    const CoordinateEmbedding& coords, const VariablePack<Real>& P, const VarMap& m_p,
+    const Real& gam, const Real rin_init, const Real rs, Real vacuum_rho,
+    Real vacuum_u_over_rho, const GridScalar& rarr, const GridScalar& rhoarr,
+    const GridScalar& Tarr, const GridScalar& vrarr, const int length, const int& k,
+    const int& j, const int& i)
 {
     // Solution constants for velocity prescriptions
     // Ideally these could be cached but preformance isn't an issue here
     Real mdot = 1.; // mdot defined arbitrarily
-    //Real rs = 1./sqrt(T); //1000.;
+    // Real rs = 1./sqrt(T); //1000.;
 
     GReal Xnative[GR_DIM], Xembed[GR_DIM];
     G.coord(k, j, i, Loci::center, Xnative);
@@ -106,7 +110,7 @@ KOKKOS_INLINE_FUNCTION void get_prim_gizmo_shell(const GRCoordinates& G, const C
 
     // Get GIZMO or vacuum/Bondi data
     Real rho, u, ur;
-    if (r < rin_init * 0.9){
+    if (r < rin_init * 0.9) {
         // Vacuum values for interior
         rho = vacuum_rho;
         u = vacuum_rho * vacuum_u_over_rho;
@@ -115,13 +119,14 @@ KOKKOS_INLINE_FUNCTION void get_prim_gizmo_shell(const GRCoordinates& G, const C
         get_bondi_soln(r, rs, mdot, gam, rho_tmp, u_tmp, ur);
     } else {
         // linear interpolation
-        int itemp; GReal del;
+        int itemp;
+        GReal del;
         XtoindexGIZMO(Xembed, rarr, length, itemp, del);
-        if (del < 0 ) { // when r is smaller than GIZMO's range
-            del = 0; // just copy over the smallest r values
+        if (del < 0) { // when r is smaller than GIZMO's range
+            del = 0;   // just copy over the smallest r values
         }
-        rho = rhoarr(itemp) * (1.-del) + rhoarr(itemp+1) * del;
-        u = rho * (Tarr(itemp) * (1.-del) + Tarr(itemp+1) * del) / (gam - 1.);
+        rho = rhoarr(itemp) * (1. - del) + rhoarr(itemp + 1) * del;
+        u = rho * (Tarr(itemp) * (1. - del) + Tarr(itemp + 1) * del) / (gam - 1.);
         ur = 0.;
     }
     Real ucon_bl[GR_DIM] = {0., ur, 0., 0.};

--- a/kharma/prob/kelvin_helmholtz.hpp
+++ b/kharma/prob/kelvin_helmholtz.hpp
@@ -47,7 +47,8 @@
  * Follows initial conditions from Lecoanet et al. 2015,
  * MNRAS 455, 4274.
  */
-TaskStatus InitializeKelvinHelmholtz(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeKelvinHelmholtz(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -72,7 +73,8 @@ TaskStatus InitializeKelvinHelmholtz(std::shared_ptr<MeshBlockData<Real>>& rc, P
     IndexDomain domain = IndexDomain::entire;
     IndexRange3 b = KDomain::GetRange(rc, domain, 0, 0);
     pmb->par_for("kh_init", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             GReal X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
             // Lecoanet's x <-> x1; z <-> x2
@@ -82,13 +84,14 @@ TaskStatus InitializeKelvinHelmholtz(std::shared_ptr<MeshBlockData<Real>>& rc, P
             rho(k, j, i) =
                 rho0 + Drho * 0.5 * (m::tanh(zdist1 / a) - m::tanh(zdist2 / a));
             u(k, j, i) = P0 / (gam - 1.) * tscale * tscale;
-            uvec(0, k, j, i) = uflow * (m::tanh(zdist1 / a) - m::tanh(zdist2 / a) - 1.) * tscale;
+            uvec(0, k, j, i) =
+                uflow * (m::tanh(zdist1 / a) - m::tanh(zdist2 / a) - 1.) * tscale;
             uvec(1, k, j, i) = amp * m::sin(2. * M_PI * X[1]) *
-                        (m::exp(-(zdist1 * zdist1) / (sigma * sigma)) +
-                        m::exp(-(zdist2 * zdist2) / (sigma * sigma))) * tscale;
+                               (m::exp(-(zdist1 * zdist1) / (sigma * sigma)) +
+                                   m::exp(-(zdist2 * zdist2) / (sigma * sigma))) *
+                               tscale;
             uvec(2, k, j, i) = 0.;
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/prob/mhdmodes.hpp
+++ b/kharma/prob/mhdmodes.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: mhdmodes.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,27 +37,27 @@
 
 #include "decs.hpp"
 
-
 using namespace std::literals::complex_literals;
 using namespace parthenon;
 
 /**
  * Initialization for different analytic wave modes in magnetized plasma.
  * Note this assumes ideal EOS with gamma=4/3!
- * 
+ *
  * @param nmode: type of linear wave, from:
  * 0. Entropy, static mode
  * 1. Slow mode
  * 2. Alfven wave
  * 3. Fast mode
- * 
+ *
  * @param dir: direction of wave. 0 = components of each
  *
  * Note this SETS the stopping time corresponding to advection by 1 wavelength.
  * Generally this is what we want for tests (run by 1 cycle and compare).
  * Modify function or reset tlim after to override.
  */
-TaskStatus InitializeMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeMHDModes(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -89,9 +89,10 @@ TaskStatus InitializeMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramete
     const Real k2 = pin->GetOrAddReal("mhdmodes", "k2", (dir == 2) ? 0. : 2. * M_PI);
     const Real k3 = pin->GetOrAddReal("mhdmodes", "k3", (dir == 3) ? 0. : 2. * M_PI);
     // Likewise
-    const Real B10 = pin->GetOrAddReal("mhdmodes", "B10", (dir == 0 || dir == 3) ? 1.0 : 0. );
-    const Real B20 = pin->GetOrAddReal("mhdmodes", "B20", (dir == 1) ? 1.0 : 0. );
-    const Real B30 = pin->GetOrAddReal("mhdmodes", "B30", (dir == 2) ? 1.0 : 0. );
+    const Real B10 =
+        pin->GetOrAddReal("mhdmodes", "B10", (dir == 0 || dir == 3) ? 1.0 : 0.);
+    const Real B20 = pin->GetOrAddReal("mhdmodes", "B20", (dir == 1) ? 1.0 : 0.);
+    const Real B30 = pin->GetOrAddReal("mhdmodes", "B30", (dir == 2) ? 1.0 : 0.);
 
     std::complex<Real> omega;
     Real drho = 0, du = 0;
@@ -129,9 +130,7 @@ TaskStatus InitializeMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramete
             dB2 = -0.203190272838;
             dB3 = -0.203190272838;
         }
-    }
-    else
-    {
+    } else {
         // 2D (1,1,0), (1,0,1), (0,1,1) wave
         if (nmode == 0) { // Entropy
             drho = 1.;
@@ -208,9 +207,9 @@ TaskStatus InitializeMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramete
     pin->GetOrAddReal("b_field", "B10", B10);
     pin->GetOrAddReal("b_field", "B20", B20);
     pin->GetOrAddReal("b_field", "B30", B30);
-    pin->GetOrAddReal("b_field", "amp_B1", amp*dB1);
-    pin->GetOrAddReal("b_field", "amp_B2", amp*dB2);
-    pin->GetOrAddReal("b_field", "amp_B3", amp*dB3);
+    pin->GetOrAddReal("b_field", "amp_B1", amp * dB1);
+    pin->GetOrAddReal("b_field", "amp_B2", amp * dB2);
+    pin->GetOrAddReal("b_field", "amp_B3", amp * dB3);
     pin->GetOrAddReal("b_field", "k1", k1);
     pin->GetOrAddReal("b_field", "k2", k2);
     pin->GetOrAddReal("b_field", "k3", k3);
@@ -221,7 +220,8 @@ TaskStatus InitializeMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramete
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("mhdmodes_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
             Real mode = amp * m::cos(k1 * X[1] + k2 * X[2] + k3 * X[3]);
@@ -230,8 +230,7 @@ TaskStatus InitializeMHDModes(std::shared_ptr<MeshBlockData<Real>>& rc, Paramete
             uvec(V1, k, j, i) = u10 + du1 * mode;
             uvec(V2, k, j, i) = u20 + du2 * mode;
             uvec(V3, k, j, i) = u30 + du3 * mode;
-        }
-    );
+        });
 
     // Override end time to be exactly 1 period for moving modes, unless we set otherwise
     if (one_period) {

--- a/kharma/prob/orszag_tang.hpp
+++ b/kharma/prob/orszag_tang.hpp
@@ -9,20 +9,21 @@
 using namespace parthenon;
 
 /**
- * relativistic version of the Orszag-Tang vortex 
- * Orszag & Tang 1979, JFM 90, 129-143. 
- * original OT problem was incompressible 
+ * relativistic version of the Orszag-Tang vortex
+ * Orszag & Tang 1979, JFM 90, 129-143.
+ * original OT problem was incompressible
  * this is based on compressible version given
  * in Toth 2000, JCP 161, 605.
- * 
+ *
  * in the limit tscale -> 0 the problem is identical
  * to the nonrelativistic problem; as tscale increases
  * the problem becomes increasingly relativistic
- * 
+ *
  * Originally stolen directly from iharm2d_v3,
  * now somewhat modified
  */
-TaskStatus InitializeOrszagTang(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeOrszagTang(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -47,16 +48,16 @@ TaskStatus InitializeOrszagTang(std::shared_ptr<MeshBlockData<Real>>& rc, Parame
     IndexDomain domain = IndexDomain::entire;
     IndexRange3 b = KDomain::GetRange(rc, domain);
     pmb->par_for("ot_init", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
-            rho(k, j, i) = 25./9.;
-            u(k, j, i) = 5./(3.*(gam - 1.)) * tscale * tscale;
+            rho(k, j, i) = 25. / 9.;
+            u(k, j, i) = 5. / (3. * (gam - 1.)) * tscale * tscale;
             uvec(0, k, j, i) = -m::sin(X[2] + phase) * tscale;
             uvec(1, k, j, i) = m::sin(X[1] + phase) * tscale;
             uvec(2, k, j, i) = 0.;
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/prob/post_initialize.cpp
+++ b/kharma/prob/post_initialize.cpp
@@ -53,21 +53,25 @@
 #include "seed_B.hpp"
 #include "types.hpp"
 
-void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
+void KHARMA::PostInitialize(ParameterInput* pin, Mesh* pmesh, bool is_restart)
 {
     // This call:
-    // 1. Initializes any magnetic fields, according to parameters set by the problem or user.
-    // 2. Renormalizes magnetic fields based on a desired ratio of maximum magnetic/gas pressures
-    // 3. Adds any extra material which might be superimposed when restarting, e.g. "hotspot" regions a.k.a. "blobs"
+    // 1. Initializes any magnetic fields, according to parameters set by the problem or
+    // user.
+    // 2. Renormalizes magnetic fields based on a desired ratio of maximum magnetic/gas
+    // pressures
+    // 3. Adds any extra material which might be superimposed when restarting, e.g.
+    // "hotspot" regions a.k.a. "blobs"
     // 4. Resets a couple of incidental flags, if Parthenon read them from a restart file
     // 5. If necessary, cleans up any magnetic field divergence present on the grid
 
-    // Coming into this function, at least the *interior* regions should be initialized with a problem:
-    // that is, rho, u, uvec, and any nonzero auxiliary variables, on each physical zone.
-    // If you need Dirichlet boundary conditions, the domain-edge *ghost* zones should also be initialized,
-    // as they will be "frozen in" during this function and applied thereafter.
+    // Coming into this function, at least the *interior* regions should be initialized
+    // with a problem: that is, rho, u, uvec, and any nonzero auxiliary variables, on each
+    // physical zone. If you need Dirichlet boundary conditions, the domain-edge *ghost*
+    // zones should also be initialized, as they will be "frozen in" during this function
+    // and applied thereafter.
 
-    auto &md = pmesh->mesh_data.Get();
+    auto& md = pmesh->mesh_data.Get();
 
     auto& pkgs = pmesh->packages.AllPackages();
 
@@ -78,7 +82,8 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
         // If we need to seed a field based on the problem's fluid initialization...
         if (pin->GetOrAddString("b_field", "type", "none") != "none" && !is_restart) {
             // B field init is not stencil-1, needs boundaries sync'd.
-            // FreezeDirichlet ensures any Dirichlet conditions aren't overwritten by zeros
+            // FreezeDirichlet ensures any Dirichlet conditions aren't overwritten by
+            // zeros
             KBoundaries::FreezeDirichlet(md);
             KHARMADriver::SyncAllBounds(md);
 
@@ -99,7 +104,7 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
     // Add any hotspots *after* we've seeded fields,
     // since seeding may be based on density
     if (pin->GetOrAddBoolean("blob", "add_blob", false)) {
-        for (auto &pmb : pmesh->block_list) {
+        for (auto& pmb : pmesh->block_list) {
             auto rc = pmb->meshblock_data.Get("base");
             // This inserts only in vicinity of some global r,th,phi
             InsertBlob(rc.get(), pin);
@@ -115,9 +120,10 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
         // We only record the conserved magnetic field in KHARMA restarts,
         // but we record primitive field in iharm3d restarts
         bool iharm3d_restart = prob_name == "resize_restart";
-        // but sometimes in a pinch we want to restart from .phdf files, which are like iharm3d restarts
+        // but sometimes in a pinch we want to restart from .phdf files, which are like
+        // iharm3d restarts
         bool prims_only_restart = pin->GetBoolean("b_field", "restart_from_prims");
-        if (!(iharm3d_restart  || prims_only_restart)) {
+        if (!(iharm3d_restart || prims_only_restart)) {
             std::cout << "Restoring B field from conserved values" << std::endl;
             if (pkgs.count("B_FluxCT")) {
                 B_FluxCT::MeshUtoP(md.get(), IndexDomain::entire);
@@ -153,7 +159,7 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
         } else if (pkgs.count("B_CT")) {
             B_CT::PrintGlobalMaxDivB(md.get());
         } else if (pkgs.count("B_CD")) {
-            //B_CD::PrintGlobalMaxDivB(md.get());
+            // B_CD::PrintGlobalMaxDivB(md.get());
         }
     }
 
@@ -178,12 +184,12 @@ void KHARMA::PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart)
             auto pouts = std::make_unique<Outputs>(pmesh, pin, &tm);
             pouts->MakeOutputs(pmesh, pin, &tm, SignalHandler::OutputSignal::now);
         }
-
     }
 
-    // The e- initialization is called during problem initialization, but we want an option
-    // to force it -- for example, if restarting an ideal GRMHD run,
-    if (pkgs.count("Electrons") && pin->GetOrAddBoolean("electrons", "reinitialize", false)) {
+    // The e- initialization is called during problem initialization, but we want an
+    // option to force it -- for example, if restarting an ideal GRMHD run,
+    if (pkgs.count("Electrons") &&
+        pin->GetOrAddBoolean("electrons", "reinitialize", false)) {
         std::cout << "Reinitializing electron temperatures!" << std::endl;
         Electrons::MeshInitElectrons(md.get(), pin);
         // We probably don't want to do this again next time we restart

--- a/kharma/prob/post_initialize.hpp
+++ b/kharma/prob/post_initialize.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: post_initialize.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,28 +35,30 @@
 
 #include "decs.hpp"
 
-#include "b_flux_ct.hpp"
 #include "b_cd.hpp"
+#include "b_flux_ct.hpp"
 
-namespace KHARMA {
+namespace KHARMA
+{
 
 /**
- * Initialize the magnetic field (if it wasn't done in ProblemGenerator), and renormalize it as
- * is common practice for torus problems.
- * 
+ * Initialize the magnetic field (if it wasn't done in ProblemGenerator), and renormalize
+ * it as is common practice for torus problems.
+ *
  * Since the latter operation is global, we perform this on the whole mesh
  * once initialization of all other problem data is completed.
  */
-void SeedAndNormalizeB(ParameterInput *pin, std::shared_ptr<MeshData<Real>> md);
+void SeedAndNormalizeB(ParameterInput* pin, std::shared_ptr<MeshData<Real>> md);
 
 /**
  * Functions run over the entire mesh after per-block initialization:
  * 1. Initial boundary sync to populate ghost zones
- * 2. Initialize magnetic field, which must be normalized globally to respect beta_min parameter
+ * 2. Initialize magnetic field, which must be normalized globally to respect beta_min
+ * parameter
  * 3. Any ad-hoc additions to fluid state, e.g. add hotspots etc.
  * 4. On restarts, reset any per-run parameters
  * 5. Clean up B field divergence if resizing the grid
  */
-void PostInitialize(ParameterInput *pin, Mesh *pmesh, bool is_restart);
+void PostInitialize(ParameterInput* pin, Mesh* pmesh, bool is_restart);
 
 }

--- a/kharma/prob/problem.cpp
+++ b/kharma/prob/problem.cpp
@@ -48,18 +48,18 @@
 #include "bondi.hpp"
 #include "explosion.hpp"
 #include "fm_torus.hpp"
-#include "resize_restart.hpp"
-#include "resize_restart_kharma.hpp"
+#include "gizmo.hpp"
 #include "kelvin_helmholtz.hpp"
 #include "mhdmodes.hpp"
 #include "orszag_tang.hpp"
+#include "resize_restart.hpp"
+#include "resize_restart_kharma.hpp"
 #include "shock_tube.hpp"
-#include "gizmo.hpp"
 // EMHD problem headers
 #include "emhd/anisotropic_conduction.hpp"
+#include "emhd/conducting_atmosphere.hpp"
 #include "emhd/emhdmodes.hpp"
 #include "emhd/emhdshock.hpp"
-#include "emhd/conducting_atmosphere.hpp"
 // Electron problem headers
 #include "elec/driven_turbulence.hpp"
 #include "elec/hubble.hpp"
@@ -67,11 +67,11 @@
 
 using namespace parthenon;
 
-void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
+void KHARMA::ProblemGenerator(MeshBlock* pmb, ParameterInput* pin)
 {
     auto rc = pmb->meshblock_data.Get("base");
     auto prob = pin->GetString("parthenon/job", "problem_id"); // Required parameter
-    Flag("ProblemGenerator_"+prob);
+    Flag("ProblemGenerator_" + prob);
     // Also just print this, it's important
     if (MPIRank0()) {
         // We have no way of tracking whether this is the first block we're initializing
@@ -94,17 +94,17 @@ void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
         status = InitializeKelvinHelmholtz(rc, pin);
     } else if (prob == "shock") {
         status = InitializeShockTube(rc, pin);
-    // GRMHD
+        // GRMHD
     } else if (prob == "bondi") {
         status = InitializeBondi(rc, pin);
-    // Electrons
+        // Electrons
     } else if (prob == "noh") {
         status = InitializeNoh(rc, pin);
     } else if (prob == "hubble") {
         status = InitializeHubble(rc, pin);
     } else if (prob == "driven_turbulence") {
         status = InitializeDrivenTurbulence(rc, pin);
-    // Extended GRMHD
+        // Extended GRMHD
     } else if (prob == "emhdmodes") {
         status = InitializeEMHDModes(rc, pin);
     } else if (prob == "anisotropic_conduction") {
@@ -113,7 +113,7 @@ void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
         status = InitializeEMHDShock(rc, pin);
     } else if (prob == "conducting_atmosphere") {
         status = InitializeAtmosphere(rc, pin);
-    // Everything
+        // Everything
     } else if (prob == "torus") {
         status = InitializeFMTorus(rc, pin);
     } else if (prob == "resize_restart") {
@@ -129,7 +129,7 @@ void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
 
     // If we didn't initialize a problem, yell
     if (status != TaskStatus::complete) {
-        throw std::invalid_argument("Invalid or incomplete problem: "+prob);
+        throw std::invalid_argument("Invalid or incomplete problem: " + prob);
     }
 
     // If we're not restarting, do any grooming of the initial conditions

--- a/kharma/prob/problem.hpp
+++ b/kharma/prob/problem.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: problem.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,24 +41,26 @@
  * Generate the initial condition on (the physical zones of) a meshblock
  * This is the callback from Parthenon -- we apply normalization and transformation
  * afterward
- * 
- * An example of running each supported problem with parameters is provided in the pars/ folder
+ *
+ * An example of running each supported problem with parameters is provided in the pars/
+ * folder
  */
-namespace KHARMA {
+namespace KHARMA
+{
 
 /**
  * Generate the initial conditions inside a meshblock according to the input parameters.
  * This mostly involves including the rest of the code from the prob/ folder, and calling
  * the appropriate function based on the parameter "problem_id"
- * 
- * This function also performs some initial consistency operations, such as applying floors,
- * calculating the conserved values, and synchronizing boundaries.
- * 
+ *
+ * This function also performs some initial consistency operations, such as applying
+ * floors, calculating the conserved values, and synchronizing boundaries.
+ *
  * Note that for some problems, this function does *not* initialize the magnetic field,
  * which is instead set in PostInitialize.  This is done if the field depends on the
  * local density rho, which may not be well-defined on the whole Mesh until after this
  * function has run over all MeshBlocks.
  */
-void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin);
+void ProblemGenerator(MeshBlock* pmb, ParameterInput* pin);
 
 }

--- a/kharma/prob/resize_restart.cpp
+++ b/kharma/prob/resize_restart.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: resize_restart.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,12 +36,12 @@
 
 #include "b_flux_ct.hpp"
 #include "hdf5_utils.h"
-#include "kharma_utils.hpp"
 #include "interpolation.hpp"
+#include "kharma_utils.hpp"
 #include "types.hpp"
 
-#include <sys/stat.h>
 #include <ctype.h>
+#include <sys/stat.h>
 
 // TODO: The iharm3d restart format fails to record several things we must guess:
 // 1. Sometimes, even precise domain boundaries in native coordinates
@@ -58,7 +58,7 @@
 hsize_t static_max(int i, int n) { return static_cast<hsize_t>(m::max(i, n)); }
 hsize_t static_min(int i, int n) { return static_cast<hsize_t>(m::min(i, n)); }
 
-void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
+void ReadIharmRestartHeader(std::string fname, ParameterInput* pin)
 {
     // Read the restart file and set parameters that need to be specified at early loading
     hdf5_open(fname.c_str());
@@ -70,7 +70,9 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
     char version[20];
     hdf5_read_single_val(version, "version", string_type);
     if (MPIRank0()) {
-        std::cout << "Initialized from " << fname << ", file version " << version << std::endl << std::endl;
+        std::cout << "Initialized from " << fname << ", file version " << version
+                  << std::endl
+                  << std::endl;
     }
 
     // Read what we need from the file, regardless of where we're putting it
@@ -120,7 +122,7 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
 
     // Set the number of primitive vars
     // TODO do this better by recording/counting flags in MODEL
-    if(hdf5_exists("game")) {
+    if (hdf5_exists("game")) {
         pin->SetInteger("resize_restart", "nfprim", 10);
     } else {
         pin->SetInteger("resize_restart", "nfprim", 8);
@@ -149,12 +151,13 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
         pin->SetReal("resize_restart", "startx2", 0.0);
         pin->SetReal("resize_restart", "stopx2", 1.0);
         pin->SetReal("resize_restart", "startx3", 0.0);
-        pin->SetReal("resize_restart", "stopx3", 2*M_PI);
+        pin->SetReal("resize_restart", "stopx3", 2 * M_PI);
     }
 
     // If specified, set *our* grid to exactly match the *file's* grid
     if (pin->GetOrAddBoolean("resize_restart", "regrid_only", false)) {
-        // This locks the Parthenon mesh size to be zone-for-zone the same as the iharm3d dump file...
+        // This locks the Parthenon mesh size to be zone-for-zone the same as the iharm3d
+        // dump file...
         pin->SetInteger("parthenon/mesh", "nx1", n1file);
         pin->SetInteger("parthenon/mesh", "nx2", n2file);
         pin->SetInteger("parthenon/mesh", "nx3", n3file);
@@ -182,12 +185,14 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
                 pin->SetReal("coordinates", "r_out", m::exp(x1max));
             }
         } else {
-            std::cout << "Guessing geometry when restarting! This is potentially very bad to do!" << std::endl;
+            std::cout << "Guessing geometry when restarting! This is potentially very "
+                         "bad to do!"
+                      << std::endl;
             // NOTE: the reason guessing is bad here has to do with old KHARMA versions:
-            // input parameters (even geometry) were only stored to 6-digit precision in old KHARMA.
-            // This means that r_in and x3max especially were cut off, and only correct to 6 digits.
-            // Restarting with more accurate parameters can mess with the B field divergence,
-            // so we warn about it.
+            // input parameters (even geometry) were only stored to 6-digit precision in
+            // old KHARMA. This means that r_in and x3max especially were cut off, and
+            // only correct to 6 digits. Restarting with more accurate parameters can mess
+            // with the B field divergence, so we warn about it.
             pin->SetReal("coordinates", "r_in", Rin);
             pin->SetReal("coordinates", "r_out", Rout);
             // xNmin/max will then be set by kharma.cpp.
@@ -208,7 +213,8 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
             pin->SetString("coordinates", "transform", "funky");
         }
     } else {
-        std::cout << "Guessing the restart file is in Cartesian coordinates!" << std::endl;
+        std::cout << "Guessing the restart file is in Cartesian coordinates!"
+                  << std::endl;
         // Anything without a BH spin was pretty likely Cartesian
         pin->SetString("coordinates", "base", "cartesian_minkowski");
         pin->SetString("coordinates", "transform", "null");
@@ -230,11 +236,12 @@ void ReadIharmRestartHeader(std::string fname, ParameterInput *pin)
     }
 }
 
-TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
-    const auto fname = pin->GetString("resize_restart", "fname"); // Require this, don't guess
+    const auto fname =
+        pin->GetString("resize_restart", "fname"); // Require this, don't guess
     const bool regrid_only = pin->GetOrAddBoolean("resize_restart", "regrid_only", false);
     const bool is_spherical = pin->GetBoolean("coordinates", "spherical");
 
@@ -243,17 +250,14 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
     const hsize_t n1tot = pin->GetInteger("resize_restart", "n1tot");
     const hsize_t n2tot = pin->GetInteger("resize_restart", "n2tot");
     const hsize_t n3tot = pin->GetInteger("resize_restart", "n3tot");
-    const GReal startx[GR_DIM] = {0,
-        pin->GetReal("resize_restart", "startx1"),
+    const GReal startx[GR_DIM] = {0, pin->GetReal("resize_restart", "startx1"),
         pin->GetReal("resize_restart", "startx2"),
         pin->GetReal("resize_restart", "startx3")};
-    const GReal stopx[GR_DIM] = {0,
-        pin->GetReal("resize_restart", "stopx1"),
+    const GReal stopx[GR_DIM] = {0, pin->GetReal("resize_restart", "stopx1"),
         pin->GetReal("resize_restart", "stopx2"),
         pin->GetReal("resize_restart", "stopx3")};
-    const GReal dx[GR_DIM] = {0., (stopx[1] - startx[1])/n1tot,
-                                  (stopx[2] - startx[2])/n2tot,
-                                  (stopx[3] - startx[3])/n3tot};
+    const GReal dx[GR_DIM] = {0., (stopx[1] - startx[1]) / n1tot,
+        (stopx[2] - startx[2]) / n2tot, (stopx[3] - startx[3]) / n3tot};
 
     // Sanity checks.  Unlikely to fire but nice to have
     if (regrid_only) {
@@ -278,7 +282,8 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
             !close_to(pin->GetReal("parthenon/mesh", "x3min"), startx[3]) ||
             !close_to(pin->GetReal("parthenon/mesh", "x3max"), stopx[3])) {
             printf("Mesh shape does not match!\n");
-            printf("X1 %g vs %g & %g vs %g\nX2 %g vs %g & %g vs %g\nX3 %g vs %g & %g vs %g",
+            printf(
+                "X1 %g vs %g & %g vs %g\nX2 %g vs %g & %g vs %g\nX3 %g vs %g & %g vs %g",
                 pin->GetReal("parthenon/mesh", "x1min"), startx[1],
                 pin->GetReal("parthenon/mesh", "x1max"), stopx[1],
                 pin->GetReal("parthenon/mesh", "x2min"), startx[2],
@@ -288,15 +293,17 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
         }
     }
 
-    if(MPIRank0()) std::cout << "Reading mesh from file to cache..." << std::endl;
+    if (MPIRank0()) std::cout << "Reading mesh from file to cache..." << std::endl;
 
-    // In this section we're dealing with two different meshes: the one we're interpolating *from* (the "file" grid)
-    // and the one we're interpolating *to* -- the "meshblock."
-    // Additionally, in the "file" mesh we must deail with global file locations (no ghost zones, global index, prefixed "g")
-    // as well as local file locations (locations in a cache we read to host memory, prefixed "m")
+    // In this section we're dealing with two different meshes: the one we're
+    // interpolating *from* (the "file" grid) and the one we're interpolating *to* -- the
+    // "meshblock." Additionally, in the "file" mesh we must deail with global file
+    // locations (no ghost zones, global index, prefixed "g") as well as local file
+    // locations (locations in a cache we read to host memory, prefixed "m")
 
     // Size/domain of the MeshBlock we're reading *to*.
-    // Note that we fill all zones, now that we might be interpolating to faces without syncing primitive B
+    // Note that we fill all zones, now that we might be interpolating to faces without
+    // syncing primitive B
     IndexDomain domain = IndexDomain::entire;
     const IndexRange ib = pmb->cellbounds.GetBoundsI(domain);
     const IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
@@ -329,30 +336,33 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
         // The values gis,gjs,gks can/will be <0 sometimes
         Interpolation::Xtoijk(X, startx, dx, gis, gjs, gks, tmp);
         // Global rightmost corner, same deal
-        G.coord(kb.e+1, jb.e+1, ib.e+1, Loci::corner, X);
+        G.coord(kb.e + 1, jb.e + 1, ib.e + 1, Loci::corner, X);
         Interpolation::Xtoijk(X, startx, dx, gie, gje, gke, tmp);
         // Include one extra zone in each direction, for right side of linear interp
-        gke += 1; gje += 1; gie += 1;
+        gke += 1;
+        gje += 1;
+        gie += 1;
     }
 
     // Truncate the file read sizes so we don't overrun the file data
     hsize_t fstart[4] = {0, static_max(gks, 0), static_max(gjs, 0), static_max(gis, 0)};
     // Test gXe against last valid index, i.e. nXtot-1
-    hsize_t fstop[4] = {nfprim-1, static_min(gke, n3tot-1), static_min(gje, n2tot-1), static_min(gie, n1tot-1)};
+    hsize_t fstop[4] = {nfprim - 1, static_min(gke, n3tot - 1),
+        static_min(gje, n2tot - 1), static_min(gie, n1tot - 1)};
     // We add one here to get sizes from indices
-    hsize_t fcount[4] = {fstop[0] - fstart[0] + 1,
-                         fstop[1] - fstart[1] + 1,
-                         fstop[2] - fstart[2] + 1,
-                         fstop[3] - fstart[3] + 1};
-    // If we overran an index on the left, we need to leave blank rows, potentially filled w/periodic vals
+    hsize_t fcount[4] = {fstop[0] - fstart[0] + 1, fstop[1] - fstart[1] + 1,
+        fstop[2] - fstart[2] + 1, fstop[3] - fstart[3] + 1};
+    // If we overran an index on the left, we need to leave blank rows, potentially filled
+    // w/periodic vals
     const hsize_t mstart1 = (gks < 0) ? -gks : 0;
     const hsize_t mstart2 = (gjs < 0) ? -gjs : 0;
     const hsize_t mstart3 = (gis < 0) ? -gis : 0;
-    // The compiler gets mad at narrowing gXs to hsize_t within initializer list, so we split it above
+    // The compiler gets mad at narrowing gXs to hsize_t within initializer list, so we
+    // split it above
     hsize_t mstart[4] = {0, mstart1, mstart2, mstart3};
     // Total memory size is never truncated
     // This calculation produces XxYx2 arrays for 2D sims w/linear interp but that's fine
-    hsize_t nmk = gke-gks+1, nmj = gje-gjs+1, nmi = gie-gis+1;
+    hsize_t nmk = gke - gks + 1, nmj = gje - gjs + 1, nmi = gie - gis + 1;
     hsize_t mdims[4] = {nfprim, nmk, nmj, nmi};
     // TODO these should be const but hdf5_read_array yells about it, fix that
     // TODO should yell if any of these fired for nearest-neighbor
@@ -360,7 +370,7 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
     // Allocate the array we'll need
     hsize_t nmblock = nmk * nmj * nmi;
     // TODO this may be float[] if we ever want to read dump files as restarts
-    double *ptmp = new double[nfprim*nmblock];
+    double* ptmp = new double[nfprim * nmblock];
 
     // Open the file
     hdf5_open(fname.c_str());
@@ -370,10 +380,16 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
     hdf5_read_array(ptmp, "p", 4, fdims, fstart, fcount, mdims, mstart, H5T_IEEE_F64LE);
 
     // Do some special reads from elsewhere in the file to fill periodic bounds
-    // Note we do NOT fill outflow/reflecting bounds here -- instead, we treat them specially below
+    // Note we do NOT fill outflow/reflecting bounds here -- instead, we treat them
+    // specially below
     // TODO this could probably be a lot cleaner
     hsize_t fstart_tmp[4], fcount_tmp[4], mstart_tmp[4];
-#define RESET_COUNTS DLOOP1 {fstart_tmp[mu] = fstart[mu]; fcount_tmp[mu] = fcount[mu]; mstart_tmp[mu] = mstart[mu];}
+#define RESET_COUNTS                                                                     \
+    DLOOP1 {                                                                             \
+        fstart_tmp[mu] = fstart[mu];                                                     \
+        fcount_tmp[mu] = fcount[mu];                                                     \
+        mstart_tmp[mu] = mstart[mu];                                                     \
+    }
     if (gks < 0 && pmb->boundary_flag[BoundaryFace::inner_x3] == BoundaryFlag::periodic) {
         RESET_COUNTS
         // same X1/X2, but take only the globally LAST ranks in X3
@@ -382,17 +398,20 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
         fcount_tmp[1] = nrank;
         // Read it to the FIRST ranks of our array
         mstart_tmp[1] = 0;
-        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp, H5T_IEEE_F64LE);
+        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp,
+            H5T_IEEE_F64LE);
     }
-    if (gke > n3tot-1 && pmb->boundary_flag[BoundaryFace::outer_x3] == BoundaryFlag::periodic) {
+    if (gke > n3tot - 1 &&
+        pmb->boundary_flag[BoundaryFace::outer_x3] == BoundaryFlag::periodic) {
         RESET_COUNTS
         // same X1/X2, but take only the globally FIRST ranks in X3
-        int nrank = gke - (n3tot-1);
+        int nrank = gke - (n3tot - 1);
         fstart_tmp[1] = 0;
         fcount_tmp[1] = nrank;
         // Read it to the LAST ranks of our array
         mstart_tmp[1] = mdims[1] - nrank;
-        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp, H5T_IEEE_F64LE);
+        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp,
+            H5T_IEEE_F64LE);
     }
     if (gjs < 0 && pmb->boundary_flag[BoundaryFace::inner_x2] == BoundaryFlag::periodic) {
         RESET_COUNTS
@@ -400,15 +419,18 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
         fstart_tmp[2] = n2tot - nrank;
         fcount_tmp[2] = nrank;
         mstart_tmp[2] = 0;
-        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp, H5T_IEEE_F64LE);
+        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp,
+            H5T_IEEE_F64LE);
     }
-    if (gje > n2tot-1 && pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::periodic) {
+    if (gje > n2tot - 1 &&
+        pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::periodic) {
         RESET_COUNTS
-        int nrank = gje - (n2tot-1);
+        int nrank = gje - (n2tot - 1);
         fstart_tmp[2] = 0;
         fcount_tmp[2] = nrank;
         mstart_tmp[2] = mdims[2] - nrank;
-        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp, H5T_IEEE_F64LE);
+        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp,
+            H5T_IEEE_F64LE);
     }
     if (gis < 0 && pmb->boundary_flag[BoundaryFace::inner_x1] == BoundaryFlag::periodic) {
         RESET_COUNTS
@@ -416,15 +438,18 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
         fstart_tmp[3] = n1tot - nrank;
         fcount_tmp[3] = nrank;
         mstart_tmp[3] = 0;
-        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp, H5T_IEEE_F64LE);
+        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp,
+            H5T_IEEE_F64LE);
     }
-    if (gie > n1tot-1 && pmb->boundary_flag[BoundaryFace::outer_x1] == BoundaryFlag::periodic) {
+    if (gie > n1tot - 1 &&
+        pmb->boundary_flag[BoundaryFace::outer_x1] == BoundaryFlag::periodic) {
         RESET_COUNTS
-        int nrank = gie - (n1tot-1);
+        int nrank = gie - (n1tot - 1);
         fstart_tmp[3] = 0;
         fcount_tmp[3] = nrank;
         mstart_tmp[3] = mdims[3] - nrank;
-        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp, H5T_IEEE_F64LE);
+        hdf5_read_array(ptmp, "p", 4, fdims, fstart_tmp, fcount_tmp, mdims, mstart_tmp,
+            H5T_IEEE_F64LE);
     }
 
     hdf5_close();
@@ -443,24 +468,33 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
     auto B_host = B_P.GetHostMirror();
 
     // Interpolate on the host side & copy into the mirror Views
-    // Nearest-neighbor interpolation is currently only used when grids exactly correspond -- otherwise, linear interpolation is used
-    // to minimize the resulting B field divergence.
+    // Nearest-neighbor interpolation is currently only used when grids exactly correspond
+    // -- otherwise, linear interpolation is used to minimize the resulting B field
+    // divergence.
     if (regrid_only) {
         // TODO Kokkos calls here had problems with CUDA, reintroduce/fix
         // OpenMP here conflicts with Kokkos parallel in some cases, so we're stuck
-        for (int k=kb.s; k <= kb.e; ++k) for (int j=jb.s; j <= jb.e; ++j) for (int i=ib.s; i <= ib.e; ++i) {
-            GReal X[GR_DIM]; int gk, gj, gi;
-            G.coord(k, j, i, Loci::center, X);
-            Interpolation::Xtoijk_nearest(X, startx, dx, gi, gj, gk);
-            // TODO verify this never reads zones outside the cache
-            // Calculate indices inside our cached block
-            int mk = gk - gks, mj = gj - gjs, mi = gi - gis;
-            // Fill cells of the new block with equivalents in the cached block
-            rho_host(k, j, i) = ptmp[0*nmblock + mk*nmj*nmi + mj*nmi + mi];
-            u_host(k, j, i)   = ptmp[1*nmblock + mk*nmj*nmi + mj*nmi + mi];
-            VLOOP uvec_host(v, k, j, i) = ptmp[(2+v)*nmblock + mk*nmj*nmi + mj*nmi + mi];
-            VLOOP B_host(v, k, j, i) = ptmp[(5+v)*nmblock + mk*nmj*nmi + mj*nmi + mi];
-        }
+        for (int k = kb.s; k <= kb.e; ++k)
+            for (int j = jb.s; j <= jb.e; ++j)
+                for (int i = ib.s; i <= ib.e; ++i) {
+                    GReal X[GR_DIM];
+                    int gk, gj, gi;
+                    G.coord(k, j, i, Loci::center, X);
+                    Interpolation::Xtoijk_nearest(X, startx, dx, gi, gj, gk);
+                    // TODO verify this never reads zones outside the cache
+                    // Calculate indices inside our cached block
+                    int mk = gk - gks, mj = gj - gjs, mi = gi - gis;
+                    // Fill cells of the new block with equivalents in the cached block
+                    rho_host(k, j, i) =
+                        ptmp[0 * nmblock + mk * nmj * nmi + mj * nmi + mi];
+                    u_host(k, j, i) = ptmp[1 * nmblock + mk * nmj * nmi + mj * nmi + mi];
+                    VLOOP
+                        uvec_host(v, k, j, i) =
+                            ptmp[(2 + v) * nmblock + mk * nmj * nmi + mj * nmi + mi];
+                    VLOOP
+                        B_host(v, k, j, i) =
+                            ptmp[(5 + v) * nmblock + mk * nmj * nmi + mj * nmi + mi];
+                }
     } else {
         // TODO real boundary flags. Repeat on any outflow/reflecting bounds
         const bool repeat_x1i = is_spherical;
@@ -468,26 +502,48 @@ TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterI
         const bool repeat_x2i = is_spherical;
         const bool repeat_x2o = is_spherical;
 
-        for (int k=kb.s; k <= kb.e; ++k) for (int j=jb.s; j <= jb.e; ++j) for (int i=ib.s; i <= ib.e; ++i) {
-            GReal X[GR_DIM], del[GR_DIM]; int gk, gj, gi;
-            // Get the zone center location
-            G.coord(k, j, i, Loci::center, X);
-            // Get global indices
-            Interpolation::Xtoijk(X, startx, dx, gi, gj, gk, del);
-            // Make any corrections due to global boundaries
-            // Currently just repeats the last zone: everywhere beyond last zone center has center's value
-            if (repeat_x1i && gi < 0) { gi = 0; del[1] = 0; }
-            if (repeat_x1o && gi >= n1tot-1) { gi = n1tot - 1; del[1] = 0; }
-            if (repeat_x2i && gj < 0) { gj = 0; del[2] = 0; }
-            if (repeat_x2o && gj >= n2tot-1) { gj = n2tot - 1; del[2] = 0; }
-            // Calculate indices inside our cached block
-            int mk = gk - gks, mj = gj - gjs, mi = gi - gis;
-            // Interpolate the value at this location from the cached grid
-            rho_host(k, j, i) = Interpolation::linear(mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[0*nmblock]));
-            u_host(k, j, i) = Interpolation::linear(mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[1*nmblock]));
-            VLOOP uvec_host(v, k, j, i) = Interpolation::linear(mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[(2+v)*nmblock]));
-            VLOOP B_host(v, k, j, i) = Interpolation::linear(mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[(5+v)*nmblock]));
-        }
+        for (int k = kb.s; k <= kb.e; ++k)
+            for (int j = jb.s; j <= jb.e; ++j)
+                for (int i = ib.s; i <= ib.e; ++i) {
+                    GReal X[GR_DIM], del[GR_DIM];
+                    int gk, gj, gi;
+                    // Get the zone center location
+                    G.coord(k, j, i, Loci::center, X);
+                    // Get global indices
+                    Interpolation::Xtoijk(X, startx, dx, gi, gj, gk, del);
+                    // Make any corrections due to global boundaries
+                    // Currently just repeats the last zone: everywhere beyond last zone
+                    // center has center's value
+                    if (repeat_x1i && gi < 0) {
+                        gi = 0;
+                        del[1] = 0;
+                    }
+                    if (repeat_x1o && gi >= n1tot - 1) {
+                        gi = n1tot - 1;
+                        del[1] = 0;
+                    }
+                    if (repeat_x2i && gj < 0) {
+                        gj = 0;
+                        del[2] = 0;
+                    }
+                    if (repeat_x2o && gj >= n2tot - 1) {
+                        gj = n2tot - 1;
+                        del[2] = 0;
+                    }
+                    // Calculate indices inside our cached block
+                    int mk = gk - gks, mj = gj - gjs, mi = gi - gis;
+                    // Interpolate the value at this location from the cached grid
+                    rho_host(k, j, i) = Interpolation::linear(
+                        mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[0 * nmblock]));
+                    u_host(k, j, i) = Interpolation::linear(
+                        mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[1 * nmblock]));
+                    VLOOP
+                        uvec_host(v, k, j, i) = Interpolation::linear(
+                            mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[(2 + v) * nmblock]));
+                    VLOOP
+                        B_host(v, k, j, i) = Interpolation::linear(
+                            mi, mj, mk, nmi, nmj, nmk, del, &(ptmp[(5 + v) * nmblock]));
+                }
     }
 
     // Deep copy to device

--- a/kharma/prob/resize_restart.hpp
+++ b/kharma/prob/resize_restart.hpp
@@ -8,11 +8,12 @@
  * Read the header of an iharm3d HDF5 restart file, and set appropriate parameters
  * Call this before mesh creation!
  */
-void ReadIharmRestartHeader(std::string fname, ParameterInput *pin);
+void ReadIharmRestartHeader(std::string fname, ParameterInput* pin);
 
 /**
  * Read data from an iharm3d restart file. Does not support >1 meshblock in Parthenon
- * 
+ *
  * Returns stop time tf of the original simulation, for e.g. replicating regression tests
  */
-TaskStatus ReadIharmRestart(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin);
+TaskStatus ReadIharmRestart(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin);

--- a/kharma/prob/resize_restart_kharma.cpp
+++ b/kharma/prob/resize_restart_kharma.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: resize_restart_kharma.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,12 +40,13 @@
 
 #include <outputs/restart_hdf5.hpp>
 
-#include <sys/stat.h>
 #include <ctype.h>
+#include <sys/stat.h>
 
 // Reads in KHARMA restart file but at a different simulation size
 
-void ReadFillFile(int i, ParameterInput *pin) {
+void ReadFillFile(int i, ParameterInput* pin)
+{
     char str[20];
     auto fname_fill = pin->GetOrAddString("resize_restart", "fname_fill", "none");
 
@@ -61,7 +62,7 @@ void ReadFillFile(int i, ParameterInput *pin) {
 
         Real fnx1 = fpinput->GetInteger("parthenon/mesh", "nx1");
         Real fmbnx1 = fpinput->GetInteger("parthenon/meshblock", "nx1");
-        
+
         restartReader = nullptr;
 
         sprintf(str, "restart%d_nx1", i);
@@ -70,12 +71,12 @@ void ReadFillFile(int i, ParameterInput *pin) {
     }
 }
 
-void ReadKharmaRestartHeader(std::string fname, ParameterInput *pin)
+void ReadKharmaRestartHeader(std::string fname, ParameterInput* pin)
 {
     bool use_dt = pin->GetOrAddBoolean("resize_restart", "use_dt", true);
     bool use_tf = pin->GetOrAddBoolean("resize_restart", "use_tf", false);
 
-    // Read input from restart file 
+    // Read input from restart file
     // (from external/parthenon/src/parthenon_manager.cpp)
     auto restartReader = std::make_unique<RestartReaderHDF5>(fname.c_str());
 
@@ -86,7 +87,7 @@ void ReadKharmaRestartHeader(std::string fname, ParameterInput *pin)
     std::istringstream is(inputString);
     fpinput->LoadFromStream(is);
 
-    // TODO(BSP) is there a way to copy all parameters finput->pin and fine-tune later?
+    // TODO(CEP) is there a way to copy all parameters finput->pin and fine-tune later?
     int fnx1, fnx2, fnx3, fmbnx1, fmbnx2, fmbnx3;
     fnx1 = fpinput->GetInteger("parthenon/mesh", "nx1");
     fnx2 = fpinput->GetInteger("parthenon/mesh", "nx2");
@@ -126,7 +127,7 @@ void ReadKharmaRestartHeader(std::string fname, ParameterInput *pin)
     tNow = restartReader->GetAttr<Real>("Info", "Time");
     dt = restartReader->GetAttr<Real>("Info", "dt");
     tf = fpinput->GetReal("parthenon/time", "tlim");
-    //int ncycle = restartReader->GetAttr<int>("Info", "NCycle");
+    // int ncycle = restartReader->GetAttr<int>("Info", "NCycle");
 
     pin->SetReal("GRMHD", "gamma", gam);
     pin->SetReal("parthenon/time", "start_time", tNow);
@@ -136,8 +137,8 @@ void ReadKharmaRestartHeader(std::string fname, ParameterInput *pin)
     if (use_tf) {
         pin->SetReal("parthenon/time", "tlim", tf);
     }
-    //pin->SetInteger("parthenon/time", "ncycle", ncycle);
-    // TODO NSTEP, next tdump/tlog, etc?
+    // pin->SetInteger("parthenon/time", "ncycle", ncycle);
+    //  TODO NSTEP, next tdump/tlog, etc?
 
     GReal a = fpinput->GetReal("coordinates", "a");
     pin->SetReal("coordinates", "a", a);
@@ -150,7 +151,7 @@ void ReadKharmaRestartHeader(std::string fname, ParameterInput *pin)
     // File closed here when restartReader falls out of scope
 }
 
-TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterInput *pin)
+TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
 
@@ -163,7 +164,8 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     auto fname = pin->GetString("resize_restart", "fname"); // Require this, don't guess
     auto fname_fill = pin->GetOrAddString("resize_restart", "fname_fill", "none");
     const hsize_t f_n1tot = pin->GetOrAddInteger("parthenon/mesh", "restart1_nx1", -1);
-    const hsize_t f_n1mb = pin->GetOrAddInteger("parthenon/meshblock", "restart1_nx1", -1);
+    const hsize_t f_n1mb =
+        pin->GetOrAddInteger("parthenon/meshblock", "restart1_nx1", -1);
     const bool is_spherical = pin->GetBoolean("coordinates", "spherical");
     const Real fx1min = pin->GetReal("parthenon/mesh", "restart_x1min");
     const Real fx1max = pin->GetReal("parthenon/mesh", "restart_x1max");
@@ -173,22 +175,22 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     const bool fghostzones = pin->GetBoolean("parthenon/mesh", "restart_ghostzones");
     auto b_field_type = pin->GetOrAddString("b_field", "type", "none");
     int verbose = pin->GetOrAddInteger("debug", "verbose", 0);
-    const Real ur_frac = pin->GetOrAddReal("bondi", "ur_frac", 1.); 
-    const Real uphi = pin->GetOrAddReal("bondi", "uphi", 0.); 
+    const Real ur_frac = pin->GetOrAddReal("bondi", "ur_frac", 1.);
+    const Real uphi = pin->GetOrAddReal("bondi", "uphi", 0.);
     const Real a = pin->GetReal("coordinates", "a");
-    const Real rin_bondi_default = 1 + m::sqrt(1 - a*a) + 0.1;
+    const Real rin_bondi_default = 1 + m::sqrt(1 - a * a) + 0.1;
     Real rin_bondi_tmp;
     rin_bondi_tmp = pin->GetOrAddReal("bondi", "r_in_bondi", rin_bondi_default);
     const Real rin_bondi = rin_bondi_tmp;
 
     // Derived parameters
-    hsize_t nBlocks = (int) (n1tot*n2tot*n3tot)/(n1mb*n2mb*n3mb);
-    hsize_t f_nBlocks = (int) (f_n1tot*n2tot*n3tot)/(f_n1mb*n2mb*n3mb);
+    hsize_t nBlocks = (int)(n1tot * n2tot * n3tot) / (n1mb * n2mb * n3mb);
+    hsize_t f_nBlocks = (int)(f_n1tot * n2tot * n3tot) / (f_n1mb * n2mb * n3mb);
     const bool should_fill = !(fname_fill == "none");
     const Real dx1 = (fx1max - fx1min) / n1tot;
     int fnghost = pin->GetReal("parthenon/mesh", "restart_nghost");
-    const Real fx1min_ghost = fx1min - fnghost*dx1;
-    const Real fx1max_ghost = fx1max + fnghost*dx1;
+    const Real fx1min_ghost = fx1min - fnghost * dx1;
+    const Real fx1max_ghost = fx1max + fnghost * dx1;
     const bool include_B = (b_field_type != "none");
     auto pkgs = pmb->packages.AllPackages();
     const bool b_ct = (pkgs.count("B_CT"));
@@ -200,52 +202,52 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
 
     // read from a restart file and save it to static GridScalar
 
-    if (!fghostzones) fnghost=0; // reset to 0
-    int x3factor=1;
-    if (n3tot <= 1) x3factor=0; // if less than 3D, do not add ghosts in x3
-    hsize_t length[GR_DIM] = {nBlocks,
-                                n1mb + 2 * fnghost,
-                                n2mb + 2 * fnghost,
-                                n3mb + 2 * fnghost * x3factor}; 
-    //hsize_t lengthB[GR_DIM] = {nBlocks,
-    //                            n1mb + 2 * fnghost + (b_ct),
-    //                            n2mb + 2 * fnghost + (b_ct),
-    //                            n3mb + 2 * fnghost * x3factor + (b_ct)}; 
-    hsize_t f_length[GR_DIM] = {f_nBlocks,
-                                f_n1mb + 2 * fnghost,
-                                n2mb   + 2 * fnghost,
-                                n3mb   + 2 * fnghost * x3factor}; 
+    if (!fghostzones) fnghost = 0; // reset to 0
+    int x3factor = 1;
+    if (n3tot <= 1) x3factor = 0; // if less than 3D, do not add ghosts in x3
+    hsize_t length[GR_DIM] = {
+        nBlocks, n1mb + 2 * fnghost, n2mb + 2 * fnghost, n3mb + 2 * fnghost * x3factor};
+    // hsize_t lengthB[GR_DIM] = {nBlocks,
+    //                             n1mb + 2 * fnghost + (b_ct),
+    //                             n2mb + 2 * fnghost + (b_ct),
+    //                             n3mb + 2 * fnghost * x3factor + (b_ct)};
+    hsize_t f_length[GR_DIM] = {f_nBlocks, f_n1mb + 2 * fnghost, n2mb + 2 * fnghost,
+        n3mb + 2 * fnghost * x3factor};
     hsize_t lengthB[GR_DIM], f_lengthB[GR_DIM];
-    DLOOP1 lengthB[mu] = length[mu] + (mu > 0? b_ct : 0);
-    DLOOP1 f_lengthB[mu] = f_length[mu] + (mu > 0? b_ct : 0);
-    //hsize_t f_lengthB[GR_DIM] = {f_nBlocks,
-    //                            f_n1mb + 2 * fnghost + (b_ct),
-    //                            n2mb   + 2 * fnghost + (b_ct),
-    //                            n3mb   + 2 * fnghost * x3factor + (b_ct)}; 
-    const int block_sz = length[0]*length[1]*length[2]*length[3];
-    const int blockB_sz = lengthB[0]*lengthB[1]*lengthB[2]*lengthB[3];
-    const int f_block_sz = f_length[0]*f_length[1]*f_length[2]*f_length[3];
-    const int f_blockB_sz = f_lengthB[0]*f_lengthB[1]*f_lengthB[2]*f_lengthB[3];
+    DLOOP1
+        lengthB[mu] = length[mu] + (mu > 0 ? b_ct : 0);
+    DLOOP1
+        f_lengthB[mu] = f_length[mu] + (mu > 0 ? b_ct : 0);
+    // hsize_t f_lengthB[GR_DIM] = {f_nBlocks,
+    //                             f_n1mb + 2 * fnghost + (b_ct),
+    //                             n2mb   + 2 * fnghost + (b_ct),
+    //                             n3mb   + 2 * fnghost * x3factor + (b_ct)};
+    const int block_sz = length[0] * length[1] * length[2] * length[3];
+    const int blockB_sz = lengthB[0] * lengthB[1] * lengthB[2] * lengthB[3];
+    const int f_block_sz = f_length[0] * f_length[1] * f_length[2] * f_length[3];
+    const int f_blockB_sz = f_lengthB[0] * f_lengthB[1] * f_lengthB[2] * f_lengthB[3];
 
     if (MPIRank0() && verbose > 0) {
-        std::cout << "Reading mesh size " << n1tot << "x" << n2tot << "x" << n3tot <<
-                        " block size " << n1mb << "x" << n2mb << "x" << n3mb << std::endl;
-        std::cout << "Reading " << length[0] << " meshblocks of total size " <<
-                     length[1] << "x" <<  length[2]<< "x" << length[3] << std::endl;
+        std::cout << "Reading mesh size " << n1tot << "x" << n2tot << "x" << n3tot
+                  << " block size " << n1mb << "x" << n2mb << "x" << n3mb << std::endl;
+        std::cout << "Reading " << length[0] << " meshblocks of total size " << length[1]
+                  << "x" << length[2] << "x" << length[3] << std::endl;
     }
-    
-    
+
     // read from file and stored in device Hyerin (10/18/2022)
-    GridScalar x1_f_device("x1_f_device", length[0], length[1]); 
-    GridScalar x2_f_device("x2_f_device", length[0], length[2]); 
-    GridScalar x3_f_device("x3_f_device", length[0], length[3]); 
-    GridScalar x1B_f_device("x1B_f_device", lengthB[0], lengthB[1]); // For the B fields. If b_ct, they take face values
-    GridScalar x2B_f_device("x2B_f_device", lengthB[0], lengthB[2]); 
-    GridScalar x3B_f_device("x3B_f_device", lengthB[0], lengthB[3]); 
-    GridScalar rho_f_device("rho_f_device", length[0], length[3], length[2], length[1]); 
-    GridScalar u_f_device("u_f_device", length[0], length[3], length[2], length[1]); 
-    GridVector uvec_f_device("uvec_f_device", NVEC, length[0], length[3], length[2], length[1]); 
-    GridVector B_f_device("B_f_device", NVEC, lengthB[0], lengthB[3], lengthB[2], lengthB[1]);
+    GridScalar x1_f_device("x1_f_device", length[0], length[1]);
+    GridScalar x2_f_device("x2_f_device", length[0], length[2]);
+    GridScalar x3_f_device("x3_f_device", length[0], length[3]);
+    GridScalar x1B_f_device("x1B_f_device", lengthB[0],
+        lengthB[1]); // For the B fields. If b_ct, they take face values
+    GridScalar x2B_f_device("x2B_f_device", lengthB[0], lengthB[2]);
+    GridScalar x3B_f_device("x3B_f_device", lengthB[0], lengthB[3]);
+    GridScalar rho_f_device("rho_f_device", length[0], length[3], length[2], length[1]);
+    GridScalar u_f_device("u_f_device", length[0], length[3], length[2], length[1]);
+    GridVector uvec_f_device(
+        "uvec_f_device", NVEC, length[0], length[3], length[2], length[1]);
+    GridVector B_f_device(
+        "B_f_device", NVEC, lengthB[0], lengthB[3], lengthB[2], lengthB[1]);
     auto x1_f_host = x1_f_device.GetHostMirror();
     auto x2_f_host = x2_f_device.GetHostMirror();
     auto x3_f_host = x3_f_device.GetHostMirror();
@@ -256,22 +258,24 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     auto u_f_host = u_f_device.GetHostMirror();
     auto uvec_f_host = uvec_f_device.GetHostMirror();
     auto B_f_host = B_f_device.GetHostMirror();
-    // Hyerin (09/19/2022) : new attempt to read the file 
+    // Hyerin (09/19/2022) : new attempt to read the file
     hdf5_open(fname.c_str());
     hdf5_set_directory("/");
-    Real *rho_file = new double[block_sz];
-    Real *u_file = new double[block_sz];
-    Real *uvec_file = new double[NVEC*block_sz];
-    Real *B_file = new double[NVEC*blockB_sz];
-    Real *x1_file = new double[length[0]*length[1]];
-    Real *x2_file = new double[length[0]*length[2]];
-    Real *x3_file = new double[length[0]*length[3]];
-    Real *x1B_file = new double[lengthB[0]*(lengthB[1])];
-    Real *x2B_file = new double[lengthB[0]*(lengthB[2])];
-    Real *x3B_file = new double[lengthB[0]*(lengthB[3])];
-    //static hsize_t fdims[] = {length[0], 1, length[3], length[2], length[1],1}; //outdated
+    Real* rho_file = new double[block_sz];
+    Real* u_file = new double[block_sz];
+    Real* uvec_file = new double[NVEC * block_sz];
+    Real* B_file = new double[NVEC * blockB_sz];
+    Real* x1_file = new double[length[0] * length[1]];
+    Real* x2_file = new double[length[0] * length[2]];
+    Real* x3_file = new double[length[0] * length[3]];
+    Real* x1B_file = new double[lengthB[0] * (lengthB[1])];
+    Real* x2B_file = new double[lengthB[0] * (lengthB[2])];
+    Real* x3B_file = new double[lengthB[0] * (lengthB[3])];
+    // static hsize_t fdims[] = {length[0], 1, length[3], length[2], length[1],1};
+    // //outdated
     static hsize_t fdims[] = {length[0], length[3], length[2], length[1]};
-    //static hsize_t fdims_vec[] = {length[0], length[3], length[2], length[1],3}; //outdated
+    // static hsize_t fdims_vec[] = {length[0], length[3], length[2], length[1],3};
+    // //outdated
     static hsize_t fdims_vec[] = {length[0], NVEC, length[3], length[2], length[1]};
     static hsize_t fdimsB_vec[] = {lengthB[0], NVEC, lengthB[3], lengthB[2], lengthB[1]};
     static hsize_t fdims_x1[] = {length[0], length[1]};
@@ -283,34 +287,52 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     hsize_t fstart[] = {0, 0, 0, 0};
     hsize_t fstart_vec[] = {0, 0, 0, 0, 0};
     hsize_t fstart_x[] = {0, 0};
-    hdf5_read_array(rho_file, "prims.rho", 4, fdims, fstart, fdims, fdims, fstart, H5T_IEEE_F64LE);
-    hdf5_read_array(u_file, "prims.u", 4, fdims, fstart, fdims, fdims, fstart, H5T_IEEE_F64LE);
-    hdf5_read_array(uvec_file, "prims.uvec", 5, fdims_vec, fstart_vec, fdims_vec, fdims_vec, fstart_vec, H5T_IEEE_F64LE);
-    //if (include_B) hdf5_read_array(B_file, "prims.B", 5, fdims_vec, fstart_vec, fdims_vec, fdims_vec, fstart_vec, H5T_IEEE_F64LE);
+    hdf5_read_array(
+        rho_file, "prims.rho", 4, fdims, fstart, fdims, fdims, fstart, H5T_IEEE_F64LE);
+    hdf5_read_array(
+        u_file, "prims.u", 4, fdims, fstart, fdims, fdims, fstart, H5T_IEEE_F64LE);
+    hdf5_read_array(uvec_file, "prims.uvec", 5, fdims_vec, fstart_vec, fdims_vec,
+        fdims_vec, fstart_vec, H5T_IEEE_F64LE);
+    // if (include_B) hdf5_read_array(B_file, "prims.B", 5, fdims_vec, fstart_vec,
+    // fdims_vec, fdims_vec, fstart_vec, H5T_IEEE_F64LE);
     if (include_B) {
-        if (b_ct) hdf5_read_array(B_file, "cons.fB", 5, fdimsB_vec, fstart_vec, fdimsB_vec, fdimsB_vec, fstart_vec, H5T_IEEE_F64LE);
-        else if (pkgs.count("B_FluxCT")) hdf5_read_array(B_file, "cons.B", 5, fdims_vec, fstart_vec, fdims_vec, fdims_vec, fstart_vec, H5T_IEEE_F64LE);
+        if (b_ct)
+            hdf5_read_array(B_file, "cons.fB", 5, fdimsB_vec, fstart_vec, fdimsB_vec,
+                fdimsB_vec, fstart_vec, H5T_IEEE_F64LE);
+        else if (pkgs.count("B_FluxCT"))
+            hdf5_read_array(B_file, "cons.B", 5, fdims_vec, fstart_vec, fdims_vec,
+                fdims_vec, fstart_vec, H5T_IEEE_F64LE);
     }
-    hdf5_read_array(x1_file, "VolumeLocations/x", 2, fdims_x1, fstart_x, fdims_x1, fdims_x1, fstart_x, H5T_IEEE_F64LE);
-    hdf5_read_array(x2_file, "VolumeLocations/y", 2, fdims_x2, fstart_x, fdims_x2, fdims_x2, fstart_x, H5T_IEEE_F64LE);
-    hdf5_read_array(x3_file, "VolumeLocations/z", 2, fdims_x3, fstart_x, fdims_x3, fdims_x3, fstart_x, H5T_IEEE_F64LE);
+    hdf5_read_array(x1_file, "VolumeLocations/x", 2, fdims_x1, fstart_x, fdims_x1,
+        fdims_x1, fstart_x, H5T_IEEE_F64LE);
+    hdf5_read_array(x2_file, "VolumeLocations/y", 2, fdims_x2, fstart_x, fdims_x2,
+        fdims_x2, fstart_x, H5T_IEEE_F64LE);
+    hdf5_read_array(x3_file, "VolumeLocations/z", 2, fdims_x3, fstart_x, fdims_x3,
+        fdims_x3, fstart_x, H5T_IEEE_F64LE);
     if (b_ct) {
-        hdf5_read_array(x1B_file, "Locations/x", 2, fdimsB_x1, fstart_x, fdimsB_x1, fdimsB_x1, fstart_x, H5T_IEEE_F64LE);
-        hdf5_read_array(x2B_file, "Locations/y", 2, fdimsB_x2, fstart_x, fdimsB_x2, fdimsB_x2, fstart_x, H5T_IEEE_F64LE);
-        hdf5_read_array(x3B_file, "Locations/z", 2, fdimsB_x3, fstart_x, fdimsB_x3, fdimsB_x3, fstart_x, H5T_IEEE_F64LE);
+        hdf5_read_array(x1B_file, "Locations/x", 2, fdimsB_x1, fstart_x, fdimsB_x1,
+            fdimsB_x1, fstart_x, H5T_IEEE_F64LE);
+        hdf5_read_array(x2B_file, "Locations/y", 2, fdimsB_x2, fstart_x, fdimsB_x2,
+            fdimsB_x2, fstart_x, H5T_IEEE_F64LE);
+        hdf5_read_array(x3B_file, "Locations/z", 2, fdimsB_x3, fstart_x, fdimsB_x3,
+            fdimsB_x3, fstart_x, H5T_IEEE_F64LE);
     }
     hdf5_close();
-    
-    GridScalar x1_fill_device("x1_fill_device", f_length[0], f_length[1]); 
-    GridScalar x2_fill_device("x2_fill_device", f_length[0], f_length[2]); 
-    GridScalar x3_fill_device("x3_fill_device", f_length[0], f_length[3]); 
-    GridScalar x1B_fill_device("x1B_fill_device", f_lengthB[0], f_lengthB[1]); 
-    GridScalar x2B_fill_device("x2B_fill_device", f_lengthB[0], f_lengthB[2]); 
-    GridScalar x3B_fill_device("x3B_fill_device", f_lengthB[0], f_lengthB[3]); 
-    GridScalar rho_fill_device("rho_fill_device", f_length[0], f_length[3], f_length[2], f_length[1]); 
-    GridScalar u_fill_device("u_fill_device", f_length[0], f_length[3], f_length[2], f_length[1]); 
-    GridVector uvec_fill_device("uvec_fill_device", NVEC, f_length[0], f_length[3], f_length[2], f_length[1]); 
-    GridVector B_fill_device("B_fill_device", NVEC, f_lengthB[0], f_lengthB[3], f_lengthB[2], f_lengthB[1]); 
+
+    GridScalar x1_fill_device("x1_fill_device", f_length[0], f_length[1]);
+    GridScalar x2_fill_device("x2_fill_device", f_length[0], f_length[2]);
+    GridScalar x3_fill_device("x3_fill_device", f_length[0], f_length[3]);
+    GridScalar x1B_fill_device("x1B_fill_device", f_lengthB[0], f_lengthB[1]);
+    GridScalar x2B_fill_device("x2B_fill_device", f_lengthB[0], f_lengthB[2]);
+    GridScalar x3B_fill_device("x3B_fill_device", f_lengthB[0], f_lengthB[3]);
+    GridScalar rho_fill_device(
+        "rho_fill_device", f_length[0], f_length[3], f_length[2], f_length[1]);
+    GridScalar u_fill_device(
+        "u_fill_device", f_length[0], f_length[3], f_length[2], f_length[1]);
+    GridVector uvec_fill_device(
+        "uvec_fill_device", NVEC, f_length[0], f_length[3], f_length[2], f_length[1]);
+    GridVector B_fill_device(
+        "B_fill_device", NVEC, f_lengthB[0], f_lengthB[3], f_lengthB[2], f_lengthB[1]);
     auto x1_fill_host = x1_fill_device.GetHostMirror();
     auto x2_fill_host = x2_fill_device.GetHostMirror();
     auto x3_fill_host = x3_fill_device.GetHostMirror();
@@ -321,42 +343,57 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     auto u_fill_host = u_fill_device.GetHostMirror();
     auto uvec_fill_host = uvec_fill_device.GetHostMirror();
     auto B_fill_host = B_fill_device.GetHostMirror();
-    Real *rho_filefill = new double[f_block_sz];
-    Real *u_filefill = new double[f_block_sz];
-    Real *uvec_filefill = new double[f_block_sz*NVEC];
-    Real *B_filefill = new double[f_blockB_sz*NVEC];
-    Real *x1_filefill = new double[f_length[0]*f_length[1]];
-    Real *x2_filefill = new double[f_length[0]*f_length[2]];
-    Real *x3_filefill = new double[f_length[0]*f_length[3]];
-    Real *x1B_filefill = new double[f_lengthB[0]*(f_lengthB[1])];
-    Real *x2B_filefill = new double[f_lengthB[0]*(f_lengthB[2])];
-    Real *x3B_filefill = new double[f_lengthB[0]*(f_lengthB[3])];
+    Real* rho_filefill = new double[f_block_sz];
+    Real* u_filefill = new double[f_block_sz];
+    Real* uvec_filefill = new double[f_block_sz * NVEC];
+    Real* B_filefill = new double[f_blockB_sz * NVEC];
+    Real* x1_filefill = new double[f_length[0] * f_length[1]];
+    Real* x2_filefill = new double[f_length[0] * f_length[2]];
+    Real* x3_filefill = new double[f_length[0] * f_length[3]];
+    Real* x1B_filefill = new double[f_lengthB[0] * (f_lengthB[1])];
+    Real* x2B_filefill = new double[f_lengthB[0] * (f_lengthB[2])];
+    Real* x3B_filefill = new double[f_lengthB[0] * (f_lengthB[3])];
     static hsize_t fill_fdims[] = {f_length[0], f_length[3], f_length[2], f_length[1]};
-    static hsize_t fill_fdims_vec[] = {f_length[0], NVEC, f_length[3], f_length[2], f_length[1]};
-    static hsize_t fill_fdimsB_vec[] = {f_lengthB[0], NVEC, f_lengthB[3], f_lengthB[2], f_lengthB[1]};
+    static hsize_t fill_fdims_vec[] = {
+        f_length[0], NVEC, f_length[3], f_length[2], f_length[1]};
+    static hsize_t fill_fdimsB_vec[] = {
+        f_lengthB[0], NVEC, f_lengthB[3], f_lengthB[2], f_lengthB[1]};
     static hsize_t fill_fdims_x1[] = {f_length[0], f_length[1]};
     static hsize_t fill_fdims_x2[] = {f_length[0], f_length[2]};
     static hsize_t fill_fdims_x3[] = {f_length[0], f_length[3]};
     static hsize_t fill_fdimsB_x1[] = {f_lengthB[0], f_lengthB[1]};
     static hsize_t fill_fdimsB_x2[] = {f_lengthB[0], f_lengthB[2]};
     static hsize_t fill_fdimsB_x3[] = {f_lengthB[0], f_lengthB[3]};
-    if (should_fill) { 
+    if (should_fill) {
         hdf5_open(fname_fill.c_str());
         hdf5_set_directory("/");
-        hdf5_read_array(rho_filefill, "prims.rho", 4, fill_fdims, fstart, fill_fdims, fill_fdims, fstart, H5T_IEEE_F64LE);
-        hdf5_read_array(u_filefill, "prims.u", 4, fill_fdims, fstart, fill_fdims, fill_fdims, fstart, H5T_IEEE_F64LE);
-        hdf5_read_array(uvec_filefill, "prims.uvec", 5, fill_fdims_vec, fstart_vec, fill_fdims_vec, fill_fdims_vec, fstart_vec, H5T_IEEE_F64LE);
+        hdf5_read_array(rho_filefill, "prims.rho", 4, fill_fdims, fstart, fill_fdims,
+            fill_fdims, fstart, H5T_IEEE_F64LE);
+        hdf5_read_array(u_filefill, "prims.u", 4, fill_fdims, fstart, fill_fdims,
+            fill_fdims, fstart, H5T_IEEE_F64LE);
+        hdf5_read_array(uvec_filefill, "prims.uvec", 5, fill_fdims_vec, fstart_vec,
+            fill_fdims_vec, fill_fdims_vec, fstart_vec, H5T_IEEE_F64LE);
         if (include_B) {
-            if (b_ct) hdf5_read_array(B_filefill, "cons.fB", 5, fill_fdimsB_vec, fstart_vec, fill_fdimsB_vec, fill_fdimsB_vec, fstart_vec,H5T_IEEE_F64LE);
-            else if (pkgs.count("B_FluxCT")) hdf5_read_array(B_filefill, "cons.B", 5, fill_fdims_vec, fstart_vec, fill_fdims_vec, fill_fdims_vec, fstart_vec,H5T_IEEE_F64LE);
+            if (b_ct)
+                hdf5_read_array(B_filefill, "cons.fB", 5, fill_fdimsB_vec, fstart_vec,
+                    fill_fdimsB_vec, fill_fdimsB_vec, fstart_vec, H5T_IEEE_F64LE);
+            else if (pkgs.count("B_FluxCT"))
+                hdf5_read_array(B_filefill, "cons.B", 5, fill_fdims_vec, fstart_vec,
+                    fill_fdims_vec, fill_fdims_vec, fstart_vec, H5T_IEEE_F64LE);
         }
-        hdf5_read_array(x1_filefill, "VolumeLocations/x", 2, fill_fdims_x1, fstart_x, fill_fdims_x1, fill_fdims_x1, fstart_x, H5T_IEEE_F64LE);
-        hdf5_read_array(x2_filefill, "VolumeLocations/y", 2, fill_fdims_x2, fstart_x, fill_fdims_x2, fill_fdims_x2, fstart_x, H5T_IEEE_F64LE);
-        hdf5_read_array(x3_filefill, "VolumeLocations/z", 2, fill_fdims_x3, fstart_x, fill_fdims_x3, fill_fdims_x3, fstart_x, H5T_IEEE_F64LE);
+        hdf5_read_array(x1_filefill, "VolumeLocations/x", 2, fill_fdims_x1, fstart_x,
+            fill_fdims_x1, fill_fdims_x1, fstart_x, H5T_IEEE_F64LE);
+        hdf5_read_array(x2_filefill, "VolumeLocations/y", 2, fill_fdims_x2, fstart_x,
+            fill_fdims_x2, fill_fdims_x2, fstart_x, H5T_IEEE_F64LE);
+        hdf5_read_array(x3_filefill, "VolumeLocations/z", 2, fill_fdims_x3, fstart_x,
+            fill_fdims_x3, fill_fdims_x3, fstart_x, H5T_IEEE_F64LE);
         if (b_ct) {
-            hdf5_read_array(x1B_filefill, "Locations/x", 2, fill_fdimsB_x1, fstart_x, fill_fdimsB_x1, fill_fdimsB_x1, fstart_x, H5T_IEEE_F64LE);
-            hdf5_read_array(x2B_filefill, "Locations/y", 2, fill_fdimsB_x2, fstart_x, fill_fdimsB_x2, fill_fdimsB_x2, fstart_x, H5T_IEEE_F64LE);
-            hdf5_read_array(x3B_filefill, "Locations/z", 2, fill_fdimsB_x3, fstart_x, fill_fdimsB_x3, fill_fdimsB_x3, fstart_x, H5T_IEEE_F64LE);
+            hdf5_read_array(x1B_filefill, "Locations/x", 2, fill_fdimsB_x1, fstart_x,
+                fill_fdimsB_x1, fill_fdimsB_x1, fstart_x, H5T_IEEE_F64LE);
+            hdf5_read_array(x2B_filefill, "Locations/y", 2, fill_fdimsB_x2, fstart_x,
+                fill_fdimsB_x2, fill_fdimsB_x2, fstart_x, H5T_IEEE_F64LE);
+            hdf5_read_array(x3B_filefill, "Locations/z", 2, fill_fdimsB_x3, fstart_x,
+                fill_fdimsB_x3, fill_fdimsB_x3, fstart_x, H5T_IEEE_F64LE);
         }
         hdf5_close();
     }
@@ -364,13 +401,13 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     // save the grid coordinate values to host array
     for (int iblocktemp = 0; iblocktemp < length[0]; iblocktemp++) {
         for (int itemp = 0; itemp < length[1]; itemp++) {
-            x1_f_host(iblocktemp,itemp) = x1_file[length[1]*iblocktemp+itemp];
+            x1_f_host(iblocktemp, itemp) = x1_file[length[1] * iblocktemp + itemp];
         }
         for (int jtemp = 0; jtemp < length[2]; jtemp++) {
-            x2_f_host(iblocktemp,jtemp) = x2_file[length[2]*iblocktemp+jtemp];
+            x2_f_host(iblocktemp, jtemp) = x2_file[length[2] * iblocktemp + jtemp];
         }
         for (int ktemp = 0; ktemp < length[3]; ktemp++) {
-            x3_f_host(iblocktemp,ktemp) = x3_file[length[3]*iblocktemp+ktemp];
+            x3_f_host(iblocktemp, ktemp) = x3_file[length[3] * iblocktemp + ktemp];
         }
     }
     // re-arrange uvec such that it can be read in the VLOOP
@@ -379,16 +416,28 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
         for (int itemp = 0; itemp < length[1]; itemp++) {
             for (int jtemp = 0; jtemp < length[2]; jtemp++) {
                 for (int ktemp = 0; ktemp < length[3]; ktemp++) {
-                    scalar_file_index = length[1]*(length[2]*(length[3]*iblocktemp+ktemp)+jtemp)+itemp;
+                    scalar_file_index =
+                        length[1] *
+                            (length[2] * (length[3] * iblocktemp + ktemp) + jtemp) +
+                        itemp;
 
-                    rho_f_host(iblocktemp,ktemp,jtemp,itemp) = rho_file[scalar_file_index];
-                    u_f_host(iblocktemp,ktemp,jtemp,itemp) = u_file[scalar_file_index];
+                    rho_f_host(iblocktemp, ktemp, jtemp, itemp) =
+                        rho_file[scalar_file_index];
+                    u_f_host(iblocktemp, ktemp, jtemp, itemp) = u_file[scalar_file_index];
                     for (int ltemp = 0; ltemp < 3; ltemp++) {
-                        //vector_file_index = 3*(scalar_file_index)+ltemp; // outdated parthenon phdf5 saving order
-                        vector_file_index = length[1]*(length[2]*(length[3]*(NVEC*iblocktemp+ltemp)+ktemp)+jtemp)+itemp;
-                        
-                        uvec_f_host(ltemp,iblocktemp,ktemp,jtemp,itemp) = uvec_file[vector_file_index];
-                        //if (include_B) B_f_host(ltemp,iblocktemp,ktemp,jtemp,itemp) = B_file[vector_file_index];
+                        // vector_file_index = 3*(scalar_file_index)+ltemp; // outdated
+                        // parthenon phdf5 saving order
+                        vector_file_index =
+                            length[1] *
+                                (length[2] * (length[3] * (NVEC * iblocktemp + ltemp) +
+                                                 ktemp) +
+                                    jtemp) +
+                            itemp;
+
+                        uvec_f_host(ltemp, iblocktemp, ktemp, jtemp, itemp) =
+                            uvec_file[vector_file_index];
+                        // if (include_B) B_f_host(ltemp,iblocktemp,ktemp,jtemp,itemp) =
+                        // B_file[vector_file_index];
                     }
                 }
             }
@@ -401,32 +450,40 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
                 for (int jtemp = 0; jtemp < lengthB[2]; jtemp++) {
                     for (int ktemp = 0; ktemp < lengthB[3]; ktemp++) {
                         for (int ltemp = 0; ltemp < 3; ltemp++) {
-                            vector_file_index = lengthB[1] * (lengthB[2] * (lengthB[3] * (NVEC * iblocktemp + ltemp) + ktemp) + jtemp) + itemp;
-                            B_f_host(ltemp, iblocktemp, ktemp, jtemp, itemp) = B_file[vector_file_index];
+                            vector_file_index =
+                                lengthB[1] *
+                                    (lengthB[2] *
+                                            (lengthB[3] * (NVEC * iblocktemp + ltemp) +
+                                                ktemp) +
+                                        jtemp) +
+                                itemp;
+                            B_f_host(ltemp, iblocktemp, ktemp, jtemp, itemp) =
+                                B_file[vector_file_index];
                         }
                     }
                 }
             }
             for (int jtemp = 0; jtemp < lengthB[2]; jtemp++)
                 x2B_f_host(iblocktemp, jtemp) = x2B_file[lengthB[2] * iblocktemp + jtemp];
-            for (int ktemp = 0; ktemp < lengthB[3]; ktemp++) 
+            for (int ktemp = 0; ktemp < lengthB[3]; ktemp++)
                 x3B_f_host(iblocktemp, ktemp) = x3B_file[lengthB[3] * iblocktemp + ktemp];
         }
     }
-    
-
 
     if (should_fill) {
         // save the grid coordinate values to host array
         for (int iblocktemp = 0; iblocktemp < f_length[0]; iblocktemp++) {
             for (int itemp = 0; itemp < f_length[1]; itemp++) {
-                x1_fill_host(iblocktemp,itemp) = x1_filefill[f_length[1]*iblocktemp+itemp];
+                x1_fill_host(iblocktemp, itemp) =
+                    x1_filefill[f_length[1] * iblocktemp + itemp];
             }
             for (int jtemp = 0; jtemp < f_length[2]; jtemp++) {
-                x2_fill_host(iblocktemp,jtemp) = x2_filefill[f_length[2]*iblocktemp+jtemp];
+                x2_fill_host(iblocktemp, jtemp) =
+                    x2_filefill[f_length[2] * iblocktemp + jtemp];
             }
             for (int ktemp = 0; ktemp < f_length[3]; ktemp++) {
-                x3_fill_host(iblocktemp,ktemp) = x3_filefill[f_length[3]*iblocktemp+ktemp];
+                x3_fill_host(iblocktemp, ktemp) =
+                    x3_filefill[f_length[3] * iblocktemp + ktemp];
             }
         }
         // re-arrange uvec such that it can be read in the VLOOP
@@ -434,15 +491,30 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
             for (int itemp = 0; itemp < f_length[1]; itemp++) {
                 for (int jtemp = 0; jtemp < f_length[2]; jtemp++) {
                     for (int ktemp = 0; ktemp < f_length[3]; ktemp++) {
-                        scalar_file_index = f_length[1]*(f_length[2]*(f_length[3]*iblocktemp+ktemp)+jtemp)+itemp;
+                        scalar_file_index =
+                            f_length[1] *
+                                (f_length[2] * (f_length[3] * iblocktemp + ktemp) +
+                                    jtemp) +
+                            itemp;
 
-                        rho_fill_host(iblocktemp,ktemp,jtemp,itemp) = rho_filefill[scalar_file_index];
-                        u_fill_host(iblocktemp,ktemp,jtemp,itemp) = u_filefill[scalar_file_index];
+                        rho_fill_host(iblocktemp, ktemp, jtemp, itemp) =
+                            rho_filefill[scalar_file_index];
+                        u_fill_host(iblocktemp, ktemp, jtemp, itemp) =
+                            u_filefill[scalar_file_index];
                         for (int ltemp = 0; ltemp < 3; ltemp++) {
-                            vector_file_index = f_length[1]*(f_length[2]*(f_length[3]*(NVEC*iblocktemp+ltemp)+ktemp)+jtemp)+itemp;
-                            
-                            uvec_fill_host(ltemp,iblocktemp,ktemp,jtemp,itemp) = uvec_filefill[vector_file_index];
-                            //if (include_B) B_fill_host(ltemp,iblocktemp,ktemp,jtemp,itemp) = B_filefill[vector_file_index];
+                            vector_file_index =
+                                f_length[1] *
+                                    (f_length[2] *
+                                            (f_length[3] * (NVEC * iblocktemp + ltemp) +
+                                                ktemp) +
+                                        jtemp) +
+                                itemp;
+
+                            uvec_fill_host(ltemp, iblocktemp, ktemp, jtemp, itemp) =
+                                uvec_filefill[vector_file_index];
+                            // if (include_B)
+                            // B_fill_host(ltemp,iblocktemp,ktemp,jtemp,itemp) =
+                            // B_filefill[vector_file_index];
                         }
                     }
                 }
@@ -451,20 +523,31 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
         if (include_B) {
             for (int iblocktemp = 0; iblocktemp < f_lengthB[0]; iblocktemp++) {
                 for (int itemp = 0; itemp < f_lengthB[1]; itemp++) {
-                    x1B_fill_host(iblocktemp, itemp) = x1B_filefill[f_lengthB[1] * iblocktemp + itemp];
+                    x1B_fill_host(iblocktemp, itemp) =
+                        x1B_filefill[f_lengthB[1] * iblocktemp + itemp];
                     for (int jtemp = 0; jtemp < f_lengthB[2]; jtemp++) {
                         for (int ktemp = 0; ktemp < f_lengthB[3]; ktemp++) {
                             for (int ltemp = 0; ltemp < 3; ltemp++) {
-                                vector_file_index = f_lengthB[1] * (f_lengthB[2] * (f_lengthB[3] * (NVEC * iblocktemp + ltemp) + ktemp) + jtemp) + itemp;
-                                B_fill_host(ltemp, iblocktemp, ktemp, jtemp, itemp) = B_filefill[vector_file_index];
+                                vector_file_index =
+                                    f_lengthB[1] *
+                                        (f_lengthB[2] *
+                                                (f_lengthB[3] *
+                                                        (NVEC * iblocktemp + ltemp) +
+                                                    ktemp) +
+                                            jtemp) +
+                                    itemp;
+                                B_fill_host(ltemp, iblocktemp, ktemp, jtemp, itemp) =
+                                    B_filefill[vector_file_index];
                             }
                         }
                     }
                 }
                 for (int jtemp = 0; jtemp < f_lengthB[2]; jtemp++)
-                    x2B_fill_host(iblocktemp, jtemp) = x2B_filefill[f_lengthB[2] * iblocktemp + jtemp];
+                    x2B_fill_host(iblocktemp, jtemp) =
+                        x2B_filefill[f_lengthB[2] * iblocktemp + jtemp];
                 for (int ktemp = 0; ktemp < f_lengthB[3]; ktemp++)
-                    x3B_fill_host(iblocktemp, ktemp) = x3B_filefill[f_lengthB[3] * iblocktemp + ktemp];
+                    x3B_fill_host(iblocktemp, ktemp) =
+                        x3B_filefill[f_lengthB[3] * iblocktemp + ktemp];
             }
         }
     }
@@ -519,9 +602,11 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
 
     // Device-side interpolate & copy into the mirror array
     if (MPIRank0() && verbose > 0) {
-        std::cout << "Initializing KHARMA restart.  Filling " << fx1min_ghost << " to " << fx1max_ghost << " from " << fname
-                    << " and the rest from " << fname_fill << std::endl;
-        std::cout << "Vacuum gam: " << gam << " mdot: " << mdot << " rs: " << rs << std::endl;
+        std::cout << "Initializing KHARMA restart.  Filling " << fx1min_ghost << " to "
+                  << fx1max_ghost << " from " << fname << " and the rest from "
+                  << fname_fill << std::endl;
+        std::cout << "Vacuum gam: " << gam << " mdot: " << mdot << " rs: " << rs
+                  << std::endl;
     }
 
     // Read to the entire meshblock -- we'll set the Dirichlet boundaries based on the
@@ -532,29 +617,32 @@ TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterI
     int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);
 
     pmb->par_for("copy_restart_state_kharma", ks, ke, js, je, is, ie,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-            get_prim_restart_kharma(G, P, m_p,
-                fx1min_ghost, fx1max_ghost, should_fill, is_spherical, gam, rs, mdot, ur_frac, uphi, rin_bondi, length, f_length,
-                x1_f_device, x2_f_device, x3_f_device, rho_f_device, u_f_device, uvec_f_device,
-                x1_fill_device, x2_fill_device, x3_fill_device, rho_fill_device, u_fill_device, uvec_fill_device,
-                k, j, i);
-        }
-    );
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
+            get_prim_restart_kharma(G, P, m_p, fx1min_ghost, fx1max_ghost, should_fill,
+                is_spherical, gam, rs, mdot, ur_frac, uphi, rin_bondi, length, f_length,
+                x1_f_device, x2_f_device, x3_f_device, rho_f_device, u_f_device,
+                uvec_f_device, x1_fill_device, x2_fill_device, x3_fill_device,
+                rho_fill_device, u_fill_device, uvec_fill_device, k, j, i);
+        });
     if (include_B) {
         Loci loc;
         VLOOP {
-            if (b_ct) loc = (Loci) v;
-            else loc = Loci::center;
-            pmb->par_for("copy_B_restart_state_kharma", ks, ke + (dir_of(loc) == 3), js, je + (dir_of(loc) == 2), is, ie + (dir_of(loc) == 1),
-                KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-                        get_B_restart_kharma(G, fx1min_ghost, fx1max_ghost, should_fill, loc, length, f_length, lengthB, f_lengthB,
-                            x1_f_device, x2_f_device, x3_f_device,
-                            x1B_f_device, x2B_f_device, x3B_f_device, B_f_device,
-                            x1_fill_device, x2_fill_device, x3_fill_device,
-                            x1B_fill_device, x2B_fill_device, x3B_fill_device, B_fill_device, B_Save,
-                            v, k, j, i);
-                }
-            );
+            if (b_ct)
+                loc = (Loci)v;
+            else
+                loc = Loci::center;
+            pmb->par_for("copy_B_restart_state_kharma", ks, ke + (dir_of(loc) == 3), js,
+                je + (dir_of(loc) == 2), is, ie + (dir_of(loc) == 1),
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
+                    get_B_restart_kharma(G, fx1min_ghost, fx1max_ghost, should_fill, loc,
+                        length, f_length, lengthB, f_lengthB, x1_f_device, x2_f_device,
+                        x3_f_device, x1B_f_device, x2B_f_device, x3B_f_device, B_f_device,
+                        x1_fill_device, x2_fill_device, x3_fill_device, x1B_fill_device,
+                        x2B_fill_device, x3B_fill_device, B_fill_device, B_Save, v, k, j,
+                        i);
+                });
         }
     }
 

--- a/kharma/prob/resize_restart_kharma.hpp
+++ b/kharma/prob/resize_restart_kharma.hpp
@@ -6,68 +6,68 @@
 #include "mesh/mesh.hpp"
 
 // added by Hyerin (10/07/22)
-#include "bondi.hpp"
 #include "b_flux_ct.hpp"
+#include "bondi.hpp"
 
 /**
  * Read the header of an KHARMA HDF5 restart file, and set appropriate parameters
  * Call this before mesh creation!
  */
-void ReadKharmaRestartHeader(std::string fname, ParameterInput *pin);
+void ReadKharmaRestartHeader(std::string fname, ParameterInput* pin);
 
 /**
  * Read data from an KHARMA restart file. Does not support >1 meshblock in Parthenon
- * 
+ *
  * Returns stop time tf of the original simulation, for e.g. replicating regression tests
  */
-TaskStatus ReadKharmaRestart(std::shared_ptr<MeshBlockData<Real>> rc, ParameterInput *pin);
+TaskStatus ReadKharmaRestart(
+    std::shared_ptr<MeshBlockData<Real>> rc, ParameterInput* pin);
 
 // Hint form resize.hpp
 // TODO: (Hyerin) should I do const for x1, x2, x3, var?
 KOKKOS_INLINE_FUNCTION void Xtoindex(const GReal XG[GR_DIM],
-                                  //Real *x1, Real *x2, Real *x3,
-                                   const GridScalar& x1, const GridScalar& x2, const GridScalar& x3,
-                                   const hsize_t length[GR_DIM], int& iblock,
-                                   int& i, int& j, int& k, GReal del[GR_DIM])
+    // Real *x1, Real *x2, Real *x3,
+    const GridScalar& x1, const GridScalar& x2, const GridScalar& x3,
+    const hsize_t length[GR_DIM], int& iblock, int& i, int& j, int& k, GReal del[GR_DIM])
 {
     Real dx1, dx2, dx3, dx_sum, dx1_min, dx2_min, dx3_min, dx_sum_min;
 
     // initialize
-    iblock =0;
+    iblock = 0;
     i = 0;
     j = 0;
     k = 0;
-    dx1_min = (XG[1]-x1(iblock,i))*(XG[1]-x1(iblock,i));
-    dx2_min = (XG[2]-x2(iblock,j))*(XG[2]-x2(iblock,j));
-    dx3_min = (XG[3]-x3(iblock,k))*(XG[3]-x3(iblock,k));
+    dx1_min = (XG[1] - x1(iblock, i)) * (XG[1] - x1(iblock, i));
+    dx2_min = (XG[2] - x2(iblock, j)) * (XG[2] - x2(iblock, j));
+    dx3_min = (XG[3] - x3(iblock, k)) * (XG[3] - x3(iblock, k));
     dx_sum_min = dx1_min + dx2_min + dx3_min;
 
     for (int iblocktemp = 0; iblocktemp < length[0]; iblocktemp++) {
         // independently searching for minimum for i,j,k
         for (int itemp = 0; itemp < length[1]; itemp++) {
-            dx1 = (XG[1]-x1(iblocktemp,itemp))*(XG[1]-x1(iblocktemp,itemp));
+            dx1 = (XG[1] - x1(iblocktemp, itemp)) * (XG[1] - x1(iblocktemp, itemp));
             if (dx1 < dx1_min) {
                 dx1_min = dx1;
                 i = itemp;
             }
         }
         for (int jtemp = 0; jtemp < length[2]; jtemp++) {
-            dx2 = (XG[2]-x2(iblocktemp,jtemp))*(XG[2]-x2(iblocktemp,jtemp));
+            dx2 = (XG[2] - x2(iblocktemp, jtemp)) * (XG[2] - x2(iblocktemp, jtemp));
             if (dx2 < dx2_min) {
                 dx2_min = dx2;
                 j = jtemp;
             }
         }
         for (int ktemp = 0; ktemp < length[3]; ktemp++) {
-            dx3 = (XG[3]-x3(iblocktemp,ktemp))*(XG[3]-x3(iblocktemp,ktemp));
+            dx3 = (XG[3] - x3(iblocktemp, ktemp)) * (XG[3] - x3(iblocktemp, ktemp));
             if (dx3 < dx3_min) {
                 dx3_min = dx3;
                 k = ktemp;
             }
         }
-        dx_sum = (XG[1]-x1(iblocktemp,i))*(XG[1]-x1(iblocktemp,i)) + 
-                 (XG[2]-x2(iblocktemp,j))*(XG[2]-x2(iblocktemp,j)) + 
-                 (XG[3]-x3(iblocktemp,k))*(XG[3]-x3(iblocktemp,k));
+        dx_sum = (XG[1] - x1(iblocktemp, i)) * (XG[1] - x1(iblocktemp, i)) +
+                 (XG[2] - x2(iblocktemp, j)) * (XG[2] - x2(iblocktemp, j)) +
+                 (XG[3] - x3(iblocktemp, k)) * (XG[3] - x3(iblocktemp, k));
         if (dx_sum < dx_sum_min) {
             dx_sum_min = dx_sum;
             iblock = iblocktemp;
@@ -75,109 +75,130 @@ KOKKOS_INLINE_FUNCTION void Xtoindex(const GReal XG[GR_DIM],
     }
 
     del[1] = 0.; //(XG[1] - ((i) * dx[1] + startx[1])) / dx[1];
-    del[2] = 0.;//(XG[2] - ((j) * dx[2] + startx[2])) / dx[2];
-    del[3] = 0.;// (phi   - ((k) * dx[3] + startx[3])) / dx[3];
+    del[2] = 0.; //(XG[2] - ((j) * dx[2] + startx[2])) / dx[2];
+    del[3] = 0.; // (phi   - ((k) * dx[3] + startx[3])) / dx[3];
 #ifndef KOKKOS_ENABLE_SYCL
-    if (m::abs(dx1_min / m::pow(XG[1],2.)) > 1.e-8) printf("Xtoindex: dx2 pretty large = %g at r= %g \n", dx1_min, XG[1]);
-    if (m::abs(dx2_min) > 1.e-8) printf("Xtoindex: dx2 pretty large = %g at th = %g \n", dx2_min, XG[2]);
-    if (m::abs(dx3_min) > 1.e-8) printf("Xtoindex: dx2 pretty large = %g at phi = %g \n", dx3_min, XG[3]);
+    if (m::abs(dx1_min / m::pow(XG[1], 2.)) > 1.e-8)
+        printf("Xtoindex: dx2 pretty large = %g at r= %g \n", dx1_min, XG[1]);
+    if (m::abs(dx2_min) > 1.e-8)
+        printf("Xtoindex: dx2 pretty large = %g at th = %g \n", dx2_min, XG[2]);
+    if (m::abs(dx3_min) > 1.e-8)
+        printf("Xtoindex: dx2 pretty large = %g at phi = %g \n", dx3_min, XG[3]);
 #endif
 }
 
-// TOOD(BSP) these can be merged and moved back into the fn body now
+// TOOD(CEP) these can be merged and moved back into the fn body now
 
-KOKKOS_INLINE_FUNCTION void get_prim_restart_kharma(const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p,
-                    const Real fx1min, const Real fx1max, const bool should_fill, const bool is_spherical,
-                    const Real gam, const Real rs, const Real mdot, const Real ur_frac, const Real uphi, const Real rin_bondi, const hsize_t length[GR_DIM], const hsize_t length_fill[GR_DIM],
-                    const GridScalar& x1, const GridScalar& x2, const GridScalar& x3, const GridScalar& rho_file, const GridScalar& u_file, const GridVector& uvec_file,
-                    const GridScalar& x1_fill, const GridScalar& x2_fill, const GridScalar& x3_fill, const GridScalar& rho_fill, const GridScalar& u_fill, const GridVector& uvec_fill,
-                    const int& k, const int& j, const int& i) 
+KOKKOS_INLINE_FUNCTION void get_prim_restart_kharma(const GRCoordinates& G,
+    const VariablePack<Real>& P, const VarMap& m_p, const Real fx1min, const Real fx1max,
+    const bool should_fill, const bool is_spherical, const Real gam, const Real rs,
+    const Real mdot, const Real ur_frac, const Real uphi, const Real rin_bondi,
+    const hsize_t length[GR_DIM], const hsize_t length_fill[GR_DIM], const GridScalar& x1,
+    const GridScalar& x2, const GridScalar& x3, const GridScalar& rho_file,
+    const GridScalar& u_file, const GridVector& uvec_file, const GridScalar& x1_fill,
+    const GridScalar& x2_fill, const GridScalar& x3_fill, const GridScalar& rho_fill,
+    const GridScalar& u_fill, const GridVector& uvec_fill, const int& k, const int& j,
+    const int& i)
 {
     Real rho = 0, u = 0;
     Real u_prim[NVEC] = {0}; //, B_prim[NVEC];
 
     GReal X[GR_DIM];
     G.coord(k, j, i, Loci::center, X);
-    GReal del[GR_DIM]; // not really needed now since I am doing nearest neighbor interpolation
+    GReal del[GR_DIM]; // not really needed now since I am doing nearest neighbor
+                       // interpolation
     int iblocktemp, itemp, jtemp, ktemp;
 
     // Interpolate the value at this location from the global grid
-    if ((!should_fill) && (X[1]<fx1min)) {// if cannot be read from restart file
+    if ((!should_fill) && (X[1] < fx1min)) { // if cannot be read from restart file
         // same as Bondi (06/13/23)
-        get_prim_bondi(G, true, rs, mdot, gam, ur_frac, uphi, rin_bondi, 0., false, rho, u, u_prim, k, j, i); // TODO(HC) diffinit=true, fill_interior = false for now...
+        get_prim_bondi(G, true, rs, mdot, gam, ur_frac, uphi, rin_bondi, 0., false, rho,
+            u, u_prim, k, j,
+            i); // TODO(HC) diffinit=true, fill_interior = false for now...
 
-        // printf("Bondi fill location: %g %g %g %g KS: %g %g %g %g\nr: %g T: %g ur: %g\nucon: %g %g %g %g native: %g %g %g %g\nPrims: %g %g %g %g %g\n",
+        // printf("Bondi fill location: %g %g %g %g KS: %g %g %g %g\nr: %g T: %g ur:
+        // %g\nucon: %g %g %g %g native: %g %g %g %g\nPrims: %g %g %g %g %g\n",
         //         X[0], X[1], X[2], X[3], Xembed[0], Xembed[1], Xembed[2], Xembed[3],
-        //         r, T, ur, ucon_bl[0], ucon_bl[1], ucon_bl[2], ucon_bl[3], ucon_native[0], ucon_native[1], ucon_native[2], ucon_native[3],
+        //         r, T, ur, ucon_bl[0], ucon_bl[1], ucon_bl[2], ucon_bl[3],
+        //         ucon_native[0], ucon_native[1], ucon_native[2], ucon_native[3],
         //         rho_temp, u_temp, u_prim[0], u_prim[1], u_prim[2]);
 
-   }
+    }
     // HyerinTODO: if fname_fill exists and smaller.
-    else if ((should_fill) && ((X[1]>fx1max)||(X[1]<fx1min))) { // fill with the fname_fill
-        Xtoindex(X, x1_fill, x2_fill, x3_fill, length_fill, iblocktemp, itemp, jtemp, ktemp, del);
+    else if ((should_fill) &&
+             ((X[1] > fx1max) || (X[1] < fx1min))) { // fill with the fname_fill
+        Xtoindex(X, x1_fill, x2_fill, x3_fill, length_fill, iblocktemp, itemp, jtemp,
+            ktemp, del);
         rho = rho_fill(iblocktemp, ktemp, jtemp, itemp);
         u = u_fill(iblocktemp, ktemp, jtemp, itemp);
-        VLOOP u_prim[v] = uvec_fill(v, iblocktemp, ktemp, jtemp, itemp);
-    }
-    else { 
+        VLOOP
+            u_prim[v] = uvec_fill(v, iblocktemp, ktemp, jtemp, itemp);
+    } else {
         Xtoindex(X, x1, x2, x3, length, iblocktemp, itemp, jtemp, ktemp, del);
-        rho = rho_file(iblocktemp,ktemp,jtemp,itemp);
-        u = u_file(iblocktemp,ktemp,jtemp,itemp);
-        VLOOP u_prim[v] = uvec_file(v,iblocktemp,ktemp,jtemp,itemp);
-        //printf("File fill location: %g %g %g %g new index: %d %d %d from old index: (%d) %d %d %d\n",
-        //       X[0], X[1], X[2], X[3], k, j, i, iblocktemp, ktemp, jtemp, itemp);
+        rho = rho_file(iblocktemp, ktemp, jtemp, itemp);
+        u = u_file(iblocktemp, ktemp, jtemp, itemp);
+        VLOOP
+            u_prim[v] = uvec_file(v, iblocktemp, ktemp, jtemp, itemp);
+        // printf("File fill location: %g %g %g %g new index: %d %d %d from old index:
+        // (%d) %d %d %d\n",
+        //        X[0], X[1], X[2], X[3], k, j, i, iblocktemp, ktemp, jtemp, itemp);
     }
     // if (u_prim[1] > 1 || u_prim[2] > 1) {
-    //     printf("Fill prims: %g %g %g %g %g from bondi,fill,file: %d %d %d\n", rho_temp, u_temp, u_prim[0], u_prim[1], u_prim[2], filled_bondi, filled_fill, filled_file);
+    //     printf("Fill prims: %g %g %g %g %g from bondi,fill,file: %d %d %d\n", rho_temp,
+    //     u_temp, u_prim[0], u_prim[1], u_prim[2], filled_bondi, filled_fill,
+    //     filled_file);
     // }
     P(m_p.RHO, k, j, i) = rho;
     P(m_p.UU, k, j, i) = u;
-    P(m_p.U1, k, j, i) = u_prim[0]; 
+    P(m_p.U1, k, j, i) = u_prim[0];
     P(m_p.U2, k, j, i) = u_prim[1];
     P(m_p.U3, k, j, i) = u_prim[2];
-
 }
 
-KOKKOS_INLINE_FUNCTION void get_B_restart_kharma(const GRCoordinates& G, 
-                    const Real fx1min, const Real fx1max, const bool should_fill, const Loci loc,
-                    const hsize_t length[GR_DIM], const hsize_t length_fill[GR_DIM],
-                    const hsize_t lengthf[GR_DIM], const hsize_t lengthf_fill[GR_DIM],
-                    const GridScalar& x1, const GridScalar& x2, const GridScalar& x3,
-                    const GridScalar& x1f, const GridScalar& x2f, const GridScalar& x3f, const GridVector& B,
-                    const GridScalar& x1_fill, const GridScalar& x2_fill, const GridScalar& x3_fill,
-                    const GridScalar& x1f_fill, const GridScalar& x2f_fill, const GridScalar& x3f_fill, const GridVector& B_fill, const GridVector& B_save,
-                    const int& v, const int& k, const int& j, const int& i) 
+KOKKOS_INLINE_FUNCTION void get_B_restart_kharma(const GRCoordinates& G,
+    const Real fx1min, const Real fx1max, const bool should_fill, const Loci loc,
+    const hsize_t length[GR_DIM], const hsize_t length_fill[GR_DIM],
+    const hsize_t lengthf[GR_DIM], const hsize_t lengthf_fill[GR_DIM],
+    const GridScalar& x1, const GridScalar& x2, const GridScalar& x3,
+    const GridScalar& x1f, const GridScalar& x2f, const GridScalar& x3f,
+    const GridVector& B, const GridScalar& x1_fill, const GridScalar& x2_fill,
+    const GridScalar& x3_fill, const GridScalar& x1f_fill, const GridScalar& x2f_fill,
+    const GridScalar& x3f_fill, const GridVector& B_fill, const GridVector& B_save,
+    const int& v, const int& k, const int& j, const int& i)
 {
     Real B_cons[NVEC];
-    
+
     GReal X[GR_DIM];
     G.coord(k, j, i, loc, X);
-    GReal del[GR_DIM]; // not really needed now since I am doing nearest neighbor interpolation
+    GReal del[GR_DIM]; // not really needed now since I am doing nearest neighbor
+                       // interpolation
     int iblocktemp, itemp, jtemp, ktemp;
     hsize_t length_loc[GR_DIM], length_fill_loc[GR_DIM];
-    
-    DLOOP1 length_loc[mu] = length[mu];
-    DLOOP1 length_fill_loc[mu] = length_fill[mu];
+
+    DLOOP1
+        length_loc[mu] = length[mu];
+    DLOOP1
+        length_fill_loc[mu] = length_fill[mu];
     if (loc != Loci::center) {
         length_loc[dir_of(loc)] = lengthf[dir_of(loc)];
         length_fill_loc[dir_of(loc)] = lengthf_fill[dir_of(loc)];
     }
- 
+
     // Interpolate the value at this location from the global grid
-    if ((!should_fill) && (X[1]<fx1min)) {// if cannot be read from restart file
+    if ((!should_fill) && (X[1] < fx1min)) { // if cannot be read from restart file
         // Just use the initialization from SeedBField
         B_cons[v] = 0.;
-    }
-    else if ((should_fill) && ((X[1]>fx1max)||(X[1]<fx1min))) { // fill with the fname_fill
-        Xtoindex(X, (loc == Loci::face1)? x1f_fill : x1_fill, 
-                    (loc == Loci::face2)? x2f_fill : x2_fill, 
-                    (loc == Loci::face3)? x3f_fill : x3_fill, length_fill_loc, iblocktemp, itemp, jtemp, ktemp, del);
+    } else if ((should_fill) &&
+               ((X[1] > fx1max) || (X[1] < fx1min))) { // fill with the fname_fill
+        Xtoindex(X, (loc == Loci::face1) ? x1f_fill : x1_fill,
+            (loc == Loci::face2) ? x2f_fill : x2_fill,
+            (loc == Loci::face3) ? x3f_fill : x3_fill, length_fill_loc, iblocktemp, itemp,
+            jtemp, ktemp, del);
         B_cons[v] = B_fill(v, iblocktemp, ktemp, jtemp, itemp);
-    }
-    else { 
-        Xtoindex(X, (loc == Loci::face1)? x1f : x1, 
-                    (loc == Loci::face2)? x2f : x2, 
-                    (loc == Loci::face3)? x3f : x3, length_loc, iblocktemp, itemp, jtemp, ktemp, del);
+    } else {
+        Xtoindex(X, (loc == Loci::face1) ? x1f : x1, (loc == Loci::face2) ? x2f : x2,
+            (loc == Loci::face3) ? x3f : x3, length_loc, iblocktemp, itemp, jtemp, ktemp,
+            del);
         B_cons[v] = B(v, iblocktemp, ktemp, jtemp, itemp);
     }
 

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -65,29 +65,32 @@ inline T MPIReduce_once(T f, MPI_Op O)
 }
 
 // Shorter names for the reductions we use here
-Real MaxBsq(MeshData<Real> *md)
+Real MaxBsq(MeshData<Real>* md)
 {
-    return Reductions::DomainReduction<Reductions::Var::bsq, UserHistoryOperation::max, Real>(md);
+    return Reductions::DomainReduction<Reductions::Var::bsq, UserHistoryOperation::max,
+        Real>(md);
 }
-Real MaxPressure(MeshData<Real> *md)
+Real MaxPressure(MeshData<Real>* md)
 {
-    return Reductions::DomainReduction<Reductions::Var::gas_pressure, UserHistoryOperation::max, Real>(md);
+    return Reductions::DomainReduction<Reductions::Var::gas_pressure,
+        UserHistoryOperation::max, Real>(md);
 }
-Real MinBeta(MeshData<Real> *md)
+Real MinBeta(MeshData<Real>* md)
 {
-    return Reductions::DomainReduction<Reductions::Var::beta, UserHistoryOperation::min, Real>(md);
+    return Reductions::DomainReduction<Reductions::Var::beta, UserHistoryOperation::min,
+        Real>(md);
 }
 
-
-template <BSeedType Seed>
-TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDomain domain = IndexDomain::entire)
+template<BSeedType Seed>
+TaskStatus SeedBFieldType(MeshBlockData<Real>* rc, ParameterInput* pin,
+    IndexDomain domain = IndexDomain::entire)
 {
     auto pmb = rc->GetBlockPointer();
     auto pkgs = pmb->packages.AllPackages();
 
     // Fields
     GridScalar rho = rc->Get("prims.rho").data;
-    const auto &G = pmb->coords;
+    const auto& G = pmb->coords;
 
     // Parameters
     std::string b_field_type = pin->GetString("b_field", "type");
@@ -112,12 +115,9 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
     int ndim = pmb->pmy_mesh->ndim;
 
     // Shortcut to field values for easy fields
-    if constexpr (Seed == BSeedType::constant ||
-                  Seed == BSeedType::monopole ||
-                  Seed == BSeedType::orszag_tang ||
-                  Seed == BSeedType::wave ||
-                  Seed == BSeedType::shock_tube)
-    {
+    if constexpr (Seed == BSeedType::constant || Seed == BSeedType::monopole ||
+                  Seed == BSeedType::orszag_tang || Seed == BSeedType::wave ||
+                  Seed == BSeedType::shock_tube) {
         // All custom B fields should set what they need of these.
         // We take the same names, but they may mean different things to the
         // particular init function, check seed_B.hpp
@@ -140,75 +140,62 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
             // Fill at 3 different locations
             // Avoid overstepping even as we fill *every face*
             IndexRange3 b1 = KDomain::GetRange(rc, domain, F1);
-            pmb->par_for(
-                "B_field_B1", b1.ks, b1.ke, b1.js, b1.je, b1.is, b1.ie,
-                KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+            pmb->par_for("B_field_B1", b1.ks, b1.ke, b1.js, b1.je, b1.is, b1.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     GReal Xembed[GR_DIM];
                     double null1, null2;
                     // TODO handle calling Seed() mid-run and adding field
                     G.coord_embed(k, j, i, Loci::face1, Xembed);
                     GReal gdet = G.gdet(Loci::face1, j, i);
                     double B_Pf1 = B10;
-                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase,
-                                 amp_B1, amp_B2, amp_B3,
-                                 amp2_B1, amp2_B2, amp2_B3,
-                                 B_Pf1, null1, null2);
+                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase, amp_B1, amp_B2, amp_B3,
+                        amp2_B1, amp2_B2, amp2_B3, B_Pf1, null1, null2);
                     B_Uf(F1, 0, k, j, i) = B_Pf1 * gdet;
-                }
-            );
+                });
             IndexRange3 b2 = KDomain::GetRange(rc, domain, F2);
-            pmb->par_for(
-                "B_field_B2", b2.ks, b2.ke, b2.js, b2.je, b2.is, b2.ie,
-                KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+            pmb->par_for("B_field_B2", b2.ks, b2.ke, b2.js, b2.je, b2.is, b2.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     GReal Xembed[GR_DIM];
                     double null1, null2;
                     G.coord_embed(k, j, i, Loci::face2, Xembed);
                     GReal gdet = G.gdet(Loci::face2, j, i);
                     double B_Pf2 = B20;
-                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase,
-                                 amp_B1, amp_B2, amp_B3,
-                                 amp2_B1, amp2_B2, amp2_B3,
-                                 null1, B_Pf2, null2);
+                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase, amp_B1, amp_B2, amp_B3,
+                        amp2_B1, amp2_B2, amp2_B3, null1, B_Pf2, null2);
                     B_Uf(F2, 0, k, j, i) = B_Pf2 * gdet;
-                }
-            );
+                });
             IndexRange3 b3 = KDomain::GetRange(rc, domain, F3);
-            pmb->par_for(
-                "B_field_B2", b3.ks, b3.ke, b3.js, b3.je, b3.is, b3.ie,
-                KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+            pmb->par_for("B_field_B2", b3.ks, b3.ke, b3.js, b3.je, b3.is, b3.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     GReal Xembed[GR_DIM];
                     double null1, null2;
                     G.coord_embed(k, j, i, Loci::face3, Xembed);
                     GReal gdet = G.gdet(Loci::face3, j, i);
                     double B_Pf3 = B30;
-                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase,
-                                 amp_B1, amp_B2, amp_B3,
-                                 amp2_B1, amp2_B2, amp2_B3,
-                                 null1, null2, B_Pf3);
+                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase, amp_B1, amp_B2, amp_B3,
+                        amp2_B1, amp2_B2, amp2_B3, null1, null2, B_Pf3);
                     B_Uf(F3, 0, k, j, i) = B_Pf3 * gdet;
-                }
-            );
+                });
             // Update primitive variables
             B_CT::BlockUtoP(rc, domain);
         } else if (pkgs.count("B_FluxCT")) {
             GridVector B_P = rc->Get("prims.B").data;
-            pmb->par_for(
-                "B_field_B", b.ks, b.ke, b.js, b.je, b.is, b.ie,
-                KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+            pmb->par_for("B_field_B", b.ks, b.ke, b.js, b.je, b.is, b.ie,
+                         KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                {
                     GReal Xembed[GR_DIM];
                     G.coord_embed(k, j, i, Loci::center, Xembed);
                     const GReal gdet = G.gdet(Loci::center, j, i);
                     B_P(V1, k, j, i) = B10;
                     B_P(V2, k, j, i) = B20;
                     B_P(V3, k, j, i) = B30;
-                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase,
-                                 amp_B1, amp_B2, amp_B3,
-                                 amp2_B1, amp2_B2, amp2_B3,
-                                 B_P(V1, k, j, i),
-                                 B_P(V2, k, j, i),
-                                 B_P(V3, k, j, i));
-                }
-            );
+                    seed_b<Seed>(Xembed, gdet, k1, k2, k3, phase, amp_B1, amp_B2, amp_B3,
+                        amp2_B1, amp2_B2, amp2_B3, B_P(V1, k, j, i), B_P(V2, k, j, i),
+                        B_P(V3, k, j, i));
+                });
             // We still need to update conserved flux values, but then we're done
             B_FluxCT::BlockPtoU(rc, domain);
         } // TODO B_CD!!
@@ -221,119 +208,128 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
         Real a, rin, rmax, gam, kappa, rho_norm, arg1, n, rs, rb;
         Real tilt = 0; // Needs to be initialized
         switch (Seed) {
-        case BSeedType::sane:
-        case BSeedType::mad:
-        case BSeedType::mad_quadrupole:
-        case BSeedType::r3s3:
-        case BSeedType::r5s5:
-        case BSeedType::gaussian:
-            // Torus parameters
-            rin = pin->GetReal("torus", "rin");
-            rmax = pin->GetReal("torus", "rmax");
-            kappa = pin->GetReal("torus", "kappa");
-            tilt = pin->GetReal("torus", "tilt") / 180. * M_PI;
-            // Other things we need only for torus evaluation
-            gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
-            rho_norm = pmb->packages.Get("GRMHD")->Param<Real>("rho_norm");
-            a = G.coords.get_a();
-            break;
-        case BSeedType::orszag_tang_a:
-            A0 = pin->GetReal("orszag_tang", "tscale");
-            arg1 = pin->GetReal("orszag_tang", "phase");
-            break;
-        case BSeedType::r1s2:
-            gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
-            n = 1. / (gam - 1.);
-            rs = pin->GetOrAddReal("bondi", "rs", m::sqrt(1e5));
-            if (m::abs(n-1.5) < 0.01) rb = rs * rs * 80. / (27. * gam);
-            else rb = (4 * (n + 1)) / (2 * (n + 3) - 9) * rs;
-            break;
-        default:
-            break;
+            case BSeedType::sane:
+            case BSeedType::mad:
+            case BSeedType::mad_quadrupole:
+            case BSeedType::r3s3:
+            case BSeedType::r5s5:
+            case BSeedType::gaussian:
+                // Torus parameters
+                rin = pin->GetReal("torus", "rin");
+                rmax = pin->GetReal("torus", "rmax");
+                kappa = pin->GetReal("torus", "kappa");
+                tilt = pin->GetReal("torus", "tilt") / 180. * M_PI;
+                // Other things we need only for torus evaluation
+                gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
+                rho_norm = pmb->packages.Get("GRMHD")->Param<Real>("rho_norm");
+                a = G.coords.get_a();
+                break;
+            case BSeedType::orszag_tang_a:
+                A0 = pin->GetReal("orszag_tang", "tscale");
+                arg1 = pin->GetReal("orszag_tang", "phase");
+                break;
+            case BSeedType::r1s2:
+                gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
+                n = 1. / (gam - 1.);
+                rs = pin->GetOrAddReal("bondi", "rs", m::sqrt(1e5));
+                if (m::abs(n - 1.5) < 0.01)
+                    rb = rs * rs * 80. / (27. * gam);
+                else
+                    rb = (4 * (n + 1)) / (2 * (n + 3) - 9) * rs;
+                break;
+            default:
+                break;
         }
 
         // For all other fields...
         // Find the magnetic vector potential.  In X3 symmetry only A_phi is non-zero,
         // But for tilted conditions we must keep track of all components
-        // TODO(BSP) Make the vector potential a proper edge-centered field, sync it before B calc
+        // TODO(CEP) Make the vector potential a proper edge-centered field, sync it
+        // before B calc
         IndexRange3 be = KDomain::GetRange(rc, domain, E3);
         IndexSize3 sz = KDomain::GetBlockSize(rc);
-        ParArrayND<double> A("A", NVEC, sz.n3+1, sz.n2+1, sz.n1+1);
-        pmb->par_for(
-            "B_field_A", be.ks, be.ke, be.js, be.je, be.is, be.ie,
-            KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+        ParArrayND<double> A("A", NVEC, sz.n3 + 1, sz.n2 + 1, sz.n1 + 1);
+        pmb->par_for("B_field_A", be.ks, be.ke, be.js, be.je, be.is, be.ie,
+            KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 GReal Xnative[GR_DIM];
                 GReal Xembed[GR_DIM], Xmidplane[GR_DIM];
                 G.coord(k, j, i, Loci::corner, Xnative);
                 G.coord_embed(k, j, i, Loci::corner, Xembed);
-                // What are our corresponding "midplane" values for evaluating the function?
+                // What are our corresponding "midplane" values for evaluating the
+                // function?
                 rotate_polar(Xembed, tilt, Xmidplane);
                 const GReal r = Xmidplane[1], th = Xmidplane[2];
 
                 // In case we need zone sizes
                 const GReal dxc[GR_DIM] = {0., G.Dxc<1>(i), G.Dxc<2>(j), G.Dxc<3>(k)};
 
-                // This is written under the assumption re-computed rho is more accurate than a bunch
-                // of averaging in a meaningful way.  Just use the average if not.
+                // This is written under the assumption re-computed rho is more accurate
+                // than a bunch of averaging in a meaningful way.  Just use the average if
+                // not.
                 Real rho_av;
                 if (is_torus) {
                     // Find rho at corner directly for torii
                     rho_av = fm_torus_rho(a, rin, rmax, gam, kappa, r, th) / rho_norm;
                 } else {
                     // Use averages for anything else
-                    // Avoid overstepping array bounds (but allow overstepping domain bounds)
-                    const int ii = clip((uint)i, (uint)1, sz.n1-1);
-                    const int jj = clip((uint)j, (uint)1, sz.n2-1);
-                    const int kk = clip((uint)k, (uint)1, sz.n3-1);
-                    if (ndim > 2)
-                    {
+                    // Avoid overstepping array bounds (but allow overstepping domain
+                    // bounds)
+                    const int ii = clip((uint)i, (uint)1, sz.n1 - 1);
+                    const int jj = clip((uint)j, (uint)1, sz.n2 - 1);
+                    const int kk = clip((uint)k, (uint)1, sz.n3 - 1);
+                    if (ndim > 2) {
+                        rho_av =
+                            (rho(kk, jj, ii) + rho(kk, jj, ii - 1) + rho(kk, jj - 1, ii) +
+                                rho(kk, jj - 1, ii - 1) + rho(kk - 1, jj, ii) +
+                                rho(kk - 1, jj, ii - 1) + rho(kk - 1, jj - 1, ii) +
+                                rho(kk - 1, jj - 1, ii - 1)) /
+                            8;
+                    } else {
                         rho_av = (rho(kk, jj, ii) + rho(kk, jj, ii - 1) +
-                                rho(kk, jj - 1, ii) + rho(kk, jj - 1, ii - 1) +
-                                rho(kk - 1, jj, ii) + rho(kk - 1, jj, ii - 1) +
-                                rho(kk - 1, jj - 1, ii) + rho(kk - 1, jj - 1, ii - 1)) /
-                                8;
-                    }
-                    else
-                    {
-                        rho_av = (rho(kk, jj, ii) + rho(kk, jj, ii - 1) +
-                                rho(kk, jj - 1, ii) + rho(kk, jj - 1, ii - 1)) /
-                                4;
+                                     rho(kk, jj - 1, ii) + rho(kk, jj - 1, ii - 1)) /
+                                 4;
                     }
                 }
 
-                Real Aphi = seed_a<Seed>(Xmidplane, dxc, rho_av, rin, min_A, A0, arg1, rb);
+                Real Aphi =
+                    seed_a<Seed>(Xmidplane, dxc, rho_av, rin, min_A, A0, arg1, rb);
 
                 if (tilt != 0.0) {
                     // This is *covariant* A_mu of an untilted disk
                     const double A_untilt_lower[GR_DIM] = {0., 0., 0., Aphi};
-                    // Raise to contravariant vector, since rotate_polar_vec will need that.
-                    // Note we have to do this in the midplane!
-                    // The coord_to_native calculation involves an iterative solve for MKS/FMKS
-                    GReal Xnative_midplane[GR_DIM] = {0}, gcon_midplane[GR_DIM][GR_DIM] = {0};
+                    // Raise to contravariant vector, since rotate_polar_vec will need
+                    // that. Note we have to do this in the midplane! The coord_to_native
+                    // calculation involves an iterative solve for MKS/FMKS
+                    GReal Xnative_midplane[GR_DIM] = {0},
+                          gcon_midplane[GR_DIM][GR_DIM] = {0};
                     G.coords.coord_to_native(Xmidplane, Xnative_midplane);
                     G.coords.gcon_native(Xnative_midplane, gcon_midplane);
                     double A_untilt[GR_DIM] = {0};
-                    DLOOP2 A_untilt[mu] += gcon_midplane[mu][nu] * A_untilt_lower[nu];
+                    DLOOP2
+                        A_untilt[mu] += gcon_midplane[mu][nu] * A_untilt_lower[nu];
 
                     // Then rotate
                     double A_tilt[GR_DIM] = {0};
                     double A_untilt_embed[GR_DIM] = {0}, A_tilt_embed[GR_DIM] = {0};
                     G.coords.con_vec_to_embed(Xnative_midplane, A_untilt, A_untilt_embed);
-                    rotate_polar_vec(Xmidplane, A_untilt_embed, -tilt, Xembed, A_tilt_embed);
+                    rotate_polar_vec(
+                        Xmidplane, A_untilt_embed, -tilt, Xembed, A_tilt_embed);
                     G.coords.con_vec_to_native(Xnative, A_tilt_embed, A_tilt);
 
                     // Lower the result as we need curl(A_mu).  Done at local zone.
                     double A_tilt_lower[GR_DIM] = {0}, gcov[GR_DIM][GR_DIM] = {0};
                     G.coords.gcov_native(Xnative, gcov);
-                    DLOOP2 A_tilt_lower[mu] += gcov[mu][nu] * A_tilt[nu];
-                    VLOOP A(v, k, j, i) = A_tilt_lower[1 + v];
+                    DLOOP2
+                        A_tilt_lower[mu] += gcov[mu][nu] * A_tilt[nu];
+                    VLOOP
+                        A(v, k, j, i) = A_tilt_lower[1 + v];
                 } else {
-                    // Some problems rely on a very accurate A->B, which the rotation lacks.
-                    // So, we preserve exact values in the no-tilt case.
+                    // Some problems rely on a very accurate A->B, which the rotation
+                    // lacks. So, we preserve exact values in the no-tilt case.
                     A(V3, k, j, i) = Aphi;
                 }
-            }
-        );
+            });
 
         if (pkgs.count("B_CT")) {
             auto B_Uf = rc->PackVariables(std::vector<std::string>{"cons.fB"});
@@ -341,37 +337,35 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
             // we need this stencil-2 op over the whole domain
             IndexRange3 bB = KDomain::GetRange(rc, domain, 0, 1);
             if (ndim > 2) {
-                B_CT::EdgeCurl<F1,3>(rc, A, B_Uf, domain);
-                B_CT::EdgeCurl<F2,3>(rc, A, B_Uf, domain);
-                B_CT::EdgeCurl<F3,3>(rc, A, B_Uf, domain);
+                B_CT::EdgeCurl<F1, 3>(rc, A, B_Uf, domain);
+                B_CT::EdgeCurl<F2, 3>(rc, A, B_Uf, domain);
+                B_CT::EdgeCurl<F3, 3>(rc, A, B_Uf, domain);
             } else if (ndim > 1) {
-                B_CT::EdgeCurl<F1,2>(rc, A, B_Uf, domain);
-                B_CT::EdgeCurl<F2,2>(rc, A, B_Uf, domain);
-                B_CT::EdgeCurl<F3,2>(rc, A, B_Uf, domain);
+                B_CT::EdgeCurl<F1, 2>(rc, A, B_Uf, domain);
+                B_CT::EdgeCurl<F2, 2>(rc, A, B_Uf, domain);
+                B_CT::EdgeCurl<F3, 2>(rc, A, B_Uf, domain);
             } else {
                 throw std::runtime_error("Must initialize 1D field directly!");
             }
             B_CT::BlockUtoP(rc, domain);
-            //std::cout << "Block divB: " << B_CT::BlockMaxDivB(rc) << std::endl;
+            // std::cout << "Block divB: " << B_CT::BlockMaxDivB(rc) << std::endl;
         } else if (pkgs.count("B_FluxCT")) {
             // Calculate B-field.  Curl can be run all together since
             // all directions areover all cells
             GridVector B_U = rc->Get("cons.B").data;
             IndexRange3 bl = KDomain::GetRange(rc, domain);
             if (ndim > 2) {
-                pmb->par_for(
-                    "B_field_B_3D", bl.ks, bl.ke, bl.js, bl.je, bl.is, bl.ie,
-                    KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+                pmb->par_for("B_field_B_3D", bl.ks, bl.ke, bl.js, bl.je, bl.is, bl.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         B_FluxCT::averaged_curl_3D(G, A, B_U, k, j, i);
-                    }
-                );
+                    });
             } else if (ndim > 1) {
-                pmb->par_for(
-                    "B_field_B_2D", bl.ks, bl.ke, bl.js, bl.je, bl.is, bl.ie,
-                    KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+                pmb->par_for("B_field_B_2D", bl.ks, bl.ke, bl.js, bl.je, bl.is, bl.ie,
+                             KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         B_FluxCT::averaged_curl_2D(G, A, B_U, k, j, i);
-                    }
-                );
+                    });
             } else {
                 throw std::runtime_error("Must initialize 1D field directly!");
             }
@@ -379,21 +373,21 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
             if (prob == "resize_restart_kharma") {
                 GridVector B_Save = rc->Get("B_Save").data;
                 // Hyerin (12/19/22) copy over data after initialization
-                pmb->par_for(
-                    "B_field_B_3D", bl.ks, bl.ke, bl.js, bl.je, bl.is, bl.ie,
-                    KOKKOS_LAMBDA(const int &k, const int &j, const int &i) {
+                pmb->par_for("B_field_B_3D", bl.ks, bl.ke, bl.js, bl.je, bl.is, bl.ie,
+                    KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+                    {
                         GReal X[GR_DIM];
                         G.coord(k, j, i, Loci::center, X);
 
-                        if ((!should_fill) && (X[1] < fx1min_ghost)) {// if cannot be read from restart file
+                        if ((!should_fill) &&
+                            (X[1] <
+                                fx1min_ghost)) { // if cannot be read from restart file
                             // do nothing. just use the initialization from SeedBField
                         } else {
-                            VLOOP B_U(v, k, j, i) = B_Save(v, k, j, i);
+                            VLOOP
+                                B_U(v, k, j, i) = B_Save(v, k, j, i);
                         }
-
-                    }
-                );
-
+                    });
             }
             // Finally, make sure we initialize the primitive field too
             B_FluxCT::BlockUtoP(rc, domain);
@@ -403,7 +397,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
     }
 }
 
-TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
+TaskStatus SeedBField(MeshData<Real>* md, ParameterInput* pin)
 {
     Flag("SeedBField");
     std::string b_field_type = pin->GetString("b_field", "type");
@@ -415,8 +409,8 @@ TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
     }
 
     TaskStatus status = TaskStatus::incomplete;
-    for (int i=0; i < md->NumBlocks(); i++) {
-        auto *rc = md->GetBlockData(i).get();
+    for (int i = 0; i < md->NumBlocks(); i++) {
+        auto* rc = md->GetBlockData(i).get();
 
         // I could make this a map or something,
         // but this is the only place I decode it.
@@ -426,7 +420,8 @@ TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
             status = SeedBFieldType<BSeedType::constant>(rc, pin);
         } else if (b_field_type == "monopole") {
             status = SeedBFieldType<BSeedType::monopole>(rc, pin);
-        } else if (b_field_type == "monopole_cube") { // Legacy name for the correct monopole init
+        } else if (b_field_type ==
+                   "monopole_cube") { // Legacy name for the correct monopole init
             status = SeedBFieldType<BSeedType::monopole>(rc, pin);
         } else if (b_field_type == "sane") {
             status = SeedBFieldType<BSeedType::sane>(rc, pin);
@@ -455,7 +450,8 @@ TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
         } else if (b_field_type == "shock_tube") {
             status = SeedBFieldType<BSeedType::shock_tube>(rc, pin);
         } else {
-            throw std::invalid_argument("Magnetic field seed type not supported: " + b_field_type);
+            throw std::invalid_argument(
+                "Magnetic field seed type not supported: " + b_field_type);
         }
     }
 
@@ -463,7 +459,7 @@ TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
     return status;
 }
 
-TaskStatus NormalizeBField(MeshData<Real> *md, ParameterInput *pin)
+TaskStatus NormalizeBField(MeshData<Real>* md, ParameterInput* pin)
 {
     Flag("NormBField");
     // Check which solver we'll be using
@@ -488,7 +484,7 @@ TaskStatus NormalizeBField(MeshData<Real> *md, ParameterInput *pin)
     } else {
         beta_min = MPIReduce_once(MinBeta(md), MPI_MIN);
     }
-    Real norm = m::sqrt(beta_min/desired_beta_min);
+    Real norm = m::sqrt(beta_min / desired_beta_min);
 
     if (MPIRank0() && verbose > 0) {
         if (beta_calc_legacy) {
@@ -528,6 +524,6 @@ TaskStatus NormalizeBField(MeshData<Real> *md, ParameterInput *pin)
         }
     }
 
-    EndFlag(); //NormBField
+    EndFlag(); // NormBField
     return TaskStatus::complete;
 }

--- a/kharma/prob/seed_B.hpp
+++ b/kharma/prob/seed_B.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: seed_B.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,31 +36,53 @@
 #include "decs.hpp"
 #include "types.hpp"
 
-TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin);
+TaskStatus SeedBField(MeshData<Real>* md, ParameterInput* pin);
 
-TaskStatus NormalizeBField(MeshData<Real> *md, ParameterInput *pin);
+TaskStatus NormalizeBField(MeshData<Real>* md, ParameterInput* pin);
 
 /*
  * B field initializations.
  * TO ADD A FIELD:
  * 1. add its internal name to the enum below
- * 2. Implement the template specialization for your field, either from seed_a<> or seed_b<>
+ * 2. Implement the template specialization for your field, either from seed_a<> or
+ * seed_b<>
  * 3. Add your specialization to the `if` statements in SeedBField
- * 4. If you used seed_b<>, add your case where SeedBFieldType<> selects direct initialization
+ * 4. If you used seed_b<>, add your case where SeedBFieldType<> selects direct
+ * initialization
  * 5. If you added arguments, make sure the calls in SeedBFieldType<> are up-to-date
  */
 
 // Internal representation of the field initialization preference, used for templating
-enum BSeedType{constant, monopole, orszag_tang, orszag_tang_a, wave, shock_tube,
-                sane, mad, mad_quadrupole, r3s3, r5s5, gaussian, bz_monopole, vertical, r1s2};
+enum BSeedType {
+    constant,
+    monopole,
+    orszag_tang,
+    orszag_tang_a,
+    wave,
+    shock_tube,
+    sane,
+    mad,
+    mad_quadrupole,
+    r3s3,
+    r5s5,
+    gaussian,
+    bz_monopole,
+    vertical,
+    r1s2
+};
 
-#define SEEDA_ARGS GReal *x, const GReal *dxc, double rho, double rin, double min_A, double A0, double arg1, double rb
+#define SEEDA_ARGS                                                                       \
+    GReal *x, const GReal *dxc, double rho, double rin, double min_A, double A0,         \
+        double arg1, double rb
 
 // This will also act as the default implementation for unspecified types,
 // which should all be filled as B field by seed_b below.
 // So, we want to set it to something dramatic.
 template<BSeedType T>
-KOKKOS_INLINE_FUNCTION Real seed_a(SEEDA_ARGS) { return 0./0.;}
+KOKKOS_INLINE_FUNCTION Real seed_a(SEEDA_ARGS)
+{
+    return 0. / 0.;
+}
 
 // EHT comparison SANE
 template<>
@@ -80,16 +102,19 @@ KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::bz_monopole>(SEEDA_ARGS)
 template<>
 KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::mad>(SEEDA_ARGS)
 {
-    return m::max(m::pow(x[1] / rin, 3) * m::pow(sin(x[2]), 3) *
-            m::exp(-x[1] / 400) * rho - min_A, 0.);
+    return m::max(
+        m::pow(x[1] / rin, 3) * m::pow(sin(x[2]), 3) * m::exp(-x[1] / 400) * rho - min_A,
+        0.);
 }
 
 // MAD, but turned into a quadrupole
 template<>
 KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::mad_quadrupole>(SEEDA_ARGS)
 {
-    return m::max(pow(x[1] / rin, 3) * m::pow(sin(x[2]), 3) *
-            m::exp(-x[1] / 400) * rho - min_A, 0.) * m::cos(x[2]);
+    return m::max(pow(x[1] / rin, 3) * m::pow(sin(x[2]), 3) * m::exp(-x[1] / 400) * rho -
+                      min_A,
+               0.) *
+           m::cos(x[2]);
 }
 
 // Just the r^3 sin^3 th term
@@ -120,7 +145,7 @@ KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::gaussian>(SEEDA_ARGS)
 template<>
 KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::vertical>(SEEDA_ARGS)
 {
-    //return A0 * x[1] * m::sin(x[2]) / 2.;
+    // return A0 * x[1] * m::sin(x[2]) / 2.;
     return A0 * (x[1] * m::sin(x[2])) * (x[1] * m::sin(x[2])) / 2.;
 }
 
@@ -133,28 +158,33 @@ KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::r1s2>(SEEDA_ARGS)
 template<>
 KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::orszag_tang_a>(SEEDA_ARGS)
 {
-    return A0 * (-0.5 * std::cos(2*x[1] + arg1)
-                        + std::cos(x[2] + arg1));
+    return A0 * (-0.5 * std::cos(2 * x[1] + arg1) + std::cos(x[2] + arg1));
 }
 
 #undef SEEDA_ARGS
-#define SEEDB_ARGS GReal *x, GReal gdet, double k1, double k2, double k3, double phase, \
-                    double amp_B1, double amp_B2, double amp_B3, \
-                    double amp2_B1, double amp2_B2, double amp2_B3, \
-                    double &B1, double &B2, double &B3
+#define SEEDB_ARGS                                                                       \
+    GReal *x, GReal gdet, double k1, double k2, double k3, double phase, double amp_B1,  \
+        double amp_B2, double amp_B3, double amp2_B1, double amp2_B2, double amp2_B3,    \
+        double &B1, double &B2, double &B3
 
 template<BSeedType T>
-KOKKOS_INLINE_FUNCTION void seed_b(SEEDB_ARGS) { B1 = 0./0.; B2 = 0./0.; B3 = 0./0.; }
+KOKKOS_INLINE_FUNCTION void seed_b(SEEDB_ARGS)
+{
+    B1 = 0. / 0.;
+    B2 = 0. / 0.;
+    B3 = 0. / 0.;
+}
 
 // Constant field of B10, B20, B30 is always set
 template<>
-KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::constant>(SEEDB_ARGS) {}
+KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::constant>(SEEDB_ARGS)
+{}
 
 // Reduce radial component by the cube of radius
 template<>
 KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::monopole>(SEEDB_ARGS)
 {
-    B1 /= (x[1]*x[1]*x[1]);
+    B1 /= (x[1] * x[1] * x[1]);
 }
 
 // For mhdmodes or linear waves tests
@@ -182,8 +212,8 @@ KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::shock_tube>(SEEDB_ARGS)
 template<>
 KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::orszag_tang>(SEEDB_ARGS)
 {
-    B1 -= amp_B1 * m::sin(    x[2] + phase );
-    B2 += amp_B2 * m::sin(2.*(x[1] + phase));
+    B1 -= amp_B1 * m::sin(x[2] + phase);
+    B2 += amp_B2 * m::sin(2. * (x[1] + phase));
 }
 
 #undef SEEDB_ARGS

--- a/kharma/prob/shock_tube.hpp
+++ b/kharma/prob/shock_tube.hpp
@@ -7,10 +7,11 @@ using namespace parthenon;
 /**
  * Generic initializer for shock tubes
  * Particular problems in pars/shocks/
- * 
+ *
  * Stolen directly from iharm3D
  */
-TaskStatus InitializeShockTube(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus InitializeShockTube(
+    std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     GridScalar rho = rc->Get("prims.rho").data;
@@ -58,18 +59,18 @@ TaskStatus InitializeShockTube(std::shared_ptr<MeshBlockData<Real>>& rc, Paramet
     pin->GetOrAddReal("b_field", "amp2_B3", B3R);
 
     pmb->par_for("ot_init", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord(k, j, i, Loci::center, X);
 
             const bool lhs = X[1] < center;
             rho(k, j, i) = (lhs) ? rhoL : rhoR;
-            u(k, j, i)   = ((lhs) ? PL : PR) / (gam - 1.);
+            u(k, j, i) = ((lhs) ? PL : PR) / (gam - 1.);
             uvec(0, k, j, i) = (lhs) ? u1L : u1R;
             uvec(1, k, j, i) = (lhs) ? u2L : u2R;
             uvec(2, k, j, i) = (lhs) ? u3L : u3R;
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/prob/utils/blob.hpp
+++ b/kharma/prob/utils/blob.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: blob.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,10 +46,10 @@
  * Insert a blob of material at a given temperature,
  * by scaling the density by a factor, then setting the temperature
  * constant.
- * 
+ *
  * TODO MeshData
  */
-void InsertBlob(MeshBlockData<Real> *rc, ParameterInput *pin)
+void InsertBlob(MeshBlockData<Real>* rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     PackIndexMap prims_map;
@@ -68,7 +68,7 @@ void InsertBlob(MeshBlockData<Real> *rc, ParameterInput *pin)
     GReal sz_out = pin->GetOrAddReal("blob", "sz_out", 5.0);
     // Blob center
     GReal blob_r = pin->GetOrAddReal("blob", "r", 15.0);
-    GReal blob_th = pin->GetOrAddReal("blob", "th", M_PI/8);
+    GReal blob_th = pin->GetOrAddReal("blob", "th", M_PI / 8);
     GReal blob_phi = pin->GetOrAddReal("blob", "phi", 0.0);
 
     IndexDomain domain = IndexDomain::interior;
@@ -76,12 +76,15 @@ void InsertBlob(MeshBlockData<Real> *rc, ParameterInput *pin)
     IndexRange jb = pmb->cellbounds.GetBoundsJ(domain);
     IndexRange kb = pmb->cellbounds.GetBoundsK(domain);
     pmb->par_for("insert_blob", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                 KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+        {
             Real X[GR_DIM];
             G.coord_embed(k, j, i, Loci::center, X);
-            Real d = m::sqrt(blob_r*blob_r + X[1]*X[1] - 2*blob_r*X[1]*
-                            (sin(blob_th) * sin(X[2]) * cos(blob_phi - X[3]) + cos(blob_th) * cos(X[2])));
-            
+            Real d = m::sqrt(blob_r * blob_r + X[1] * X[1] -
+                             2 * blob_r * X[1] *
+                                 (sin(blob_th) * sin(X[2]) * cos(blob_phi - X[3]) +
+                                     cos(blob_th) * cos(X[2])));
+
             if (d <= sz_out) {
                 FourVectors Dtmp;
                 GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
@@ -101,6 +104,5 @@ void InsertBlob(MeshBlockData<Real> *rc, ParameterInput *pin)
                     P(m_p.UU, k, j, i) = u_over_rho * P(m_p.RHO, k, j, i);
                 }
             }
-        }
-    );
+        });
 }

--- a/kharma/prob/utils/hdf5_utils.cpp
+++ b/kharma/prob/utils/hdf5_utils.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: hdf5_utils.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,9 +37,9 @@
 
 #include "hdf5_utils.h"
 
+#include <hdf5.h>
 #include <stdlib.h>
 #include <string.h>
-#include <hdf5.h>
 
 // KHARMA uses unset/set, but this file used 0/1. Convert.
 #ifndef DEBUG
@@ -55,7 +55,12 @@
 #endif
 
 #if FAIL_HARD
-#define FAIL(errcode, fn_name, val_name) { fprintf(stderr, "HDF5 Error code %d in %s processing %s\n", (int) errcode, fn_name, val_name); exit(-1); }
+#define FAIL(errcode, fn_name, val_name)                                                 \
+    {                                                                                    \
+        fprintf(stderr, "HDF5 Error code %d in %s processing %s\n", (int)errcode,        \
+            fn_name, val_name);                                                          \
+        exit(-1);                                                                        \
+    }
 #else
 #define FAIL(errcode, fn_name, val_name) return errcode;
 #endif
@@ -71,373 +76,373 @@ hid_t file_id;
 // Create a new HDF5 file in memory and group specified by name to
 // the root of the new HDF5 file and return pointer to blob.
 // Returns NULL on failure.
-hdf5_blob hdf5_get_blob(const char *name)
+hdf5_blob hdf5_get_blob(const char* name)
 {
-  herr_t status;
+    herr_t status;
 
-  // Open HDF5 file in memory by using CORE file driver
-  hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
-  status = H5Pset_fapl_core(plist_id, (size_t)1024, (hbool_t)0);
-  if ( status < 0 ) {
+    // Open HDF5 file in memory by using CORE file driver
+    hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
+    status = H5Pset_fapl_core(plist_id, (size_t)1024, (hbool_t)0);
+    if (status < 0) {
+        H5Pclose(plist_id);
+        FAIL(status, "hdf5_get_blob", name);
+    }
+
+    hid_t file_image_id = H5Fcreate("blob", H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
     H5Pclose(plist_id);
-    FAIL(status, "hdf5_get_blob", name);
-  }
+    if (file_image_id < 0) FAIL(file_image_id, "hdf5_get_blob", name);
 
-  hid_t file_image_id = H5Fcreate("blob", H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
-  H5Pclose(plist_id);
-  if ( file_image_id < 0 ) FAIL(file_image_id, "hdf5_get_blob", name);
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    // Copy according to default settings (don't assume nice behavior with links)
+    status = H5Ocopy(file_id, path, file_image_id, "blob", H5P_DEFAULT, H5P_DEFAULT);
+    if (status < 0) FAIL(status, "hdf5_get_blob", name);
 
-  // Copy according to default settings (don't assume nice behavior with links)
-  status = H5Ocopy(file_id, path, file_image_id, "blob", H5P_DEFAULT, H5P_DEFAULT);
-  if ( status < 0 ) FAIL(status, "hdf5_get_blob", name);
-
-  return file_image_id;
+    return file_image_id;
 }
 
 // Write the passed HDF5 blob wrapper to the opened HDF5 file under
 // the group with passed name.
 // Returns 0 on success.
-int hdf5_write_blob(hdf5_blob blob, const char *name)
+int hdf5_write_blob(hdf5_blob blob, const char* name)
 {
-  if ( blob < 0 ) return blob;
+    if (blob < 0) return blob;
 
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  herr_t status = H5Ocopy(blob, "blob", file_id, path, H5P_DEFAULT, H5P_DEFAULT);
+    herr_t status = H5Ocopy(blob, "blob", file_id, path, H5P_DEFAULT, H5P_DEFAULT);
 
-  if(status < 0) FAIL(status, "hdf5_write_blob", name);
-  return 0;
+    if (status < 0) FAIL(status, "hdf5_write_blob", name);
+    return 0;
 }
 
 // Closes the HDF5 blob wrapper passed as argument
 // Returns 0 on success.
 int hdf5_close_blob(hdf5_blob blob)
 {
-  herr_t status = H5Fclose(blob);
-  if (status < 0) FAIL(status, "hdf5_close_blob", "none");
-  return 0;
+    herr_t status = H5Fclose(blob);
+    if (status < 0) FAIL(status, "hdf5_close_blob", "none");
+    return 0;
 }
 
 // Create a new HDF file (or overwrite whatever file exists)
-int hdf5_create(const char *fname)
+int hdf5_create(const char* fname)
 {
-  hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
+    hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
 #if USE_MPI
-  H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL); // TODO tune HDF with an MPI info object
+    H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD,
+        MPI_INFO_NULL); // TODO tune HDF with an MPI info object
 #endif
-  file_id = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
-  H5Pclose(plist_id);
+    file_id = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
+    H5Pclose(plist_id);
 
-  // Everyone expects directory to be root after opening a file
-  hdf5_set_directory("/");
+    // Everyone expects directory to be root after opening a file
+    hdf5_set_directory("/");
 
-  // Quiet HDF5's own errors, so we can control them
-  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    // Quiet HDF5's own errors, so we can control them
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-  if(file_id < 0) FAIL(file_id, "hdf5_create", fname);
-  return 0;
+    if (file_id < 0) FAIL(file_id, "hdf5_create", fname);
+    return 0;
 }
 
 // Open an existing file for reading
-int hdf5_open(const char *fname)
+int hdf5_open(const char* fname)
 {
-  hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
+    hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
 #if USE_MPI
-  H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
+    H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
 #endif
-  file_id = H5Fopen(fname, H5F_ACC_RDONLY, plist_id);
-  H5Pclose(plist_id);
+    file_id = H5Fopen(fname, H5F_ACC_RDONLY, plist_id);
+    H5Pclose(plist_id);
 
-  // Everyone expects directory to be root after open
-  hdf5_set_directory("/");
+    // Everyone expects directory to be root after open
+    hdf5_set_directory("/");
 
-  // Quiet HDF5's own errors, so we can control them
-  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    // Quiet HDF5's own errors, so we can control them
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-  if(file_id < 0) FAIL(file_id, "hdf5_open", fname);
-  return 0;
+    if (file_id < 0) FAIL(file_id, "hdf5_open", fname);
+    return 0;
 }
 
 // Close a file
 int hdf5_close()
 {
-  H5Fflush(file_id,H5F_SCOPE_GLOBAL);
-  herr_t err = H5Fclose(file_id);
+    H5Fflush(file_id, H5F_SCOPE_GLOBAL);
+    herr_t err = H5Fclose(file_id);
 
-  if(err < 0) FAIL(err, "hdf5_close", "none");
-  return 0;
+    if (err < 0) FAIL(err, "hdf5_close", "none");
+    return 0;
 }
 
 // Make a directory (in the current directory) with given name
 // This doesn't take a full path, just a name
-int hdf5_make_directory(const char *name)
+int hdf5_make_directory(const char* name)
 {
-  // Add current directory to group name
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    // Add current directory to group name
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  if(DEBUG) fprintf(stderr,"Adding dir %s\n", path);
+    if (DEBUG) fprintf(stderr, "Adding dir %s\n", path);
 
-  hid_t group_id = H5Gcreate2(file_id, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  if (group_id < 0) FAIL(group_id, "hdf5_make_directory", path);
-  H5Gclose(group_id);
+    hid_t group_id = H5Gcreate2(file_id, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (group_id < 0) FAIL(group_id, "hdf5_make_directory", path);
+    H5Gclose(group_id);
 
-  return 0;
+    return 0;
 }
 
 // Set the current directory
-void hdf5_set_directory(const char *path)
-{
-  strncpy(hdf5_cur_dir, path, STRLEN);
-}
+void hdf5_set_directory(const char* path) { strncpy(hdf5_cur_dir, path, STRLEN); }
 
 // Check if an object's name exists: returns 1 if it does
 // Doesn't verify if the object itself exists, or anything about it!
-int hdf5_exists(const char *name) {
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+int hdf5_exists(const char* name)
+{
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  hid_t link_plist = H5Pcreate(H5P_LINK_ACCESS);
-  herr_t exists = H5Lexists(file_id, path, link_plist);
-  H5Pclose(link_plist);
+    hid_t link_plist = H5Pcreate(H5P_LINK_ACCESS);
+    herr_t exists = H5Lexists(file_id, path, link_plist);
+    H5Pclose(link_plist);
 
-  if(DEBUG) fprintf(stderr,"Checking existence of %s: %d\n", path, exists);
+    if (DEBUG) fprintf(stderr, "Checking existence of %s: %d\n", path, exists);
 
-  return exists > 0;
+    return exists > 0;
 }
 
 // Return a fixed-size string type
 // H5T_VARIABLE indicates any string but isn't compatible w/parallel IO
 hid_t hdf5_make_str_type(size_t len)
 {
-  hid_t string_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(string_type, len);
-  return string_type;
+    hid_t string_type = H5Tcopy(H5T_C_S1);
+    H5Tset_size(string_type, len);
+    return string_type;
 }
 
 // Add the named attribute to the named variable
-int hdf5_add_attr(const void *att, const char *att_name, const char *data_name, hsize_t hdf5_type)
+int hdf5_add_attr(
+    const void* att, const char* att_name, const char* data_name, hsize_t hdf5_type)
 {
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, data_name, STRLEN - strlen(path));
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, data_name, STRLEN - strlen(path));
 
-  if(DEBUG) fprintf(stderr,"Adding att %s\n", path);
+    if (DEBUG) fprintf(stderr, "Adding att %s\n", path);
 
-  hid_t attribute_id = H5Acreate_by_name(file_id, path, att_name, hdf5_type, H5Screate(H5S_SCALAR), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  if (attribute_id < 0) FAIL(attribute_id, "hdf5_add_attr", path);
-  H5Awrite(attribute_id, hdf5_type, att);
-  H5Aclose(attribute_id);
+    hid_t attribute_id = H5Acreate_by_name(file_id, path, att_name, hdf5_type,
+        H5Screate(H5S_SCALAR), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (attribute_id < 0) FAIL(attribute_id, "hdf5_add_attr", path);
+    H5Awrite(attribute_id, hdf5_type, att);
+    H5Aclose(attribute_id);
 
-  return 0;
+    return 0;
 }
 
 // Add an attribute named "units"
-int hdf5_add_units(const char *name, const char *unit)
+int hdf5_add_units(const char* name, const char* unit)
 {
-  hid_t string_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(string_type, strlen(unit)+1);
-  herr_t err = hdf5_add_attr(unit, "units", name, string_type);
-  if (err < 0) FAIL(err, "hdf5_add_units", name);
-  H5Tclose(string_type);
-  return 0;
+    hid_t string_type = H5Tcopy(H5T_C_S1);
+    H5Tset_size(string_type, strlen(unit) + 1);
+    herr_t err = hdf5_add_attr(unit, "units", name, string_type);
+    if (err < 0) FAIL(err, "hdf5_add_units", name);
+    H5Tclose(string_type);
+    return 0;
 }
 
 // Write a 1D list of strings (used for labeling primitives array)
 // Must be an array of constant-length strings, i.e. char strs[len][str_len] = etc.
-int hdf5_write_str_list(const void *data, const char *name, size_t str_len, size_t len)
+int hdf5_write_str_list(const void* data, const char* name, size_t str_len, size_t len)
 {
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  if(DEBUG) fprintf(stderr,"Adding str list %s\n", path);
+    if (DEBUG) fprintf(stderr, "Adding str list %s\n", path);
 
-  // Adapted (stolen) from https://support.hdfgroup.org/ftp/HDF5/examples/C/
-  hsize_t dims_of_char_dataspace[] = {len};
+    // Adapted (stolen) from https://support.hdfgroup.org/ftp/HDF5/examples/C/
+    hsize_t dims_of_char_dataspace[] = {len};
 
-  hid_t vlstr_h5t = H5Tcopy(H5T_C_S1);
-  H5Tset_size(vlstr_h5t, str_len);
+    hid_t vlstr_h5t = H5Tcopy(H5T_C_S1);
+    H5Tset_size(vlstr_h5t, str_len);
 
-  hid_t dataspace = H5Screate_simple(1, dims_of_char_dataspace, NULL);
-  hid_t dataset = H5Dcreate(file_id, path, vlstr_h5t, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  herr_t err = H5Dwrite(dataset, vlstr_h5t, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
-  if (err < 0) FAIL(err, "hdf5_write_str_list", path); // If anything above fails, the write should too
+    hid_t dataspace = H5Screate_simple(1, dims_of_char_dataspace, NULL);
+    hid_t dataset = H5Dcreate(
+        file_id, path, vlstr_h5t, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    herr_t err = H5Dwrite(dataset, vlstr_h5t, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+    if (err < 0)
+        FAIL(err, "hdf5_write_str_list",
+            path); // If anything above fails, the write should too
 
-  H5Dclose(dataset);
-  H5Sclose(dataspace);
-  H5Tclose(vlstr_h5t);
+    H5Dclose(dataset);
+    H5Sclose(dataspace);
+    H5Tclose(vlstr_h5t);
 
-  return 0;
+    return 0;
 }
 
-// Write the section 'mdims_copy' starting at 'mstart' of a C-order array of rank 'rank' and size 'mdims_full'
-// To the section 'fdims' at 'fstart' of the file 'file_id'
-int hdf5_write_array(const void *data, const char *name, size_t rank,
-                      hsize_t *fdims, hsize_t *fstart, hsize_t *fcount, hsize_t *mdims, hsize_t *mstart, hsize_t hdf5_type)
+// Write the section 'mdims_copy' starting at 'mstart' of a C-order array of rank 'rank'
+// and size 'mdims_full' To the section 'fdims' at 'fstart' of the file 'file_id'
+int hdf5_write_array(const void* data, const char* name, size_t rank, hsize_t* fdims,
+    hsize_t* fstart, hsize_t* fcount, hsize_t* mdims, hsize_t* mstart, hsize_t hdf5_type)
 {
-  // Declare spaces of the right size
-  hid_t filespace = H5Screate_simple(rank, fdims, NULL);
-  H5Sselect_hyperslab(filespace, H5S_SELECT_SET, fstart, NULL, fcount,
-    NULL);
-  hid_t memspace = H5Screate_simple(rank, mdims, NULL);
-  H5Sselect_hyperslab(memspace, H5S_SELECT_SET, mstart, NULL, fcount,
-    NULL);
+    // Declare spaces of the right size
+    hid_t filespace = H5Screate_simple(rank, fdims, NULL);
+    H5Sselect_hyperslab(filespace, H5S_SELECT_SET, fstart, NULL, fcount, NULL);
+    hid_t memspace = H5Screate_simple(rank, mdims, NULL);
+    H5Sselect_hyperslab(memspace, H5S_SELECT_SET, mstart, NULL, fcount, NULL);
 
-  // Add our current path to the dataset name
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    // Add our current path to the dataset name
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  if(DEBUG) fprintf(stderr,"Adding array %s\n", path);
+    if (DEBUG) fprintf(stderr, "Adding array %s\n", path);
 
-  // Create the dataset in the file
-  hid_t plist_id = H5Pcreate(H5P_DATASET_CREATE);
-  hid_t dset_id = H5Dcreate(file_id, path, hdf5_type, filespace, H5P_DEFAULT,
-    plist_id, H5P_DEFAULT);
-  H5Pclose(plist_id);
+    // Create the dataset in the file
+    hid_t plist_id = H5Pcreate(H5P_DATASET_CREATE);
+    hid_t dset_id = H5Dcreate(
+        file_id, path, hdf5_type, filespace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+    H5Pclose(plist_id);
 
-  // Conduct the transfer
-  plist_id = H5Pcreate(H5P_DATASET_XFER);
+    // Conduct the transfer
+    plist_id = H5Pcreate(H5P_DATASET_XFER);
 #if USE_MPI
-  H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
 #endif
-  herr_t err = H5Dwrite(dset_id, hdf5_type, memspace, filespace, plist_id, data);
-  if (err < 0) FAIL(err, "hdf5_write_array", path);
+    herr_t err = H5Dwrite(dset_id, hdf5_type, memspace, filespace, plist_id, data);
+    if (err < 0) FAIL(err, "hdf5_write_array", path);
 
-  H5Dclose(dset_id);
-  H5Pclose(plist_id);
-  H5Sclose(filespace);
-  H5Sclose(memspace);
+    H5Dclose(dset_id);
+    H5Pclose(plist_id);
+    H5Sclose(filespace);
+    H5Sclose(memspace);
 
-  return 0;
+    return 0;
 }
 
 // Write a single value of hdf5_type to a file
-int hdf5_write_single_val(const void *val, const char *name, hsize_t hdf5_type)
+int hdf5_write_single_val(const void* val, const char* name, hsize_t hdf5_type)
 {
-  // Add current path to the dataset name
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    // Add current path to the dataset name
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  if(DEBUG) fprintf(stderr,"Adding val %s\n", path);
+    if (DEBUG) fprintf(stderr, "Adding val %s\n", path);
 
-  // Declare scalar spaces
-  hid_t scalarspace = H5Screate(H5S_SCALAR);
-  hid_t plist_id = H5Pcreate(H5P_DATASET_CREATE);
-  hid_t dset_id = H5Dcreate(file_id, path, hdf5_type, scalarspace, H5P_DEFAULT,
-    plist_id, H5P_DEFAULT);
-  H5Pclose(plist_id);
+    // Declare scalar spaces
+    hid_t scalarspace = H5Screate(H5S_SCALAR);
+    hid_t plist_id = H5Pcreate(H5P_DATASET_CREATE);
+    hid_t dset_id = H5Dcreate(
+        file_id, path, hdf5_type, scalarspace, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+    H5Pclose(plist_id);
 
-  // Conduct transfer
-  plist_id = H5Pcreate(H5P_DATASET_XFER);
+    // Conduct transfer
+    plist_id = H5Pcreate(H5P_DATASET_XFER);
 #if USE_MPI
-  H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
 #endif
-  herr_t err = H5Dwrite(dset_id, hdf5_type, scalarspace, scalarspace, plist_id, val);
-  if (err < 0) FAIL(err, "hdf5_write_single_val", path);
+    herr_t err = H5Dwrite(dset_id, hdf5_type, scalarspace, scalarspace, plist_id, val);
+    if (err < 0) FAIL(err, "hdf5_write_single_val", path);
 
-  // Close spaces (TODO could definitely keep these open instead of re-declaring)
-  H5Dclose(dset_id);
-  H5Pclose(plist_id);
-  H5Sclose(scalarspace);
+    // Close spaces (TODO could definitely keep these open instead of re-declaring)
+    H5Dclose(dset_id);
+    H5Pclose(plist_id);
+    H5Sclose(scalarspace);
 
-  return 0;
+    return 0;
 }
 
 // These are very like above but there's not a good way to share code...
-int hdf5_read_single_val(void *val, const char *name, hsize_t hdf5_type)
+int hdf5_read_single_val(void* val, const char* name, hsize_t hdf5_type)
 {
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  if(DEBUG) fprintf(stderr,"Reading val %s\n", path);
+    if (DEBUG) fprintf(stderr, "Reading val %s\n", path);
 
-  hid_t scalarspace = H5Screate(H5S_SCALAR);
-  hid_t dset_id = H5Dopen(file_id, path, H5P_DEFAULT);
+    hid_t scalarspace = H5Screate(H5S_SCALAR);
+    hid_t dset_id = H5Dopen(file_id, path, H5P_DEFAULT);
 
-  hid_t plist_id = H5Pcreate(H5P_DATASET_XFER);
+    hid_t plist_id = H5Pcreate(H5P_DATASET_XFER);
 #if USE_MPI
-  H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
 #endif
-  herr_t err = H5Dread(dset_id, hdf5_type, scalarspace, scalarspace, plist_id, val);
-  if (err < 0) FAIL(err, "hdf5_read_single_val", path);
+    herr_t err = H5Dread(dset_id, hdf5_type, scalarspace, scalarspace, plist_id, val);
+    if (err < 0) FAIL(err, "hdf5_read_single_val", path);
 
-  H5Dclose(dset_id);
-  H5Pclose(plist_id);
-  H5Sclose(scalarspace);
+    H5Dclose(dset_id);
+    H5Pclose(plist_id);
+    H5Sclose(scalarspace);
 
-  return 0;
+    return 0;
 }
 
-int hdf5_read_array(void *data, const char *name, size_t rank,
-                      hsize_t *fdims, hsize_t *fstart, hsize_t *fcount, hsize_t *mdims, hsize_t *mstart, hsize_t hdf5_type)
+int hdf5_read_array(void* data, const char* name, size_t rank, hsize_t* fdims,
+    hsize_t* fstart, hsize_t* fcount, hsize_t* mdims, hsize_t* mstart, hsize_t hdf5_type)
 {
-  //hid_t filespace = H5Screate_simple(4, fdims, NULL);
-  hid_t filespace = H5Screate_simple(rank, fdims, NULL); // edited by Hyerin
-  H5Sselect_hyperslab(filespace, H5S_SELECT_SET, fstart, NULL, fcount,
-    NULL);
-  hid_t memspace = H5Screate_simple(rank, mdims, NULL);
-  H5Sselect_hyperslab(memspace, H5S_SELECT_SET, mstart, NULL, fcount,
-    NULL);
+    // hid_t filespace = H5Screate_simple(4, fdims, NULL);
+    hid_t filespace = H5Screate_simple(rank, fdims, NULL); // edited by Hyerin
+    H5Sselect_hyperslab(filespace, H5S_SELECT_SET, fstart, NULL, fcount, NULL);
+    hid_t memspace = H5Screate_simple(rank, mdims, NULL);
+    H5Sselect_hyperslab(memspace, H5S_SELECT_SET, mstart, NULL, fcount, NULL);
 
-  char path[STRLEN];
-  strncpy(path, hdf5_cur_dir, STRLEN);
-  strncat(path, name, STRLEN - strlen(path));
+    char path[STRLEN];
+    strncpy(path, hdf5_cur_dir, STRLEN);
+    strncat(path, name, STRLEN - strlen(path));
 
-  if(DEBUG) {
-    fprintf(stderr,"Reading arr %s:\n", path);
-    // Prevent compiler complaining when hsize_t changes on different platforms
-    fprintf(stderr,"Total file size: %llu %llu %llu %llu\n",
-        static_cast<unsigned long long>(fdims[0]),
-        static_cast<unsigned long long>(fdims[1]),
-        static_cast<unsigned long long>(fdims[2]),
-        static_cast<unsigned long long>(fdims[3]));
-    fprintf(stderr,"File start: %llu %llu %llu %llu\n", 
-        static_cast<unsigned long long>(fstart[0]),
-        static_cast<unsigned long long>(fstart[1]),
-        static_cast<unsigned long long>(fstart[2]),
-        static_cast<unsigned long long>(fstart[3]));
-    fprintf(stderr,"File read size: %llu %llu %llu %llu\n",
-        static_cast<unsigned long long>(fcount[0]),
-        static_cast<unsigned long long>(fcount[1]),
-        static_cast<unsigned long long>(fcount[2]),
-        static_cast<unsigned long long>(fcount[3]));
-    fprintf(stderr,"Total memory size: %llu %llu %llu %llu\n",
-        static_cast<unsigned long long>(mdims[0]),
-        static_cast<unsigned long long>(mdims[1]),
-        static_cast<unsigned long long>(mdims[2]),
-        static_cast<unsigned long long>(mdims[3]));
-    fprintf(stderr,"Memory start: %llu %llu %llu %llu\n\n",
-        static_cast<unsigned long long>(mstart[0]),
-        static_cast<unsigned long long>(mstart[1]),
-        static_cast<unsigned long long>(mstart[2]),
-        static_cast<unsigned long long>(mstart[3]));
-  }
+    if (DEBUG) {
+        fprintf(stderr, "Reading arr %s:\n", path);
+        // Prevent compiler complaining when hsize_t changes on different platforms
+        fprintf(stderr, "Total file size: %llu %llu %llu %llu\n",
+            static_cast<unsigned long long>(fdims[0]),
+            static_cast<unsigned long long>(fdims[1]),
+            static_cast<unsigned long long>(fdims[2]),
+            static_cast<unsigned long long>(fdims[3]));
+        fprintf(stderr, "File start: %llu %llu %llu %llu\n",
+            static_cast<unsigned long long>(fstart[0]),
+            static_cast<unsigned long long>(fstart[1]),
+            static_cast<unsigned long long>(fstart[2]),
+            static_cast<unsigned long long>(fstart[3]));
+        fprintf(stderr, "File read size: %llu %llu %llu %llu\n",
+            static_cast<unsigned long long>(fcount[0]),
+            static_cast<unsigned long long>(fcount[1]),
+            static_cast<unsigned long long>(fcount[2]),
+            static_cast<unsigned long long>(fcount[3]));
+        fprintf(stderr, "Total memory size: %llu %llu %llu %llu\n",
+            static_cast<unsigned long long>(mdims[0]),
+            static_cast<unsigned long long>(mdims[1]),
+            static_cast<unsigned long long>(mdims[2]),
+            static_cast<unsigned long long>(mdims[3]));
+        fprintf(stderr, "Memory start: %llu %llu %llu %llu\n\n",
+            static_cast<unsigned long long>(mstart[0]),
+            static_cast<unsigned long long>(mstart[1]),
+            static_cast<unsigned long long>(mstart[2]),
+            static_cast<unsigned long long>(mstart[3]));
+    }
 
-  hid_t dset_id = H5Dopen(file_id, path, H5P_DEFAULT);
+    hid_t dset_id = H5Dopen(file_id, path, H5P_DEFAULT);
 
-  hid_t plist_id = H5Pcreate(H5P_DATASET_XFER);
+    hid_t plist_id = H5Pcreate(H5P_DATASET_XFER);
 #if USE_MPI
-  H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
 #endif
-  herr_t err = H5Dread(dset_id, hdf5_type, memspace, filespace, plist_id, data);
-  if (err < 0) FAIL(err, "hdf5_read_array", path);
+    herr_t err = H5Dread(dset_id, hdf5_type, memspace, filespace, plist_id, data);
+    if (err < 0) FAIL(err, "hdf5_read_array", path);
 
-  H5Dclose(dset_id);
-  H5Pclose(plist_id);
-  H5Sclose(filespace);
-  H5Sclose(memspace);
+    H5Dclose(dset_id);
+    H5Pclose(plist_id);
+    H5Sclose(filespace);
+    H5Sclose(memspace);
 
-  return 0;
+    return 0;
 }

--- a/kharma/prob/utils/interpolation.hpp
+++ b/kharma/prob/utils/interpolation.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: interpolation.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,31 +39,30 @@
  * Routines for interpolating on a grid, using values given in a flattened array.
  * Mostly used in resize_restart.cpp, which must interpolate from old simulation
  * data.
- * 
+ *
  * Note that resizing or resampling of magnetic fields usually requires
  * fixing a resulting divergence -- see b_cleanup/ for details.
  */
-namespace Interpolation {
+namespace Interpolation
+{
 
 /**
  * Finds the closest grid zone index (i,j,k) with a center left of the given point.
  * Additionally returns the point's proportional distance measured from the left
- * zone center to the right (e.g., to (i+1, j, k) in X1) 
- * 
+ * zone center to the right (e.g., to (i+1, j, k) in X1)
+ *
  * This proportion is useful in interpolation, since linear interpolation corresponds to
  * del*var[i+1] + (1. - del)*var[i]
  */
-KOKKOS_INLINE_FUNCTION void Xtoijk(const GReal X[GR_DIM],
-                                   const GReal startx[GR_DIM],
-                                   const GReal dx[GR_DIM],
-                                   int& i, int& j, int& k, GReal del[GR_DIM])
+KOKKOS_INLINE_FUNCTION void Xtoijk(const GReal X[GR_DIM], const GReal startx[GR_DIM],
+    const GReal dx[GR_DIM], int& i, int& j, int& k, GReal del[GR_DIM])
 {
     // Normal operation
     // get provisional zone index. see note above function for details. note we
     // shift to zone centers because that's where variables are most exact.
-    i = (int) ((X[1] - startx[1]) / dx[1] - 0.5 + 1000) - 1000;
-    j = (int) ((X[2] - startx[2]) / dx[2] - 0.5 + 1000) - 1000;
-    k = (int) ((X[3] - startx[3]) / dx[3] - 0.5 + 1000) - 1000;
+    i = (int)((X[1] - startx[1]) / dx[1] - 0.5 + 1000) - 1000;
+    j = (int)((X[2] - startx[2]) / dx[2] - 0.5 + 1000) - 1000;
+    k = (int)((X[3] - startx[3]) / dx[3] - 0.5 + 1000) - 1000;
 
     // Distance from closest zone center on the left
     // i.e., portion of left zone to use vs right when interpolating
@@ -77,45 +76,41 @@ KOKKOS_INLINE_FUNCTION void Xtoijk(const GReal X[GR_DIM],
  * Note this is different from the above!
  */
 KOKKOS_INLINE_FUNCTION void Xtoijk_nearest(const GReal X[GR_DIM],
-                                   const GReal startx[GR_DIM],
-                                   const GReal dx[GR_DIM],
-                                   int& i, int& j, int& k)
+    const GReal startx[GR_DIM], const GReal dx[GR_DIM], int& i, int& j, int& k)
 {
     // Get the index of the zone this point falls into.
     // i.e., are we >= the left corner?
-    i = (int) ((X[1] - startx[1]) / dx[1] + 1000) - 1000;
-    j = (int) ((X[2] - startx[2]) / dx[2] + 1000) - 1000;
-    k = (int) ((X[3] - startx[3]) / dx[3] + 1000) - 1000;
+    i = (int)((X[1] - startx[1]) / dx[1] + 1000) - 1000;
+    j = (int)((X[2] - startx[2]) / dx[2] + 1000) - 1000;
+    k = (int)((X[3] - startx[3]) / dx[3] + 1000) - 1000;
 }
 
 // For using the ipole routines in a recognizable form on a 1D array
-#define ind(i, j, k) ( (k) * n2 * n1 + (j) * n1 + (i))
+#define ind(i, j, k) ((k) * n2 * n1 + (j) * n1 + (i))
 
 /**
  * Dumb linear interpolation: no special cases for boundaries.
  * Takes indices i,j,k and a block size n1, n2, n3,
  * as well as a flat array var.
- * 
+ *
  * TODO version(s) with View(s) for real device-side operation
  */
 KOKKOS_INLINE_FUNCTION Real linear(const int& i, const int& j, const int& k,
-                                   const int& n1, const int& n2, const int& n3,
-                                   const double del[4], const double *var)
+    const int& n1, const int& n2, const int& n3, const double del[4], const double* var)
 {
     // Interpolate in 1D at a time to avoid reading zones we don't have
-    Real interp = var[ind(i    , j    , k)]*(1. - del[1]) +
-                  var[ind(i + 1, j    , k)]*del[1];
+    Real interp = var[ind(i, j, k)] * (1. - del[1]) + var[ind(i + 1, j, k)] * del[1];
     if (n2 > 1) {
-        interp = (1. - del[2])*interp +
-                 del[2]*(var[ind(i    , j + 1, k)]*(1. - del[1]) +
-                         var[ind(i + 1, j + 1, k)]*del[1]);
+        interp =
+            (1. - del[2]) * interp + del[2] * (var[ind(i, j + 1, k)] * (1. - del[1]) +
+                                                  var[ind(i + 1, j + 1, k)] * del[1]);
     }
     if (n3 > 1) {
-        interp = (1. - del[3])*interp +
-                 del[3]*(var[ind(i    , j    , k + 1)]*(1. - del[1])*(1. - del[2]) +
-                         var[ind(i + 1, j    , k + 1)]*del[1]*(1. - del[2]) +
-                         var[ind(i    , j + 1, k + 1)]*(1. - del[1])*del[2] +
-                         var[ind(i + 1, j + 1, k + 1)]*del[1]*del[2]);
+        interp = (1. - del[3]) * interp +
+                 del[3] * (var[ind(i, j, k + 1)] * (1. - del[1]) * (1. - del[2]) +
+                              var[ind(i + 1, j, k + 1)] * del[1] * (1. - del[2]) +
+                              var[ind(i, j + 1, k + 1)] * (1. - del[1]) * del[2] +
+                              var[ind(i + 1, j + 1, k + 1)] * del[1] * del[2]);
     }
     return interp;
 }

--- a/kharma/prob/utils/perturbation.hpp
+++ b/kharma/prob/utils/perturbation.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: perturbation.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,8 +35,8 @@
 
 #include "decs.hpp"
 
-#include <random>
 #include "Kokkos_Random.hpp"
+#include <random>
 
 /**
  * Perturb the internal energy by a uniform random proportion per cell.
@@ -46,7 +46,7 @@
  * @param u_jitter see description
  * @param rng_seed is added to the MPI rank to seed the GSL RNG
  */
-TaskStatus PerturbU(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pin)
+TaskStatus PerturbU(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput* pin)
 {
     auto pmb = rc->GetBlockPointer();
     auto rho = rc->Get("prims.rho").data;
@@ -54,24 +54,28 @@ TaskStatus PerturbU(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pi
 
     const Real u_jitter = pin->GetReal("perturbation", "u_jitter");
     // Don't jitter values set by floors, by default
-    Real rho_min = pin->DoesParameterExist("floors", "rho_min_geom") ? pin->GetReal("floors", "rho_min_geom") :
-                                                                       pin->GetReal("floors", "rho_min_const");
-    const Real jitter_above_rho = pin->GetOrAddReal("perturbation", "jitter_above_rho", rho_min);
+    Real rho_min = pin->DoesParameterExist("floors", "rho_min_geom")
+                       ? pin->GetReal("floors", "rho_min_geom")
+                       : pin->GetReal("floors", "rho_min_const");
+    const Real jitter_above_rho =
+        pin->GetOrAddReal("perturbation", "jitter_above_rho", rho_min);
     // Note we add the MeshBlock gid to this value when seeding RNG,
     // to get a new sequence for every block
     const int rng_seed = pin->GetOrAddInteger("perturbation", "rng_seed", 31337);
     // Print real seed used for all blocks, to ensure they're different
     if (pmb->packages.Get("Globals")->Param<int>("verbose") > 1) {
-        std::cout << "Seeding RNG in block " << pmb->gid << " with value " << rng_seed + pmb->gid << std::endl;
+        std::cout << "Seeding RNG in block " << pmb->gid << " with value "
+                  << rng_seed + pmb->gid << std::endl;
     }
     const bool serial = pin->GetOrAddInteger("perturbation", "serial", false);
 
-    // Should we jitter ghosts? If first boundary sync doesn't work it's marginally less disruptive
+    // Should we jitter ghosts? If first boundary sync doesn't work it's marginally less
+    // disruptive
     IndexDomain domain = IndexDomain::interior;
     const int is = pmb->cellbounds.is(domain), ie = pmb->cellbounds.ie(domain);
     const int js = pmb->cellbounds.js(domain), je = pmb->cellbounds.je(domain);
     const int ks = pmb->cellbounds.ks(domain), ke = pmb->cellbounds.ke(domain);
-    
+
     // HYERIN (07/26/23) get fx1min and fx1max
     const Real fx1min = pin->GetOrAddReal("parthenon/mesh", "restart_x1min", -1);
     const Real fx1max = pin->GetOrAddReal("parthenon/mesh", "restart_x1max", -1);
@@ -82,13 +86,12 @@ TaskStatus PerturbU(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pi
         // Serial version
         // Probably guarantees better determinism, but CPU single-thread only
         std::mt19937 gen(rng_seed + pmb->gid);
-        std::uniform_real_distribution<Real> dis(-u_jitter/2, u_jitter/2);
+        std::uniform_real_distribution<Real> dis(-u_jitter / 2, u_jitter / 2);
 
         auto u_host = u.GetHostMirrorAndCopy();
-        for(int k=ks; k <= ke; k++)
-            for(int j=js; j <= je; j++)
-                for(int i=is; i <= ie; i++)
-                    u_host(k, j, i) *= 1. + dis(gen);
+        for (int k = ks; k <= ke; k++)
+            for (int j = js; j <= je; j++)
+                for (int i = is; i <= ie; i++) u_host(k, j, i) *= 1. + dis(gen);
         u.DeepCopy(u_host);
     } else {
         // Kokkos version
@@ -96,18 +99,19 @@ TaskStatus PerturbU(std::shared_ptr<MeshBlockData<Real>>& rc, ParameterInput *pi
         RandPoolType rand_pool(rng_seed + pmb->gid);
         typedef typename RandPoolType::generator_type gen_type;
         pmb->par_for("perturb_u", ks, ke, js, je, is, ie,
-            KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+                     KOKKOS_LAMBDA(const int& k, const int& j, const int& i)
+            {
                 GReal X[GR_DIM];
                 G.coord(k, j, i, Loci::center, X);
-                if ((! rstf_exists) || (X[1]<fx1min) || (X[1]>fx1max)) {
+                if ((!rstf_exists) || (X[1] < fx1min) || (X[1] > fx1max)) {
                     if (rho(k, j, i) > jitter_above_rho) {
                         gen_type rgen = rand_pool.get_state();
-                        u(k, j, i) *= 1. + Kokkos::rand<gen_type, Real>::draw(rgen, -u_jitter/2, u_jitter/2);
+                        u(k, j, i) *= 1. + Kokkos::rand<gen_type, Real>::draw(
+                                               rgen, -u_jitter / 2, u_jitter / 2);
                         rand_pool.free_state(rgen);
                     }
                 }
-            }
-        );
+            });
     }
 
     return TaskStatus::complete;

--- a/kharma/reductions/reductions.cpp
+++ b/kharma/reductions/reductions.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: reductions.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,10 +39,11 @@
 // TODO none of this machinery preserves zone locations,
 // which we pretty often would like...
 
-std::shared_ptr<KHARMAPackage> Reductions::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Reductions::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Reductions");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // These pools are vectors of Reducers which operate on vectors (or scalars)
     // They exist to allow several reductions to be in-flight at once to hide latency
@@ -66,14 +67,15 @@ std::shared_ptr<KHARMAPackage> Reductions::Initialize(ParameterInput *pin, std::
     params.Add("allreduce_pool", allreduce_pool, true);
 
     // Reductions sometimes need global elements of the simulation we don't otherwise keep
-    params.Add("domain_r_in", (GReal) pin->GetReal("coordinates", "r_in"));
-    params.Add("domain_r_eh", (GReal) pin->GetReal("coordinates", "r_eh"));
+    params.Add("domain_r_in", (GReal)pin->GetReal("coordinates", "r_in"));
+    params.Add("domain_r_eh", (GReal)pin->GetReal("coordinates", "r_eh"));
 
     return pkg;
 }
 
 // Flag reductions: local
-int Reductions::CountFlag(MeshData<Real> *md, std::string field_name, const int& flag_val, IndexDomain domain, bool is_bitflag)
+int Reductions::CountFlag(MeshData<Real>* md, std::string field_name, const int& flag_val,
+    IndexDomain domain, bool is_bitflag)
 {
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
     // Pack variables
@@ -88,21 +90,25 @@ int Reductions::CountFlag(MeshData<Real> *md, std::string field_name, const int&
 
     int n_flag;
     Kokkos::Sum<int> flag_ct(n_flag);
-    pmb0->par_reduce("count_flag", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, int &local_result) {
+    pmb0->par_reduce(
+        "count_flag", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(
+            const int& b, const int& k, const int& j, const int& i, int& local_result)
+        {
             if ((is_bitflag && static_cast<int>(flag(b, 0, k, j, i)) & flag_val) ||
                 (!is_bitflag && static_cast<int>(flag(b, 0, k, j, i)) == flag_val))
                 ++local_result;
-        }
-    , flag_ct);
+        },
+        flag_ct);
     return n_flag;
 }
 
 #define MAX_NFLAGS 20
 
-std::vector<int> Reductions::CountFlags(MeshData<Real> *md, std::string field_name, const std::map<int, std::string> &flag_values, IndexDomain domain, bool is_bitflag)
+std::vector<int> Reductions::CountFlags(MeshData<Real>* md, std::string field_name,
+    const std::map<int, std::string>& flag_values, IndexDomain domain, bool is_bitflag)
 {
-    Flag("CountFlags_"+field_name);
+    Flag("CountFlags_" + field_name);
     auto pmb0 = md->GetBlockData(0)->GetBlockPointer();
 
     // Pack variables
@@ -119,8 +125,8 @@ std::vector<int> Reductions::CountFlags(MeshData<Real> *md, std::string field_na
     const int n_of_flags = flag_values.size();
     ParArray1D<int> flag_val_list("flag_values", MAX_NFLAGS);
     auto flag_val_list_h = flag_val_list.GetHostMirror();
-    int f=1;
-    for (auto &flag : flag_values) {
+    int f = 1;
+    for (auto& flag : flag_values) {
         flag_val_list_h[f] = flag.first;
         f++;
     }
@@ -132,36 +138,42 @@ std::vector<int> Reductions::CountFlags(MeshData<Real> *md, std::string field_na
     // This works for pflags or fflags, so long as they're separate
     // We don't count negative pflags as they denote zones that shouldn't be fixed
     Reductions::array_type<int, MAX_NFLAGS> flag_reducer;
-    pmb0->par_reduce("count_flags", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, 
-                       Reductions::array_type<int, MAX_NFLAGS> &local_result) {
+    pmb0->par_reduce(
+        "count_flags", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
+            Reductions::array_type<int, MAX_NFLAGS>& local_result)
+        {
             const int flag_int = static_cast<int>(flag(b, 0, k, j, i));
             // First element is total count
             if (flag_int > 0) ++local_result.my_array[0];
             // The rest of the list is individual flags
-            for (int f=1; f <= n_of_flags; f++)
+            for (int f = 1; f <= n_of_flags; f++)
                 if ((is_bitflag && flag_int & flag_val_list(f)) ||
                     (!is_bitflag && flag_int == flag_val_list(f)))
                     ++local_result.my_array[f];
-        }
-    , Reductions::ArraySum<int, HostExecSpace, MAX_NFLAGS>(flag_reducer));
+        },
+        Reductions::ArraySum<int, HostExecSpace, MAX_NFLAGS>(flag_reducer));
 
     std::vector<int> n_each_flag;
-    for (int f=0; f < n_of_flags+1; f++)
+    for (int f = 0; f < n_of_flags + 1; f++)
         n_each_flag.push_back(flag_reducer.my_array[f]);
-    
+
     EndFlag();
     return n_each_flag;
 }
 
 // Flag reductions: global
-void Reductions::StartFlagReduce(MeshData<Real> *md, std::string field_name, const std::map<int, std::string> &flag_values, IndexDomain domain, bool is_bitflag, int channel)
+void Reductions::StartFlagReduce(MeshData<Real>* md, std::string field_name,
+    const std::map<int, std::string>& flag_values, IndexDomain domain, bool is_bitflag,
+    int channel)
 {
-    Start<std::vector<int>>(md, channel, CountFlags(md, field_name, flag_values, domain, is_bitflag), MPI_SUM);
+    Start<std::vector<int>>(md, channel,
+        CountFlags(md, field_name, flag_values, domain, is_bitflag), MPI_SUM);
 }
 
-std::vector<int> Reductions::CheckFlagReduceAndPrintHits(MeshData<Real> *md, std::string field_name, const std::map<int, std::string> &flag_values,
-                                                     IndexDomain domain, bool is_bitflag, int channel)
+std::vector<int> Reductions::CheckFlagReduceAndPrintHits(MeshData<Real>* md,
+    std::string field_name, const std::map<int, std::string>& flag_values,
+    IndexDomain domain, bool is_bitflag, int channel)
 {
     Flag("CheckFlagReduce");
     const auto& pmesh = md->GetMeshPointer();
@@ -169,28 +181,34 @@ std::vector<int> Reductions::CheckFlagReduceAndPrintHits(MeshData<Real> *md, std
 
     // Get the relevant reducer and result
     auto& pars = md->GetMeshPointer()->packages.Get("Reductions")->AllParams();
-    auto *vector_int_reduce_pool = pars.GetMutable<std::vector<Reduce<std::vector<int>>>>("vector_int_reduce_pool");
+    auto* vector_int_reduce_pool =
+        pars.GetMutable<std::vector<Reduce<std::vector<int>>>>("vector_int_reduce_pool");
     auto& vector_int_reduce = (*vector_int_reduce_pool)[channel];
 
     while (vector_int_reduce.CheckReduce() == TaskStatus::incomplete);
-    const std::vector<int> &total_flag_counts = vector_int_reduce.val;
+    const std::vector<int>& total_flag_counts = vector_int_reduce.val;
 
-    // Print flags 
+    // Print flags
     if (total_flag_counts[0] > 0 && verbose > 0) {
         if (MPIRank0()) {
             // Always our domain size times total number of blocks
             IndexRange ib = md->GetBoundsI(domain);
             IndexRange jb = md->GetBoundsJ(domain);
             IndexRange kb = md->GetBoundsK(domain);
-            int n_cells = pmesh->nbtotal * (kb.e - kb.s + 1) * (jb.e - jb.s + 1) * (ib.e - ib.s + 1);
+            int n_cells = pmesh->nbtotal * (kb.e - kb.s + 1) * (jb.e - jb.s + 1) *
+                          (ib.e - ib.s + 1);
 
             int nflags = total_flag_counts[0];
-            std::cout << field_name << ": " << nflags << " (" << (int)(((double) nflags )/n_cells * 100) << "% of all cells)" << std::endl;
+            std::cout << field_name << ": " << nflags << " ("
+                      << (int)(((double)nflags) / n_cells * 100) << "% of all cells)"
+                      << std::endl;
             if (verbose > 1) {
                 // Print nonzero vector contents against flag names in order
                 int i = 1;
                 for (auto& status : flag_values) {
-                    if (total_flag_counts[i] > 0) std::cout << status.second << ": " << total_flag_counts[i] << std::endl;
+                    if (total_flag_counts[i] > 0)
+                        std::cout << status.second << ": " << total_flag_counts[i]
+                                  << std::endl;
                     ++i;
                 }
                 std::cout << std::endl;

--- a/kharma/reductions/reductions.hpp
+++ b/kharma/reductions/reductions.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: reductions.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,36 +39,41 @@
 #include "grmhd_functions.hpp"
 #include "types.hpp"
 
-namespace Reductions {
+namespace Reductions
+{
 
 // Think about how to do channels as not ints
-//constexpr enum class Channel{fflag, pflag, iflag, };
+// constexpr enum class Channel{fflag, pflag, iflag, };
 
 /**
  * These, too, are a package.
  * Mostly it exists to keep track of Reducers, so we can clean them up to keep MPI happy.
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
  * Perform a reduction using operation 'op' over a given domain.
  * Note startx/stopx are in *embedding* coordinates e.g. Kerr-Schild, not MKS/FMKS
- * 
+ *
  * This should be used for all 2D shell sums not around the EH:
  * Just set equal min/max, 2D slices are detected
  */
 template<Var var, UserHistoryOperation op, typename T>
-T DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel=-1);
+T DomainReduction(
+    MeshData<Real>* md, const GReal startx[3], const GReal stopx[3], int channel = -1);
 // Defaults -- use numeric limits to set some indices unrestricted
 static constexpr Real real_max = std::numeric_limits<GReal>::max();
 template<Var var, UserHistoryOperation op, typename T>
-T DomainReduction(MeshData<Real> *md, int channel=-1) {
+T DomainReduction(MeshData<Real>* md, int channel = -1)
+{
     const GReal startx[3] = {-real_max, -real_max, -real_max};
     const GReal stopx[3] = {real_max, real_max, real_max};
     return DomainReduction<var, op, T>(md, startx, stopx, channel);
 }
 template<Var var, UserHistoryOperation op, typename T>
-T ShellReduction(MeshData<Real> *md, GReal r, int channel=-1) {
+T ShellReduction(MeshData<Real>* md, GReal r, int channel = -1)
+{
     const GReal startx[3] = {r, -real_max, -real_max};
     const GReal stopx[3] = {r, real_max, real_max};
     return DomainReduction<var, op, T>(md, startx, stopx, channel);
@@ -76,24 +81,24 @@ T ShellReduction(MeshData<Real> *md, GReal r, int channel=-1) {
 
 // Parthenon doesn't allow taking options, so we define some common reductions
 template<Var var>
-Real SumAt0(MeshData<Real> *md)
+Real SumAt0(MeshData<Real>* md)
 {
     return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
         md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in"));
 }
 template<Var var>
-Real SumAtEH(MeshData<Real> *md)
+Real SumAtEH(MeshData<Real>* md)
 {
     return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
         md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_eh"));
 }
 template<Var var>
-Real SumAt5M(MeshData<Real> *md)
+Real SumAt5M(MeshData<Real>* md)
 {
     return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md, 5.);
 }
 template<Var var>
-Real Total(MeshData<Real> *md)
+Real Total(MeshData<Real>* md)
 {
     return Reductions::DomainReduction<var, UserHistoryOperation::sum, Real>(md);
 }
@@ -102,9 +107,9 @@ Real Total(MeshData<Real> *md)
  * Start reductions with a value you have on hand
  */
 template<typename T>
-void Start(MeshData<Real> *md, int channel, T val, MPI_Op op);
+void Start(MeshData<Real>* md, int channel, T val, MPI_Op op);
 template<typename T>
-void StartToAll(MeshData<Real> *md, int channel, T val, MPI_Op op);
+void StartToAll(MeshData<Real>* md, int channel, T val, MPI_Op op);
 
 /**
  * Check the results of reductions that have been started.
@@ -112,9 +117,9 @@ void StartToAll(MeshData<Real> *md, int channel, T val, MPI_Op op);
  * Real/default, int, vector<Real> and vector<int> (i.e. Flags)
  */
 template<typename T>
-T Check(MeshData<Real> *md, int channel);
+T Check(MeshData<Real>* md, int channel);
 template<typename T>
-T CheckOnAll(MeshData<Real> *md, int channel);
+T CheckOnAll(MeshData<Real>* md, int channel);
 
 /**
  * Check the results of reductions that have been started.
@@ -122,32 +127,38 @@ T CheckOnAll(MeshData<Real> *md, int channel);
  * Real/default, int, vector<Real> and vector<int> (i.e. Flags)
  */
 template<typename T>
-T Check(MeshData<Real> *md, int channel);
+T Check(MeshData<Real>* md, int channel);
 
 /**
  * Count instances of a particular flag value in the named field.
- * is_bitflag specifies whether multiple flags may be present and will be orthogonal (e.g. FFlag),
- * or whether flags receive consecutive integer values.
+ * is_bitflag specifies whether multiple flags may be present and will be orthogonal (e.g.
+ * FFlag), or whether flags receive consecutive integer values.
  */
-int CountFlag(MeshData<Real> *md, std::string field_name, const int& flag_val, IndexDomain domain, bool is_bitflag);
+int CountFlag(MeshData<Real>* md, std::string field_name, const int& flag_val,
+    IndexDomain domain, bool is_bitflag);
 
 /**
  * Count instances of all flags in the named field.
- * is_bitflag specifies whether multiple flags may be present and will be orthogonal (e.g. FFlag),
- * or whether flags receive consecutive integer values.
+ * is_bitflag specifies whether multiple flags may be present and will be orthogonal (e.g.
+ * FFlag), or whether flags receive consecutive integer values.
  */
-std::vector<int> CountFlags(MeshData<Real> *md, std::string field_name, const std::map<int, std::string> &flag_values, IndexDomain domain, bool is_bitflag);
+std::vector<int> CountFlags(MeshData<Real>* md, std::string field_name,
+    const std::map<int, std::string>& flag_values, IndexDomain domain, bool is_bitflag);
 
 /**
- * Determine number of local flags hit with CountFlags, and send the value over MPI reducer 'channel'
+ * Determine number of local flags hit with CountFlags, and send the value over MPI
+ * reducer 'channel'
  */
-void StartFlagReduce(MeshData<Real> *md, std::string field_name, const std::map<int, std::string> &flag_values, IndexDomain domain, bool is_bitflag, int channel);
+void StartFlagReduce(MeshData<Real>* md, std::string field_name,
+    const std::map<int, std::string>& flag_values, IndexDomain domain, bool is_bitflag,
+    int channel);
 
 /**
  * Check a flag's MPI reduction and print any flags hit
  */
-std::vector<int> CheckFlagReduceAndPrintHits(MeshData<Real> *md, std::string field_name, const std::map<int, std::string> &flag_values,
-                                             IndexDomain domain, bool is_bitflag, int channel);
+std::vector<int> CheckFlagReduceAndPrintHits(MeshData<Real>* md, std::string field_name,
+    const std::map<int, std::string>& flag_values, IndexDomain domain, bool is_bitflag,
+    int channel);
 
 } // namespace Reductions
 

--- a/kharma/reductions/reductions_impl.hpp
+++ b/kharma/reductions/reductions_impl.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: reductions_variables.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,19 +44,15 @@ template<typename T, bool all_reduce>
 inline std::string GetPoolName()
 {
     if constexpr (all_reduce) {
-        if constexpr (std::is_same<T, Real>::value)
-            return "allreduce_pool";
-        if constexpr (std::is_same<T, int>::value)
-            return "int_allreduce_pool";
+        if constexpr (std::is_same<T, Real>::value) return "allreduce_pool";
+        if constexpr (std::is_same<T, int>::value) return "int_allreduce_pool";
         if constexpr (std::is_same<T, std::vector<Real>>::value)
             return "vector_allreduce_pool";
         if constexpr (std::is_same<T, std::vector<int>>::value)
             return "vector_int_allreduce_pool";
     } else {
-        if constexpr (std::is_same<T, Real>::value)
-            return "reduce_pool";
-        if constexpr (std::is_same<T, int>::value)
-            return "int_reduce_pool";
+        if constexpr (std::is_same<T, Real>::value) return "reduce_pool";
+        if constexpr (std::is_same<T, int>::value) return "int_reduce_pool";
         if constexpr (std::is_same<T, std::vector<Real>>::value)
             return "vector_reduce_pool";
         if constexpr (std::is_same<T, std::vector<int>>::value)
@@ -66,12 +62,12 @@ inline std::string GetPoolName()
 
 // MPI reduction starts
 template<typename T>
-void Reductions::Start(MeshData<Real> *md, int channel, T val, MPI_Op op)
+void Reductions::Start(MeshData<Real>* md, int channel, T val, MPI_Op op)
 {
     // Get the relevant reducer
     const std::string pool_name = GetPoolName<T, false>();
     auto& pars = md->GetMeshPointer()->packages.Get("Reductions")->AllParams();
-    auto *reduce_pool = pars.GetMutable<std::vector<Reduce<T>>>(pool_name);
+    auto* reduce_pool = pars.GetMutable<std::vector<Reduce<T>>>(pool_name);
     while (reduce_pool->size() <= channel) reduce_pool->push_back(Reduce<T>());
     auto& reduce = (*reduce_pool)[channel];
     // Fill with flags
@@ -79,12 +75,12 @@ void Reductions::Start(MeshData<Real> *md, int channel, T val, MPI_Op op)
     reduce.StartReduce(0, op);
 }
 template<typename T>
-void Reductions::StartToAll(MeshData<Real> *md, int channel, T val, MPI_Op op)
+void Reductions::StartToAll(MeshData<Real>* md, int channel, T val, MPI_Op op)
 {
     // Get the relevant reducer
     const std::string pool_name = GetPoolName<T, true>();
     auto& pars = md->GetMeshPointer()->packages.Get("Reductions")->AllParams();
-    auto *allreduce_pool = pars.GetMutable<std::vector<AllReduce<T>>>(pool_name);
+    auto* allreduce_pool = pars.GetMutable<std::vector<AllReduce<T>>>(pool_name);
     while (allreduce_pool->size() <= channel) allreduce_pool->push_back(AllReduce<T>());
     auto& reduce = (*allreduce_pool)[channel];
     // Fill with flags
@@ -94,38 +90,40 @@ void Reductions::StartToAll(MeshData<Real> *md, int channel, T val, MPI_Op op)
 
 // MPI reduction checks
 template<typename T>
-T Reductions::Check(MeshData<Real> *md, int channel)
+T Reductions::Check(MeshData<Real>* md, int channel)
 {
     // Get the relevant reducer and result
     const std::string pool_name = GetPoolName<T, false>();
     auto& pars = md->GetMeshPointer()->packages.Get("Reductions")->AllParams();
-    auto *reduce_pool = pars.GetMutable<std::vector<Reduce<T>>>(pool_name);
+    auto* reduce_pool = pars.GetMutable<std::vector<Reduce<T>>>(pool_name);
     auto& reducer = (*reduce_pool)[channel];
 
     while (reducer.CheckReduce() == TaskStatus::incomplete);
     return reducer.val;
 }
 template<typename T>
-T Reductions::CheckOnAll(MeshData<Real> *md, int channel)
+T Reductions::CheckOnAll(MeshData<Real>* md, int channel)
 {
     // Get the relevant reducer and result
     const std::string pool_name = GetPoolName<T, true>();
     auto& pars = md->GetMeshPointer()->packages.Get("Reductions")->AllParams();
-    auto *reduce_pool = pars.GetMutable<std::vector<AllReduce<T>>>(pool_name);
+    auto* reduce_pool = pars.GetMutable<std::vector<AllReduce<T>>>(pool_name);
     auto& reducer = (*reduce_pool)[channel];
 
     while (reducer.CheckReduce() == TaskStatus::incomplete);
     return reducer.val;
 }
 
-#define INSIDE (x[1] >= startx1 && x[2] >= startx2 && x[3] >= startx3) && \
-                (trivial1 ? xin[1] < startx1 : x[1] <= stopx1) && \
-                (trivial2 ? xin[2] < startx2 : x[2] <= stopx2) && \
-                (trivial3 ? xin[3] < startx3 : x[3] <= stopx3)
+#define INSIDE                                                                           \
+    (x[1] >= startx1 && x[2] >= startx2 && x[3] >= startx3) &&                           \
+        (trivial1 ? xin[1] < startx1 : x[1] <= stopx1) &&                                \
+        (trivial2 ? xin[2] < startx2 : x[2] <= stopx2) &&                                \
+        (trivial3 ? xin[3] < startx3 : x[3] <= stopx3)
 
 // TODO additionally template on return type to avoid counting flags with Reals
 template<Reductions::Var var, UserHistoryOperation op, typename T>
-T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel)
+T Reductions::DomainReduction(
+    MeshData<Real>* md, const GReal startx[3], const GReal stopx[3], int channel)
 {
     Flag("DomainReduction");
     auto pmesh = md->GetMeshPointer();
@@ -136,8 +134,11 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
 
     // Just pass in everything we might want. Probably slow?
     PackIndexMap prims_map, cons_map;
-    const auto& P = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    const auto& U = md->PackVariablesAndFluxes(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    const auto& P = md->PackVariables(
+        std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::Cell},
+        prims_map);
+    const auto& U = md->PackVariablesAndFluxes(
+        std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
     const auto& cmax = md->PackVariables(std::vector<std::string>{"Flux.cmax"});
     const auto& cmin = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
@@ -149,7 +150,8 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
     IndexRange block = IndexRange{0, U.GetDim(5) - 1};
 
     bool trivial_tmp[3] = {false, false, false};
-    VLOOP trivial_tmp[v] = (startx[v] == stopx[v]);
+    VLOOP
+        trivial_tmp[v] = (startx[v] == stopx[v]);
 
     // Pull values to pass to device, because passing views is cumbersome
     const bool trivial1 = trivial_tmp[0];
@@ -165,72 +167,93 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
     // TODO is 'if constexpr' faster now op is compile-time?
     T result = 0.;
     MPI_Op mop;
-    switch(op) {
-    case UserHistoryOperation::sum: {
-        Kokkos::Sum<T> sum_reducer(result);
-        // TODO these should be nested parallel loops to skip blocks fully outside domain
-        pmb0->par_reduce("domain_sum", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, T &local_result) {
-                const auto& G = U.GetCoords(b);
-                GReal x[GR_DIM], xin[GR_DIM];
-                G.coord_embed(k, j, i, Loci::center, x);
-                if (trivial1 || trivial2 || trivial3)
-                    G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
-                if(INSIDE) {
-                    local_result += reduction_var<var>(REDUCE_FUNCTION_CALL) *
-                        ((trivial3) ? 1. : G.Dxc<3>(k)) * ((trivial2) ? 1. : G.Dxc<2>(j)) * ((trivial1) ? 1. : G.Dxc<1>(i));
-                }
-            }
-        , sum_reducer);
-        mop = MPI_SUM;
-        break;
-    }
-    case UserHistoryOperation::max: {
-        Kokkos::Max<T> max_reducer(result);
-        pmb0->par_reduce("domain_max", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, T &local_result) {
-                const auto& G = U.GetCoords(b);
-                GReal x[GR_DIM], xin[GR_DIM];
-                G.coord_embed(k, j, i, Loci::center, x);
-                if (trivial1 || trivial2 || trivial3)
-                    G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
-                if(INSIDE) {
-                    const Real val = reduction_var<var>(REDUCE_FUNCTION_CALL) *
-                        ((trivial3) ? 1. : G.Dxc<3>(k)) * ((trivial2) ? 1. : G.Dxc<2>(j)) * ((trivial1) ? 1. : G.Dxc<1>(i));
-                    if (val > local_result) local_result = val;
-                }
-            }
-        , max_reducer);
-        mop = MPI_MAX;
-        break;
-    }
-    case UserHistoryOperation::min: {
-        Kokkos::Min<T> min_reducer(result);
-        pmb0->par_reduce("domain_min", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-            KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i, T &local_result) {
-                const auto& G = U.GetCoords(b);
-                GReal x[GR_DIM], xin[GR_DIM];
-                G.coord_embed(k, j, i, Loci::center, x);
-                if (trivial1 || trivial2 || trivial3)
-                    G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
-                if(INSIDE) {
-                    const Real val = reduction_var<var>(REDUCE_FUNCTION_CALL) *
-                        ((trivial3) ? 1. : G.Dxc<3>(k)) * ((trivial2) ? 1. : G.Dxc<2>(j)) * ((trivial1) ? 1. : G.Dxc<1>(i));
-                    if (val < local_result) local_result = val;
-                }
-            }
-        , min_reducer);
-        mop = MPI_MIN;
-        break;
-    }
+    switch (op) {
+        case UserHistoryOperation::sum: {
+            Kokkos::Sum<T> sum_reducer(result);
+            // TODO these should be nested parallel loops to skip blocks fully outside
+            // domain
+            pmb0->par_reduce(
+                "domain_sum", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
+                    T& local_result)
+                {
+                    const auto& G = U.GetCoords(b);
+                    GReal x[GR_DIM], xin[GR_DIM];
+                    G.coord_embed(k, j, i, Loci::center, x);
+                    if (trivial1 || trivial2 || trivial3)
+                        G.coord_embed(
+                            k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                    if (INSIDE) {
+                        local_result += reduction_var<var>(REDUCE_FUNCTION_CALL) *
+                                        ((trivial3) ? 1. : G.Dxc<3>(k)) *
+                                        ((trivial2) ? 1. : G.Dxc<2>(j)) *
+                                        ((trivial1) ? 1. : G.Dxc<1>(i));
+                    }
+                },
+                sum_reducer);
+            mop = MPI_SUM;
+            break;
+        }
+        case UserHistoryOperation::max: {
+            Kokkos::Max<T> max_reducer(result);
+            pmb0->par_reduce(
+                "domain_max", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
+                    T& local_result)
+                {
+                    const auto& G = U.GetCoords(b);
+                    GReal x[GR_DIM], xin[GR_DIM];
+                    G.coord_embed(k, j, i, Loci::center, x);
+                    if (trivial1 || trivial2 || trivial3)
+                        G.coord_embed(
+                            k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                    if (INSIDE) {
+                        const Real val = reduction_var<var>(REDUCE_FUNCTION_CALL) *
+                                         ((trivial3) ? 1. : G.Dxc<3>(k)) *
+                                         ((trivial2) ? 1. : G.Dxc<2>(j)) *
+                                         ((trivial1) ? 1. : G.Dxc<1>(i));
+                        if (val > local_result) local_result = val;
+                    }
+                },
+                max_reducer);
+            mop = MPI_MAX;
+            break;
+        }
+        case UserHistoryOperation::min: {
+            Kokkos::Min<T> min_reducer(result);
+            pmb0->par_reduce(
+                "domain_min", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+                KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i,
+                    T& local_result)
+                {
+                    const auto& G = U.GetCoords(b);
+                    GReal x[GR_DIM], xin[GR_DIM];
+                    G.coord_embed(k, j, i, Loci::center, x);
+                    if (trivial1 || trivial2 || trivial3)
+                        G.coord_embed(
+                            k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                    if (INSIDE) {
+                        const Real val = reduction_var<var>(REDUCE_FUNCTION_CALL) *
+                                         ((trivial3) ? 1. : G.Dxc<3>(k)) *
+                                         ((trivial2) ? 1. : G.Dxc<2>(j)) *
+                                         ((trivial1) ? 1. : G.Dxc<1>(i));
+                        if (val < local_result) local_result = val;
+                    }
+                },
+                min_reducer);
+            mop = MPI_MIN;
+            break;
+        }
     }
 
-    // Optionally start an MPI reducer w/given index, so the mesh-wide result is ready when we want it
+    // Optionally start an MPI reducer w/given index, so the mesh-wide result is ready
+    // when we want it
     if (channel >= 0) {
         Start<T>(md, channel, result, mop);
     }
 
-    //fprintf(stderr, "r: %f trivial: %d %d %d result: %f\n", startx1, trivial1, trivial2, trivial3, result);
+    // fprintf(stderr, "r: %f trivial: %d %d %d result: %f\n", startx1, trivial1,
+    // trivial2, trivial3, result);
 
     EndFlag();
     return result;

--- a/kharma/reductions/reductions_types.hpp
+++ b/kharma/reductions/reductions_types.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: reductions_variables.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -38,23 +38,27 @@
 
 #include "decs.hpp"
 
-namespace Reductions {
+namespace Reductions
+{
 // Array type for reducing arbitrary numbers of reals or ints
-template <class ScalarType, int N>
-struct array_type {
+template<class ScalarType, int N>
+struct array_type
+{
     ScalarType my_array[N];
 
     KOKKOS_INLINE_FUNCTION
     array_type() { init(); }
 
     KOKKOS_INLINE_FUNCTION
-    array_type(const array_type& rhs) {
+    array_type(const array_type& rhs)
+    {
         for (int i = 0; i < N; i++) {
             my_array[i] = rhs.my_array[i];
         }
     }
 
-    KOKKOS_INLINE_FUNCTION void init() {
+    KOKKOS_INLINE_FUNCTION void init()
+    {
         for (int i = 0; i < N; i++) {
             my_array[i] = 0;
         }
@@ -63,7 +67,8 @@ struct array_type {
     // The kokkos example defines both of these,
     // but we clearly can't. Guess.
     KOKKOS_INLINE_FUNCTION
-    array_type& operator+=(const array_type& src) {
+    array_type& operator+=(const array_type& src)
+    {
         for (int i = 0; i < N; i++) {
             my_array[i] += src.my_array[i];
         }
@@ -76,41 +81,40 @@ struct array_type {
     //         my_array[i] += src.my_array[i];
     //     }
     // }
-
 };
 
-template <class T, class Space, int N>
-struct ArraySum {
- public:
-  // Required
-  typedef ArraySum reducer;
-  typedef array_type<T, N> value_type;
-  typedef Kokkos::View<value_type*, Space, Kokkos::MemoryUnmanaged>
-      result_view_type;
+template<class T, class Space, int N>
+struct ArraySum
+{
+  public:
+    // Required
+    typedef ArraySum reducer;
+    typedef array_type<T, N> value_type;
+    typedef Kokkos::View<value_type*, Space, Kokkos::MemoryUnmanaged> result_view_type;
 
- private:
-  value_type& value;
+  private:
+    value_type& value;
 
- public:
-  KOKKOS_INLINE_FUNCTION
-  ArraySum(value_type& value_) : value(value_) {}
+  public:
+    KOKKOS_INLINE_FUNCTION
+    ArraySum(value_type& value_)
+        : value(value_)
+    {}
 
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  void join(value_type& dest, const value_type& src) const {
-    dest += src;
-  }
+    // Required
+    KOKKOS_INLINE_FUNCTION
+    void join(value_type& dest, const value_type& src) const { dest += src; }
 
-  KOKKOS_INLINE_FUNCTION
-  void init(value_type& val) const { val.init(); }
+    KOKKOS_INLINE_FUNCTION
+    void init(value_type& val) const { val.init(); }
 
-  KOKKOS_INLINE_FUNCTION
-  value_type& reference() const { return value; }
+    KOKKOS_INLINE_FUNCTION
+    value_type& reference() const { return value; }
 
-  KOKKOS_INLINE_FUNCTION
-  result_view_type view() const { return result_view_type(&value, 1); }
+    KOKKOS_INLINE_FUNCTION
+    result_view_type view() const { return result_view_type(&value, 1); }
 
-  KOKKOS_INLINE_FUNCTION
-  bool references_scalar() const { return true; }
+    KOKKOS_INLINE_FUNCTION
+    bool references_scalar() const { return true; }
 };
 }

--- a/kharma/reductions/reductions_variables.hpp
+++ b/kharma/reductions/reductions_variables.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: reductions_variables.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,31 +40,56 @@
 #include "flux_functions.hpp"
 
 // Arguments to computing any variable defined below
-#define REDUCE_FUNCTION_ARGS const GRCoordinates& G, const VariablePack<Real>& P, const VarMap& m_p, \
-                        const VariableFluxPack<Real>& U, const VarMap& m_u, \
-                        const VariablePack<Real>& cmax, const VariablePack<Real>& cmin,\
-                        const EMHD::EMHD_parameters& emhd_params, const Real& gam, const int& k, const int& j, const int& i
+#define REDUCE_FUNCTION_ARGS                                                             \
+    const GRCoordinates &G, const VariablePack<Real>&P, const VarMap &m_p,               \
+        const VariableFluxPack<Real>&U, const VarMap &m_u,                               \
+        const VariablePack<Real>&cmax, const VariablePack<Real>&cmin,                    \
+        const EMHD::EMHD_parameters &emhd_params, const Real &gam, const int &k,         \
+        const int &j, const int &i
 // Call for passing a particular block's values
-#define REDUCE_FUNCTION_CALL G, P(b), m_p, U(b), m_u, cmax(b), cmin(b), emhd_params, gam, k, j, i
+#define REDUCE_FUNCTION_CALL                                                             \
+    G, P(b), m_p, U(b), m_u, cmax(b), cmin(b), emhd_params, gam, k, j, i
 
 using namespace parthenon;
 
-namespace Reductions {
+namespace Reductions
+{
 
 // Add any new reduction variables to this list, then implementations below
 // Not elegant, but fast & portable.
 // HIPCC doesn't like passing function pointers as we used to do,
 // and it doesn't vectorize anyway. Look forward to more of this pattern in the code
-enum class Var{phi, bsq, gas_pressure, beta, rhou0, mix_T00, mix_T01, mix_T02, mix_T03,
-               mdot, edot, ldot, mdot_flux, edot_flux, ldot_flux, eht_lum, jet_lum,
-               nan_ctop, zero_ctop, neg_rho, neg_u, neg_rhout};
+enum class Var {
+    phi,
+    bsq,
+    gas_pressure,
+    beta,
+    rhou0,
+    mix_T00,
+    mix_T01,
+    mix_T02,
+    mix_T03,
+    mdot,
+    edot,
+    ldot,
+    mdot_flux,
+    edot_flux,
+    ldot_flux,
+    eht_lum,
+    jet_lum,
+    nan_ctop,
+    zero_ctop,
+    neg_rho,
+    neg_u,
+    neg_rhout
+};
 
 // Function template for all reductions.
 template<Var T>
 KOKKOS_INLINE_FUNCTION Real reduction_var(REDUCE_FUNCTION_ARGS);
 
 // Can also sum the hemispheres independently to be fancy (TODO?)
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::phi>(REDUCE_FUNCTION_ARGS)
 {
     // \Phi == \int |*F^1^0| * gdet * dx2 * dx3 == \int |B1| * gdet * dx2 * dx3
@@ -72,48 +97,49 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::phi>(REDUCE_FUNCTION_ARGS)
 }
 
 // Basic variables
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::bsq>(REDUCE_FUNCTION_ARGS)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
     return dot(Dtmp.bcon, Dtmp.bcov);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::gas_pressure>(REDUCE_FUNCTION_ARGS)
 {
     return (gam - 1) * P(m_p.UU, k, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::beta>(REDUCE_FUNCTION_ARGS)
 {
     FourVectors Dtmp;
     GRMHD::calc_4vecs(G, P, m_p, k, j, i, Loci::center, Dtmp);
-    return ((gam - 1) * P(m_p.UU, k, j, i))/(0.5*(dot(Dtmp.bcon, Dtmp.bcov) + SMALL_NUM));
+    return ((gam - 1) * P(m_p.UU, k, j, i)) /
+           (0.5 * (dot(Dtmp.bcon, Dtmp.bcov) + SMALL_NUM));
 }
 
 // Stuff that should be conserved
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::rhou0>(REDUCE_FUNCTION_ARGS)
 {
     return U(m_u.RHO, k, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mix_T00>(REDUCE_FUNCTION_ARGS)
 {
     return U(m_u.UU, k, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mix_T01>(REDUCE_FUNCTION_ARGS)
 {
     return U(m_u.U1, k, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mix_T02>(REDUCE_FUNCTION_ARGS)
 {
     return U(m_u.U2, k, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mix_T03>(REDUCE_FUNCTION_ARGS)
 {
     return U(m_u.U3, k, j, i);
@@ -121,7 +147,7 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mix_T03>(REDUCE_FUNCTION_ARGS)
 
 // Accretion rates: return a zone's contribution to the surface integral
 // forming each rate measurement.
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mdot>(REDUCE_FUNCTION_ARGS)
 {
     Real ucon[GR_DIM];
@@ -129,7 +155,7 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mdot>(REDUCE_FUNCTION_ARGS)
     // \dot{M} == \int rho * u^1 * gdet * dx2 * dx3
     return -P(m_p.RHO, k, j, i) * ucon[X1DIR] * G.gdet(Loci::center, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::edot>(REDUCE_FUNCTION_ARGS)
 {
     FourVectors Dtmp;
@@ -139,7 +165,7 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::edot>(REDUCE_FUNCTION_ARGS)
     // \dot{E} == \int - T^1_0 * gdet * dx2 * dx3
     return -T1[X0DIR] * G.gdet(Loci::center, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::ldot>(REDUCE_FUNCTION_ARGS)
 {
     FourVectors Dtmp;
@@ -151,24 +177,24 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::ldot>(REDUCE_FUNCTION_ARGS)
 }
 
 // Then we can define the same with fluxes.
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mdot_flux>(REDUCE_FUNCTION_ARGS)
 {
     return -U.flux(X1DIR, m_u.RHO, k, j, i);
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::edot_flux>(REDUCE_FUNCTION_ARGS)
 {
     return (U.flux(X1DIR, m_u.UU, k, j, i) - U.flux(X1DIR, m_u.RHO, k, j, i));
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::ldot_flux>(REDUCE_FUNCTION_ARGS)
 {
     return U.flux(X1DIR, m_u.U3, k, j, i);
 }
 
 // Luminosity proxy from (for example) Porth et al 2019.
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::eht_lum>(REDUCE_FUNCTION_ARGS)
 {
     FourVectors Dtmp;
@@ -176,14 +202,15 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::eht_lum>(REDUCE_FUNCTION_ARGS)
     Real rho = P(m_p.RHO, k, j, i);
     Real Pg = (gam - 1.) * P(m_p.UU, k, j, i);
     Real Bmag = m::sqrt(dot(Dtmp.bcon, Dtmp.bcov));
-    Real j_eht = rho*rho*rho/Pg/Pg * m::exp(-0.2 * m::cbrt(rho * rho / (Bmag * Pg * Pg)));
+    Real j_eht =
+        rho * rho * rho / Pg / Pg * m::exp(-0.2 * m::cbrt(rho * rho / (Bmag * Pg * Pg)));
     return j_eht;
 }
 
 // Example of checking extra conditions before adding local results:
 // sums total jet power only at exactly r=radius, for areas with sig > 1
 // TODO version w/E&M power only.  Needs "calc_tensor_EM"
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::jet_lum>(REDUCE_FUNCTION_ARGS)
 {
     FourVectors Dtmp;
@@ -200,16 +227,16 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::jet_lum>(REDUCE_FUNCTION_ARGS)
 }
 
 // Diagnostics.  Still have to return Real so we get creative.
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::zero_ctop>(REDUCE_FUNCTION_ARGS)
 {
     Real is_zero = 0;
     VLOOP {
-        if(m::max(cmax(v, k, j, i), cmin(v, k, j, i)) <= 0.) {
+        if (m::max(cmax(v, k, j, i), cmin(v, k, j, i)) <= 0.) {
             is_zero = 1.; // once per zone
 #if DEBUG
 #ifndef KOKKOS_ENABLE_SYCL
-            printf("ctop zero at %d %d %d along dir %d\n", i, j, k, v+1);
+            printf("ctop zero at %d %d %d along dir %d\n", i, j, k, v + 1);
 #endif
 #endif
         }
@@ -217,16 +244,16 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::zero_ctop>(REDUCE_FUNCTION_ARGS)
 
     return is_zero;
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::nan_ctop>(REDUCE_FUNCTION_ARGS)
 {
     Real is_nan = 0.;
     VLOOP {
-        if(m::isnan(m::max(cmax(v, k, j, i), cmin(v, k, j, i)))) {
+        if (m::isnan(m::max(cmax(v, k, j, i), cmin(v, k, j, i)))) {
             is_nan = 1.;
 #if DEBUG
 #ifndef KOKKOS_ENABLE_SYCL
-            printf("ctop NaN at %d %d %d along dir %d\n", i, j, k, v+1);
+            printf("ctop NaN at %d %d %d along dir %d\n", i, j, k, v + 1);
 #endif
 #endif
         }
@@ -235,7 +262,7 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::nan_ctop>(REDUCE_FUNCTION_ARGS)
     return is_nan;
 }
 
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::neg_rhout>(REDUCE_FUNCTION_ARGS)
 {
     Real is_neg = 0.;
@@ -249,7 +276,7 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::neg_rhout>(REDUCE_FUNCTION_ARGS)
     }
     return is_neg;
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::neg_u>(REDUCE_FUNCTION_ARGS)
 {
     Real is_neg = 0.;
@@ -263,7 +290,7 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::neg_u>(REDUCE_FUNCTION_ARGS)
     }
     return is_neg;
 }
-template <>
+template<>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::neg_rho>(REDUCE_FUNCTION_ARGS)
 {
     Real is_neg = 0.;

--- a/kharma/types.hpp
+++ b/kharma/types.hpp
@@ -219,7 +219,7 @@ class VarMap {
 
 // Reasonable maximum number of fluid primitive or conserved variables being evolved
 // e.g. 8 for GRMHD, 10 for EMHD, and additional vars for e-/passives
-// TODO(BSP) make configurable.  Currently only used for implicit kernel temporaries
+// TODO(CEP) make configurable.  Currently only used for implicit kernel temporaries
 #define MAX_VARS 20
 
 #if DEBUG

--- a/kharma/wind/wind.cpp
+++ b/kharma/wind/wind.cpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: wind.cpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,10 +33,11 @@
  */
 #include "wind.hpp"
 
-std::shared_ptr<KHARMAPackage> Wind::Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages)
+std::shared_ptr<KHARMAPackage> Wind::Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages)
 {
     auto pkg = std::make_shared<KHARMAPackage>("Wind");
-    Params &params = pkg->AllParams();
+    Params& params = pkg->AllParams();
 
     // Wind term in funnel
     Real n = pin->GetOrAddReal("wind", "ne", 2.e-4);
@@ -59,7 +60,7 @@ std::shared_ptr<KHARMAPackage> Wind::Initialize(ParameterInput *pin, std::shared
     return pkg;
 }
 
-TaskStatus Wind::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain)
+TaskStatus Wind::AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain)
 {
     // Pointers
     auto pmesh = mdudt->GetMeshPointer();
@@ -79,7 +80,8 @@ TaskStatus Wind::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomai
 
     // Pack variables
     PackIndexMap cons_map;
-    auto dUdt = mdudt->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
+    auto dUdt =
+        mdudt->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
     const VarMap m_u(cons_map, true);
     // Get sizes
     const IndexRange ib = mdudt->GetBoundsI(IndexDomain::interior);
@@ -88,10 +90,14 @@ TaskStatus Wind::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomai
     const IndexRange block = IndexRange{0, dUdt.GetDim(5) - 1};
 
     // Set the wind via linear ramp-up with time, if enabled
-    const Real current_n = (ramp_end > 0.0) ? m::min(m::max(time - ramp_start, 0.0) / (ramp_end - ramp_start), 1.0) * n : n;
+    const Real current_n =
+        (ramp_end > 0.0)
+            ? m::min(m::max(time - ramp_start, 0.0) / (ramp_end - ramp_start), 1.0) * n
+            : n;
 
     pmb0->par_for("add_wind", block.s, block.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA (const int& b, const int &k, const int &j, const int &i) {
+        KOKKOS_LAMBDA(const int& b, const int& k, const int& j, const int& i)
+        {
             const auto& G = dUdt.GetCoords(b);
             // Need coordinates to evaluate particle addtn rate
             // Note that makes the wind spherical-only, TODO ensure this
@@ -110,15 +116,15 @@ TaskStatus Wind::AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomai
             // Add plasma to the T^t_a component of the stress-energy tensor
             // Notice that U already contains a factor of sqrt{-g}
             Real rho_ut, T[GR_DIM];
-            GRMHD::p_to_u_mhd(G, drhopdt, drhopdt * Tp * 3., uvec, B_P, gam, k, j, i, rho_ut, T);
+            GRMHD::p_to_u_mhd(
+                G, drhopdt, drhopdt * Tp * 3., uvec, B_P, gam, k, j, i, rho_ut, T);
 
             dUdt(b, m_u.RHO, k, j, i) += rho_ut;
             dUdt(b, m_u.UU, k, j, i) += T[0];
             dUdt(b, m_u.U1, k, j, i) += T[1];
             dUdt(b, m_u.U2, k, j, i) += T[2];
             dUdt(b, m_u.U3, k, j, i) += T[3];
-        }
-    );
+        });
 
     return TaskStatus::complete;
 }

--- a/kharma/wind/wind.hpp
+++ b/kharma/wind/wind.hpp
@@ -1,25 +1,25 @@
-/* 
+/*
  *  File: wind.hpp
- *  
+ *
  *  BSD 3-Clause License
- *  
+ *
  *  Copyright (c) 2020, AFD Group at UIUC
  *  All rights reserved.
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- *  
+ *
  *  1. Redistributions of source code must retain the above copyright notice, this
  *     list of conditions and the following disclaimer.
- *  
+ *
  *  2. Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *  
+ *
  *  3. Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,16 +37,19 @@
 
 #include <parthenon/parthenon.hpp>
 
-namespace Wind {
+namespace Wind
+{
 
 /**
  * Initialize the wind package with several options from the input deck
  */
-std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<Packages_t>& packages);
+std::shared_ptr<KHARMAPackage> Initialize(
+    ParameterInput* pin, std::shared_ptr<Packages_t>& packages);
 
 /**
- * Add the wind source term.  Applied in Flux::AddSource, just after the FluxDivergence calculation
+ * Add the wind source term.  Applied in Flux::AddSource, just after the FluxDivergence
+ * calculation
  */
-TaskStatus AddSource(MeshData<Real> *md, MeshData<Real> *mdudt, IndexDomain domain);
+TaskStatus AddSource(MeshData<Real>* md, MeshData<Real>* mdudt, IndexDomain domain);
 
 }

--- a/machines/polaris.sh
+++ b/machines/polaris.sh
@@ -34,7 +34,7 @@ if [[ $HOST == *".polaris.alcf.anl.gov" ]]; then
   # Since we ran 'module purge',
   # The Cray wrappers will warn unless we set this
   export CRAY_CPU_TARGET=x86-64
-  # TODO(BSP) need to set CRAYPE_LINK_TYPE=dynamic long-term?
+  # TODO(CEP) need to set CRAYPE_LINK_TYPE=dynamic long-term?
 
   EXTRA_FLAGS="-DPARTHENON_DISABLE_HDF5_COMPRESSION=ON $EXTRA_FLAGS"
 fi

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#------------------------------------------------------------------------------
+# © 2021-2025. Triad National Security, LLC. All rights reserved.  This
+# program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad
+# National Security, LLC for the U.S.  Department of Energy/National
+# Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is
+# granted for itself and others acting on its behalf a nonexclusive,
+# paid-up, irrevocable worldwide license in this material to reproduce,
+# prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+#------------------------------------------------------------------------------
+
+
+: ${CFM:=clang-format-19}
+: ${VERBOSE:=0}
+
+if ! command -v ${CFM} &> /dev/null; then
+    >&2 echo "Error: No clang format found! Looked for ${CFM}"
+    exit 1
+else
+    CFM=$(command -v ${CFM})
+    echo "Clang format found: ${CFM}"
+fi
+
+# clang format major version
+TARGET_CF_VRSN=19
+CF_VRSN=$(${CFM} --version)
+echo "Note we assume clang format version ${TARGET_CF_VRSN}."
+echo "You are using ${CF_VRSN}."
+echo "If these differ, results may not be stable."
+
+echo "Formatting..."
+git ls-files -z '*.cpp' '*.hpp' | xargs -0 ${CFM} -style=file -i
+echo "...Done"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -34,5 +34,5 @@ echo "You are using ${CF_VRSN}."
 echo "If these differ, results may not be stable."
 
 echo "Formatting..."
-git ls-files -z '*.cpp' '*.hpp' | xargs -0 ${CFM} -style=file -i
+git ls-files -z 'kharma/**/*.cpp' 'kharma/**/*.hpp' | xargs -0 ${CFM} -style=file -i
 echo "...Done"


### PR DESCRIPTION
Jonah added clang-format to KHARMA, and I've got a parameter file I like which doesn't needlessly line break readable code.  Thus: we format the code.

This will necessarily be a bit disruptive to people with downstream code based on KHARMA -- when opening pull requests or merging changes from `dev`, you will need to format your code first, which should hopefully cut down on the changes and eliminate the potentially disruptive ones.

Future commits should be formatted with `clang-format-19`, as is now mentioned on the [wiki](https://github.com/parthenon-hpc-lab/kharma/wiki/KHARMA-Specific-Conventions).  That page has instructions on how to run the formatter for yourself -- it will also be run as a part of CI for new pull requests.

If you find that after formatting your code, there are still a bunch of conflicts when you try to merge `dev`, you can do the merge in stages.  First, merge the `dev-preformat` tag, then cherry-pick the commit `eeaaa5e` which applies formatting, then merge the rest of the `dev` branch.  I'll provide more explicit instructions on how to do each of those if/as we run into issues this week.