### PR TITLE
Usability for dev

### DIFF
--- a/external/patches/parthenon-quiet-defaults.patch
+++ b/external/patches/parthenon-quiet-defaults.patch
@@ -1,0 +1,23 @@
+diff --git a/src/parameter_input.hpp b/src/parameter_input.hpp
+index 896bedfed..4523d6aeb 100644
+--- a/src/parameter_input.hpp
++++ b/src/parameter_input.hpp
+@@ -471,12 +471,12 @@ class ParameterInput {
+             PARTHENON_THROW(msg);
+           }
+         } else if (defval.value() != std::any_cast<T>(record.default_value)) {
+-          std::stringstream msg;
+-          msg << "Input parameter " << block << "/" << name
+-              << " has at least two inconsistent default values. "
+-              << "The ones I detected are " << defval.value() << " and "
+-              << std::any_cast<T>(record.default_value) << std::endl;
+-          PARTHENON_THROW(msg);
++          //std::stringstream msg;
++          //msg << "Input parameter " << block << "/" << name
++          //    << " has at least two inconsistent default values. "
++          //    << "The ones I detected are " << defval.value() << " and "
++          //    << std::any_cast<T>(record.default_value) << std::endl;
++          //PARTHENON_THROW(msg);
+         }
+       }
+       // Allowed values are checked after a query, so this function

--- a/kharma/decs.hpp
+++ b/kharma/decs.hpp
@@ -71,6 +71,7 @@ namespace m = std;
 #include <mesh/domain.hpp>
 
 // KHARMA DEFINITIONS
+#define DISABLE_GMG_CLEANUP 1
 
 // Parthenon stole our type names
 // Lots of work will need to be done for Real != double


### PR DESCRIPTION
This rolls back things we should have, in order to make the usual compile+run more convenient.

We add a downstream patch disabling Parthenon's error when default values conflict -- obviously we want a better solution long-term, but this will involve picking through the conflicts and/or making upstream more flexible about parameters.

We also disable multigrid magnetic field cleanup in-source.  This needs fixing before anyone should use it, and at that point should get a normal disablement flag.