### PR TITLE
More traditional implementation of primitive solver fallback

### DIFF
--- a/kharma/b_cd/b_cd.cpp
+++ b/kharma/b_cd/b_cd.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     // B field as usual
     // TODO allow for implicit B here
     Metadata m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Independent, Metadata::FillGhost,
-                 Metadata::Restart, Metadata::Conserved, Metadata::Conserved,
+                 Metadata::Restart, Metadata::Conserved,
                  Metadata::WithFluxes, Metadata::Vector}, s_vector);
     pkg->AddField("cons.B", m);
     m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
@@ -83,7 +83,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
     // i.e. differ by a factor of gdet.  This is apparently marginally more stable in some
     // circumstances.
     m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Independent, Metadata::FillGhost,
-                  Metadata::Restart, Metadata::Conserved, Metadata::Conserved, Metadata::WithFluxes});
+                  Metadata::Restart, Metadata::Conserved, Metadata::WithFluxes});
     pkg->AddField("cons.psi_cd", m);
     m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived,
                   Metadata::Restart, Metadata::GetUserFlag("Primitive")});

--- a/kharma/b_ct/b_ct_boundaries.cpp
+++ b/kharma/b_ct/b_ct_boundaries.cpp
@@ -341,7 +341,7 @@ void B_CT::ReconnectBoundaryB3(MeshBlockData<Real> *rc, IndexDomain domain, cons
 
                     // Recover primitive GRMHD variables from our modified U
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              25, 1e-12, false);
+                                                              25, 1e-12);
                     // Floor them
                     // TODO THIS IS IN FLUID FRAME
                     int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);

--- a/kharma/driver/kharma_step.cpp
+++ b/kharma/driver/kharma_step.cpp
@@ -86,6 +86,8 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
     TaskCollection tc;
     const TaskID t_none(0);
 
+    Flag("MakeTaskCollection::allocations");
+
     // Which packages we load affects which tasks we'll add to the list
     auto& pkgs = pmesh->packages.AllPackages();
     auto& flux_pkg   = pkgs.at("Flux")->AllParams();
@@ -94,6 +96,7 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
     const bool use_electrons = pkgs.count("Electrons");
     const bool use_fofc = flux_pkg.Get<bool>("use_fofc");
     const bool use_jcon = pkgs.count("Current");
+    const bool track_additions = pkgs.at("Floors")->Param<bool>("track_additions");
 
     // Allocate/copy the things we need
     // TODO these can now be reduced by including the var lists/flags which actually need to be allocated
@@ -117,6 +120,10 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
                             base.get(), pmesh->mesh_data.Get("preserve").get());
             }
         }
+        // Preserve state for time derivatives if we need to output current
+        if (track_additions) {
+            pmesh->mesh_data.Add("pre_fix");
+        }
         // FOFC needs to determine whether the "real" U-divF will violate floors, and needs a safe place to do it.
         // We populate it later, with each *sub-step*'s initial state
         if (use_fofc) {
@@ -125,6 +132,7 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
         }
     }
 
+    EndFlag();
     Flag("MakeTaskCollection::fluxes");
 
     static std::vector<std::string> sync_vars;
@@ -207,7 +215,13 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
                                                   std::vector<MetadataFlag>{Metadata::GetUserFlag("Explicit"), Metadata::Independent},
                                                   use_b_ct, stage);
 
-        KHARMADriver::AddBoundarySync(t_update, tl, md_sync);
+        auto t_sync = KHARMADriver::AddBoundarySync(t_update, tl, md_sync);
+
+        if (track_additions) {
+            // Copy the pre-fix state into a container to save it
+            tl.AddTask(t_sync, Copy<MeshData<Real>>, std::vector<MetadataFlag>{Metadata::Conserved},
+                        md_sub_step_final.get(), pmesh->mesh_data.Get("pre_fix").get());
+        }
     }
 
     EndFlag();
@@ -283,6 +297,11 @@ TaskCollection KHARMADriver::MakeDefaultTaskCollection(BlockList_t &blocks, int 
                 auto t_floors_2 = tl.AddTask(t_derefine_f, Packages::MeshApplyFloors, md_sub_step_final.get(), IndexDomain::entire);
                 t_step_done = tl.AddTask(t_floors_2, Inverter::MeshFixUtoP, md_sub_step_final.get());
             }
+        }
+
+        if (track_additions) {
+            auto t_track_additions = tl.AddTask(t_ptou, Floors::TrackAdditions,
+                                                md_sub_step_final.get(), pmesh->mesh_data.Get("pre_fix").get());
         }
 
         // Estimate next time step based on ctop

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // less reliable but velocity reconstructions potentially more robust.
     // Drift frame floors are now available and preferred when using 
     // the implicit solver to avoid UtoP calls.
-    // TODO(BSP) automate/standardize parsing enums like this: classes w/tables like the flags?
+    // TODO(CEP) automate/standardize parsing enums like this: classes w/tables like the flags?
     std::vector<std::string> allowed_floor_frames = {"normal", "fluid", "mixed",
                                                      "mixed_fluid_normal", "mixed_normal_drift", "drift"};
     std::string frame_s = pin->GetOrAddString("floors", "frame", "normal", allowed_floor_frames);
@@ -132,7 +132,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     pkg->AddField("Floors.u_floor", m);
 
     // Flag for which floor conditions were violated.  Used for diagnostics
-    // TODO(BSP) Should switch these to "Integer" fields when Parthenon supports it
+    // TODO(CEP) Should switch these to "Integer" fields when Parthenon supports it
     pkg->AddField("fflag", m);
     // When not using UtoP, we still need a "dummy" copy of pflag to write the post-flooring flag to
     m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Overridable});
@@ -141,8 +141,8 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // Don't actually call the usual floor function if we're using normal frame w/Kastaun,
     // floors will be applied during the inversion call.
     // Also allow manually disabling the call, for testing
-    if (!disable_call && frame != InjectionFrame::normal_kastaun) {
-        // TODO(BSP) THIS IS THE ONLY MeshApplyFloors.  Any others will NOT BE CALLED.
+    if (!disable_call) {
+        // TODO(CEP) THIS IS THE ONLY MeshApplyFloors.  Any others will NOT BE CALLED.
         // Use BlockApplyFloors in your packages or fix Packages::MeshApplyFloors
         pkg->MeshApplyFloors = Floors::ApplyGRMHDFloors;
     }
@@ -247,13 +247,12 @@ TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
         KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
             const auto& G = P.GetCoords(b);
             // The inverter might have set some floor flags, so we add to that non-destructively
-            fflag(b, 0, k, j, i) = static_cast<int>(fflag(b, 0, k, j, i)) |
-                                    determine_floors(G, P(b), m_p, gam, k, j, i, floors, floors_inner,
-                                                     floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i));
+            fflag(b, 0, k, j, i) = static_cast<int>(determine_floors(G, P(b), m_p, gam, k, j, i, floors, floors_inner,
+                                                     floor_vals(b, rhofi, k, j, i), floor_vals(b, ufi, k, j, i)));
         }
     );
 
-    // TODO(BSP) if we can somehow guarantee one call/rank we can start the reduction here
+    // TODO(CEP) if we can somehow guarantee one call/rank we can start the reduction here
     //Reductions::StartFlagReduce(md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
 
     return TaskStatus::complete;

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // less reliable but velocity reconstructions potentially more robust.
     // Drift frame floors are now available and preferred when using 
     // the implicit solver to avoid UtoP calls.
-    // TODO(CEP) automate/standardize parsing enums like this: classes w/tables like the flags?
+    // TODO(BSP) automate/standardize parsing enums like this: classes w/tables like the flags?
     std::vector<std::string> allowed_floor_frames = {"normal", "fluid", "mixed",
                                                      "mixed_fluid_normal", "mixed_normal_drift", "drift"};
     std::string frame_s = pin->GetOrAddString("floors", "frame", "normal", allowed_floor_frames);
@@ -132,7 +132,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     pkg->AddField("Floors.u_floor", m);
 
     // Flag for which floor conditions were violated.  Used for diagnostics
-    // TODO(CEP) Should switch these to "Integer" fields when Parthenon supports it
+    // TODO(BSP) Should switch these to "Integer" fields when Parthenon supports it
     pkg->AddField("fflag", m);
     // When not using UtoP, we still need a "dummy" copy of pflag to write the post-flooring flag to
     m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Overridable});
@@ -142,7 +142,7 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // floors will be applied during the inversion call.
     // Also allow manually disabling the call, for testing
     if (!disable_call) {
-        // TODO(CEP) THIS IS THE ONLY MeshApplyFloors.  Any others will NOT BE CALLED.
+        // TODO(BSP) THIS IS THE ONLY MeshApplyFloors.  Any others will NOT BE CALLED.
         // Use BlockApplyFloors in your packages or fix Packages::MeshApplyFloors
         pkg->MeshApplyFloors = Floors::ApplyGRMHDFloors;
     }
@@ -252,7 +252,7 @@ TaskStatus Floors::DetermineGRMHDFloors(MeshData<Real> *md, IndexDomain domain,
         }
     );
 
-    // TODO(CEP) if we can somehow guarantee one call/rank we can start the reduction here
+    // TODO(BSP) if we can somehow guarantee one call/rank we can start the reduction here
     //Reductions::StartFlagReduce(md, "fflag", FFlag::flag_names, IndexDomain::interior, true, 0);
 
     return TaskStatus::complete;

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -149,9 +149,10 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     if (track_additions) {
         // Track total additions to conserved variables
         // TODO add primitive versions, advect as passives
+        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::Conserved});
         pkg->AddField("Floors.rhou0add", m);
         std::vector<int> s_4v({4});
-        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_4v);
+        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::Conserved}, s_4v);
         pkg->AddField("Floors.Tadd", m);
         // TODO(CEP) Maybe also want Floors.floorUadd, etc etc, for understanding the breakdown...
     }
@@ -172,6 +173,19 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, CountFFlags, "FFlags"));
     // TODO Domain::entire version?
     // TODO entries for each individual flag?
+    if (track_additions) {
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::rhou0add>, "rhou0add"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T00add>, "T00add"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T01add>, "T01add"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T02add>, "T02add"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T03add>, "T03add"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::rhou0sub>, "rhou0sub"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T00sub>, "T00sub"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T01sub>, "T01sub"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T02sub>, "T02sub"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::T03sub>, "T03sub"));
+    }
     // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 
@@ -325,7 +339,7 @@ TaskStatus Floors::TrackAdditions(MeshData<Real> *md, MeshData<Real> *md_save)
             tU(b, Ti+2, k, j, i) = U(b, m_u.U2, k, j, i) - U_save(b, m_u.U2, k, j, i);
             tU(b, Ti+3, k, j, i) = U(b, m_u.U3, k, j, i) - U_save(b, m_u.U3, k, j, i);
         });
-    Kokkos::Profiling::popRegion(); // Task_WeightedSumDataFace
+    Kokkos::Profiling::popRegion(); // Task_TrackAdditions
     return TaskStatus::complete;
 }
 

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -87,17 +87,17 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     params.Add("frame", frame);
 
     // New inverter w/recovery only supports normal frame floors. Yell about it, but allow overriding
-    if (pin->DoesBlockExist("inverter") &&
-        pin->GetString("inverter", "type") == "kastaun" &&
-        frame != InjectionFrame::normal_kastaun) {
-        if (!pin->GetOrAddBoolean("floors", "allow_unsafe", false)) {
-            std::cout << "With version 2025.10, KHARMA dramatically changed how floors are applied.\n"
-                      << "The resulting algorithm is much more stable, but requires that floors be applied in the normal observer frame.\n"
-                      << "Consider using the <floors> parameters from pars/tori_3d/mad.par.\n"
-                      << "If you know what you're doing, set floors/allow_unsafe=true";
-            throw std::runtime_error("Unsafe floors requested without override");
-        }
-    }
+    // if (pin->DoesBlockExist("inverter") &&
+    //     pin->GetString("inverter", "type") == "kastaun" &&
+    //     frame != InjectionFrame::normal_kastaun) {
+    //     if (!pin->GetOrAddBoolean("floors", "allow_unsafe", false)) {
+    //         std::cerr << "With version 2025.10, KHARMA dramatically changed how floors are applied.\n"
+    //                   << "The resulting algorithm is much more stable, but requires that floors be applied in the normal observer frame.\n"
+    //                   << "Consider using the <floors> parameters from pars/tori_3d/mad.par.\n"
+    //                   << "If you know what you're doing, set floors/allow_unsafe=true";
+    //         throw std::runtime_error("Unsafe floors requested without override");
+    //     }
+    // }
 
     // Switch points for "mixed" frames
     // TODO no-ops under new floors

--- a/kharma/floors/floors.cpp
+++ b/kharma/floors/floors.cpp
@@ -120,9 +120,17 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     else
         params.Add("prescription_inner", MakePrescriptionInner(pin, MakePrescription(pin)), "floors");
 
+    // All of these are now the same option: disable the *call* only.
+    // This lets us assume that the floors package is loaded, which is convenient many places
+    bool floors_on_default = !pin->GetOrAddBoolean("floors", "disable_floors", false);
+    bool floors_on = pin->GetOrAddBoolean("floors", "on", floors_on_default);
     // Sometimes we want the floors package, but don't want to apply anything, for tests
-    bool disable_call = pin->GetOrAddBoolean("floors", "disable_call", false);
+    bool disable_call = pin->GetOrAddBoolean("floors", "disable_call", !floors_on);
     params.Add("disable_call", disable_call);
+
+    // Track all conserved variable changes not produced by fluxes
+    bool track_additions = pin->GetOrAddBoolean("floors", "track_additions", false);
+    params.Add("track_additions", track_additions);
 
     // These preserve floor values between the "mark" pass and the actual floor application
     // We need them even if floors are disabled, to apply initial values based on some prescription
@@ -137,6 +145,16 @@ std::shared_ptr<KHARMAPackage> Floors::Initialize(ParameterInput *pin, std::shar
     // When not using UtoP, we still need a "dummy" copy of pflag to write the post-flooring flag to
     m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Overridable});
     pkg->AddField("pflag", m);
+
+    if (track_additions) {
+        // Track total additions to conserved variables
+        // TODO add primitive versions, advect as passives
+        pkg->AddField("Floors.rhou0add", m);
+        std::vector<int> s_4v({4});
+        m = Metadata({Metadata::Real, Metadata::Cell, Metadata::Derived, Metadata::OneCopy}, s_4v);
+        pkg->AddField("Floors.Tadd", m);
+        // TODO(CEP) Maybe also want Floors.floorUadd, etc etc, for understanding the breakdown...
+    }
 
     // Don't actually call the usual floor function if we're using normal frame w/Kastaun,
     // floors will be applied during the inversion call.
@@ -283,6 +301,32 @@ TaskStatus Floors::ApplyGRMHDFloors(MeshData<Real> *md, IndexDomain domain)
     } else {
         throw std::invalid_argument("Floors for requested frame not implemented!");
     }
+}
+
+TaskStatus Floors::TrackAdditions(MeshData<Real> *md, MeshData<Real> *md_save)
+{
+    Kokkos::Profiling::pushRegion("Task_TrackAdditions");
+    PackIndexMap cons_map, tracks_map;
+    const auto &U = md->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved}, cons_map);
+    const auto &U_save = md_save->PackVariables(std::vector<MetadataFlag>{Metadata::Conserved});
+    const VarMap m_u(cons_map, true);
+
+    const auto &tU = md->PackVariables(std::vector<std::string>{"Floors.rhou0add","Floors.Tadd"}, tracks_map);
+    const int rhou0i = tracks_map["Floors.rhou0add"].first;
+    const int Ti = tracks_map["Floors.Tadd"].first;
+
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "TrackAdditions", DevExecSpace(), 0, U.GetDim(5) - 1, 
+            0, U.GetDim(3) - 1, 0, U.GetDim(2) - 1, 0, U.GetDim(1) - 1,
+        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+            tU(b, rhou0i, k, j, i) = U(b, m_u.RHO, k, j, i) - U_save(b, m_u.RHO, k, j, i);
+            tU(b, Ti+0, k, j, i) = U(b, m_u.UU, k, j, i) - U_save(b, m_u.UU, k, j, i);
+            tU(b, Ti+1, k, j, i) = U(b, m_u.U1, k, j, i) - U_save(b, m_u.U1, k, j, i);
+            tU(b, Ti+2, k, j, i) = U(b, m_u.U2, k, j, i) - U_save(b, m_u.U2, k, j, i);
+            tU(b, Ti+3, k, j, i) = U(b, m_u.U3, k, j, i) - U_save(b, m_u.U3, k, j, i);
+        });
+    Kokkos::Profiling::popRegion(); // Task_WeightedSumDataFace
+    return TaskStatus::complete;
 }
 
 TaskStatus Floors::PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md)

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -41,6 +41,7 @@
 #include "grmhd_functions.hpp"
 #include "emhd.hpp"
 #include "reductions.hpp"
+#include <limits>
 
 namespace Floors {
 
@@ -62,10 +63,8 @@ static constexpr int KTOT = 2048;
 static constexpr int GEOM_RHO_FLUX = 4096;
 static constexpr int GEOM_U_FLUX = 8192;
 // Yet more flags for floors hit during inversion
-static constexpr int INVERTER_RHO = 16384;
-static constexpr int INVERTER_U = 32768;
-static constexpr int INVERTER_GAMMA = 65536;
-static constexpr int INVERTER_U_MAX = 131072;
+static constexpr int FIXUP_MOMENTUM = 16384;
+static constexpr int FIXUP_ENERGY = 32768;
 // Lowest flag value. Needed for combining floor and other return flags
 static constexpr int MINIMUM = GEOM_RHO;
 
@@ -83,10 +82,8 @@ static const std::map<int, std::string> flag_names = {
     {KTOT, "ENTROPY"},
     {GEOM_RHO_FLUX, "GEOM_RHO_ON_RECON"},
     {GEOM_U_FLUX, "GEOM_U_ON_RECON"},
-    {INVERTER_RHO, "GEOM_RHO_ON_INVERT"},
-    {INVERTER_U, "GEOM_U_ON_INVERT"},
-    {INVERTER_GAMMA, "GAMMA_ON_INVERT"},
-    {INVERTER_U_MAX, "U_MAX_ON_INVERT"}
+    {FIXUP_MOMENTUM, "MOMENTUM_FIXUP"},
+    {FIXUP_ENERGY, "ENERGY_FIXUP"}
 };
 }
 
@@ -146,20 +143,20 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
     p.r_char = pin->GetOrAddReal(block, "r_char", 10);
 
     // Floors vs magnetic field.  Most commonly hit & most temperamental
-    p.bsq_over_rho_max = pin->GetOrAddReal(block, "bsq_over_rho_max", 1e20);
-    p.bsq_over_u_max = pin->GetOrAddReal(block, "bsq_over_u_max", 1e20);
+    p.bsq_over_rho_max = pin->GetOrAddReal(block, "bsq_over_rho_max", std::numeric_limits<Real>::max());
+    p.bsq_over_u_max = pin->GetOrAddReal(block, "bsq_over_u_max", std::numeric_limits<Real>::max());
 
     // Limit temperature or entropy, optionally by siphoning off extra rather
     // than by adding material.
-    p.u_over_rho_max = pin->GetOrAddReal(block, "u_over_rho_max", 1e20);
-    p.ktot_max = pin->GetOrAddReal(block, "ktot_max", 1e20);
+    p.u_over_rho_max = pin->GetOrAddReal(block, "u_over_rho_max", std::numeric_limits<Real>::max());
+    p.ktot_max = pin->GetOrAddReal(block, "ktot_max", std::numeric_limits<Real>::max());
     p.temp_adjust_u = pin->GetOrAddBoolean(block, "temp_adjust_u", false);
     // Adjust electron entropy values when applying density floors to conserve
     // internal energy, as in Ressler+ but not more recent implementations
     p.adjust_k = pin->GetOrAddBoolean(block, "adjust_k", true);
 
     // Limit the fluid Lorentz factor gamma
-    p.gamma_max = pin->GetOrAddReal(block, "gamma_max", 50.);
+    p.gamma_max = pin->GetOrAddReal(block, "gamma_max", std::numeric_limits<Real>::max());
 
     p.radius_dependent_floors = pin->GetOrAddBoolean("floors", "radius_dependent_floors", false); 
     p.floors_switch_r = pin->GetOrAddReal("floors", "floors_switch_r", 50.);
@@ -176,7 +173,7 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
  */
 inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescription p_outer, std::string block="floors_inner")
 {
-    // TODO(BSP) I wonder if there's an easier way to "set if parameter exists" from pin, that would be broadly useful
+    // TODO(CEP) I wonder if there's an easier way to "set if parameter exists" from pin, that would be broadly useful
     Prescription p_inner;
 
     // Floor parameters

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -283,6 +283,12 @@ TaskStatus ApplyInitialFloors(ParameterInput *pin, MeshBlockData<Real> *mbd, Ind
 int CountFFlags(MeshData<Real> *md);
 
 /**
+ * Record any changes in conserved variables since the application of flux divergence + geometric sources
+ * Intended as a way to track *all* changes (floors, fixups, boundaries, etc.)
+ */
+TaskStatus TrackAdditions(MeshData<Real> *md, MeshData<Real> *md_save);
+
+/**
  * Print a summary of floors which were hit
  */
 TaskStatus PostStepDiagnostics(const SimTime& tm, MeshData<Real> *md);

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -46,30 +46,46 @@
 namespace Floors {
 
 namespace FFlag {
+
+// To avoid numerical typos
+template <typename T>
+constexpr T ipow(T num, unsigned int pow)
+{
+    return (pow >= sizeof(unsigned int)*8) ? 0 :
+        pow == 0 ? 1 : num * ipow(num, pow-1);
+}
+
 // Floor codes are non-exclusive, so it makes little sense to use an enum
 // Instead, we use bitflags, starting high enough that we can stick the pflag in the bottom 5 bits
 // See floors.hpp for explanations of the flags
 // This is the namespaced, typed equivalent of #define
-static constexpr int GEOM_RHO = 32;
-static constexpr int GEOM_U = 64;
-static constexpr int B_RHO = 128;
-static constexpr int B_U = 256;
-static constexpr int TEMP = 512;
-static constexpr int GAMMA = 1024;
-static constexpr int KTOT = 2048;
+static constexpr int GEOM_RHO = ipow(2,6);
+static constexpr int GEOM_U   = ipow(2,7);
+static constexpr int B_RHO    = ipow(2,8);
+static constexpr int B_U      = ipow(2,9);
+static constexpr int TEMP     = ipow(2,10);
+static constexpr int GAMMA    = ipow(2,11);
+static constexpr int KTOT     = ipow(2,12);
 // Separate flags for when the floors are applied after reconstruction.
 // Not yet used, as this will likely have some speed penalty paid even if
 // the flags aren't written
-static constexpr int GEOM_RHO_FLUX = 4096;
-static constexpr int GEOM_U_FLUX = 8192;
+static constexpr int GEOM_RHO_FLUX = ipow(2,13);
+static constexpr int GEOM_U_FLUX   = ipow(2,14);
 // Yet more flags for floors hit during inversion
-static constexpr int FIXUP_MOMENTUM = 16384;
-static constexpr int FIXUP_ENERGY = 32768;
-static constexpr int FIXUP_MOMENTUM_FAILED = 65536;
-static constexpr int FIXUP_MOMENTUM_GAMMA = 131072;
-static constexpr int FIXUP_MOMENTUM_RANGE = 262144;
-static constexpr int FIXUP_RHO_DIRECT = 524288;
-static constexpr int FIXUP_U_DIRECT = 1048576;
+// Energy had to be augmented
+static constexpr int FIXUP_ENERGY = ipow(2,15);
+// Attempting extra T00 -> velocity
+static constexpr int FIXUP_VEL        = ipow(2,16);
+static constexpr int FIXUP_VEL_FAILED = ipow(2,17);
+static constexpr int FIXUP_VEL_GAMMA  = ipow(2,18);
+static constexpr int FIXUP_VEL_RANGE  = ipow(2,19);
+// Attempting extra T00 -> internal energy
+static constexpr int FIXUP_U        = ipow(2,20);
+static constexpr int FIXUP_U_FAILED = ipow(2,21);
+static constexpr int FIXUP_U_RANGE  = ipow(2,22);
+// Direct last-ditch fixups
+static constexpr int FIXUP_RHO_DIRECT = ipow(2,23);
+static constexpr int FIXUP_U_DIRECT   = ipow(2,24);
 // Lowest flag value. Needed for combining floor and other return flags
 static constexpr int MINIMUM = GEOM_RHO;
 
@@ -78,22 +94,25 @@ static constexpr int MINIMUM = GEOM_RHO;
 // 1. prettier names?
 // 2. What deep majicks would allow this to be constexpr?
 static const std::map<int, std::string> flag_names = {
-    {GEOM_RHO, "GEOM_RHO"},
-    {GEOM_U, "GEOM_U"},
-    {B_RHO, "B_RHO"},
-    {B_U, "B_U"},
-    {GAMMA, "GAMMA"},
-    {TEMP, "TEMPERATURE"},
-    {KTOT, "ENTROPY"},
-    {GEOM_RHO_FLUX, "GEOM_RHO_ON_RECON"},
-    {GEOM_U_FLUX, "GEOM_U_ON_RECON"},
-    {FIXUP_MOMENTUM, "MOMENTUM_FIXUP"},
-    {FIXUP_ENERGY, "ENERGY_FIXUP"},
-    {FIXUP_MOMENTUM_FAILED, "ENERGY_FIXUP_FROM_SOLVE_FAIL"},
-    {FIXUP_MOMENTUM_GAMMA, "ENERGY_FIXUP_FOUND_BAD_GAMMA"},
-    {FIXUP_MOMENTUM_RANGE, "ENERGY_FIXUP_BAD_RANGE"},
-    {FIXUP_RHO_DIRECT, "ENERGY_FIXUP_BAD_RHO"},
-    {FIXUP_U_DIRECT, "ENERGY_FIXUP_BAD_U"}
+    {GEOM_RHO, "GEOM_RHO: Geometric floor on density"},
+    {GEOM_U,   "GEOM_U: Geometric floor on internal energy"},
+    {B_RHO,    "B_RHO: Ceiling on plasma sigma"},
+    {B_U,      "B_U: Ceiling on plasma beta"},
+    {GAMMA,    "GAMMA: Direct limit on Lorentz factor"},
+    {TEMP,     "TEMP: Temperature ceiling"},
+    {KTOT,     "KTOT: Entropy ceiling"},
+    {GEOM_RHO_FLUX,  "GEOM_RHO_FLUX: Geometric rho post-reconstruction"},
+    {GEOM_U_FLUX,    "GEOM_U_FLUX: Geometric u post-reconstruction"},
+    {FIXUP_ENERGY,   "FIXUP_ENERGY: Total energy backstop"},
+    {FIXUP_VEL,   "FIXUP_VEL: Internal energy backstop, recovered some velocity"},
+    {FIXUP_VEL_FAILED,  "FIXUP_VEL_FAILED: Velocity recovery failed"},
+    {FIXUP_VEL_GAMMA,   "FIXUP_VEL_GAMMA:  Vel recovery failure: speed would increase"},
+    {FIXUP_VEL_RANGE,   "FIXUP_VEL_RANGE:  Vel recovery failure: solution out of range"},
+    {FIXUP_U,   "FIXUP_VEL: Internal energy backstop, recovered some internal energy"},
+    {FIXUP_U_FAILED,  "FIXUP_VEL_FAILED: Energy recovery failed"},
+    {FIXUP_U_RANGE,   "FIXUP_VEL_RANGE:  E recovery failure: solution out of range"},
+    {FIXUP_RHO_DIRECT, "FIXUP_RHO_DIRECT: Last-ditch fluid-frame rho"},
+    {FIXUP_U_DIRECT, "FIXUP_U_DIRECT: Last-ditch fluid-frame u"}
 };
 }
 

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -65,6 +65,11 @@ static constexpr int GEOM_U_FLUX = 8192;
 // Yet more flags for floors hit during inversion
 static constexpr int FIXUP_MOMENTUM = 16384;
 static constexpr int FIXUP_ENERGY = 32768;
+static constexpr int FIXUP_MOMENTUM_FAILED = 65536;
+static constexpr int FIXUP_MOMENTUM_GAMMA = 131072;
+static constexpr int FIXUP_MOMENTUM_RANGE = 262144;
+static constexpr int FIXUP_RHO_DIRECT = 524288;
+static constexpr int FIXUP_U_DIRECT = 1048576;
 // Lowest flag value. Needed for combining floor and other return flags
 static constexpr int MINIMUM = GEOM_RHO;
 
@@ -83,7 +88,12 @@ static const std::map<int, std::string> flag_names = {
     {GEOM_RHO_FLUX, "GEOM_RHO_ON_RECON"},
     {GEOM_U_FLUX, "GEOM_U_ON_RECON"},
     {FIXUP_MOMENTUM, "MOMENTUM_FIXUP"},
-    {FIXUP_ENERGY, "ENERGY_FIXUP"}
+    {FIXUP_ENERGY, "ENERGY_FIXUP"},
+    {FIXUP_MOMENTUM_FAILED, "ENERGY_FIXUP_FROM_SOLVE_FAIL"},
+    {FIXUP_MOMENTUM_GAMMA, "ENERGY_FIXUP_FOUND_BAD_GAMMA"},
+    {FIXUP_MOMENTUM_RANGE, "ENERGY_FIXUP_BAD_RANGE"},
+    {FIXUP_RHO_DIRECT, "ENERGY_FIXUP_BAD_RHO"},
+    {FIXUP_U_DIRECT, "ENERGY_FIXUP_BAD_U"}
 };
 }
 

--- a/kharma/floors/floors.hpp
+++ b/kharma/floors/floors.hpp
@@ -173,7 +173,7 @@ inline Prescription MakePrescription(parthenon::ParameterInput *pin, std::string
  */
 inline Prescription MakePrescriptionInner(parthenon::ParameterInput *pin, Prescription p_outer, std::string block="floors_inner")
 {
-    // TODO(CEP) I wonder if there's an easier way to "set if parameter exists" from pin, that would be broadly useful
+    // TODO(BSP) I wonder if there's an easier way to "set if parameter exists" from pin, that would be broadly useful
     Prescription p_inner;
 
     // Floor parameters

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -506,4 +506,36 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, c
     return fflag;
 }
 
+template<typename Global>
+KOKKOS_INLINE_FUNCTION int determine_geo_floors(const GRCoordinates& G, Global& P, const VarMap& m,
+                                            const Real& gam, const int& k, const int& j, const int& i,
+                                            const Floors::Prescription& floors, const Floors::Prescription& floors_inner,
+                                            Real& rhoflr_geom, Real& uflr_geom,
+                                            const Loci loc=Loci::center)
+{
+    // Choose our floor scheme
+    const Floors::Prescription& myfloors = (floors.radius_dependent_floors
+                                            && G.r(0, j, i) < floors.floors_switch_r) ? floors_inner : floors;
+
+    // Apply only the geometric floors
+    if(G.coords.is_spherical()) {
+        const GReal r = G.r(0, j, i);
+        // r_char sets more aggressive floor close to EH but backs off
+        Real rhoscal = (myfloors.use_r_char) ? 1. / ((r*r) * (1 + r / myfloors.r_char)) : 1. / m::sqrt(r*r*r);
+        rhoflr_geom = m::max(myfloors.rho_min_geom * rhoscal, myfloors.rho_min_const);
+        uflr_geom   = m::max(myfloors.u_min_geom * m::pow(rhoscal, gam), myfloors.u_min_const);
+    } else {
+        rhoflr_geom = myfloors.rho_min_const;
+        uflr_geom   = myfloors.u_min_const;
+    }
+
+    // TODO(CEP) really needed?  Not used in the only call
+    int fflag = 0;
+    // Record all the floors that were hit, using bitflags
+    // Record Geometric floor hits
+    fflag |= (rhoflr_geom > P(m.RHO, k, j, i)) * FFlag::GEOM_RHO_FLUX;
+    fflag |= (uflr_geom > P(m.UU, k, j, i)) * FFlag::GEOM_U_FLUX;
+    return fflag;
+}
+
 } // Floors

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -93,7 +93,7 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
 
     // Calculate the different floor values in play:
     // 1. Geometric hard floors, not based on fluid relationships
-    // TODO(CEP) can this be cached if it's slow?
+    // TODO(BSP) can this be cached if it's slow?
     Real rhoflr_geom, uflr_geom;
     if(G.coords.is_spherical()) {
         const GReal r = G.r(k, j, i);
@@ -410,8 +410,8 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_kastaun>(FLOOR_ON
 
 //         SPACELOOP(ii) P(m_p.U1+ii, k, j, i) = z * (Spar[ii] / (rhoh_min * z * z) +
 //                                                 Sperp[ii] / (rhoh_min * z * z + Bsq));
-//         // TODO(CEP) record when solve fails?
-//         // TODO(CEP) Fallthrough
+//         // TODO(BSP) record when solve fails?
+//         // TODO(BSP) Fallthrough
 //     }
 // }
 

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -93,7 +93,7 @@ KOKKOS_INLINE_FUNCTION int determine_floors(const GRCoordinates& G, const Variab
 
     // Calculate the different floor values in play:
     // 1. Geometric hard floors, not based on fluid relationships
-    // TODO(BSP) can this be cached if it's slow?
+    // TODO(CEP) can this be cached if it's slow?
     Real rhoflr_geom, uflr_geom;
     if(G.coords.is_spherical()) {
         const GReal r = G.r(k, j, i);
@@ -285,7 +285,7 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_onedw>(FLOOR_ONE_
 
     // Recover primitive variables from conserved versions
     return Inverter::u_to_p<Inverter::Type::onedw>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                    8, 1e-8, false);
+                                                    8, 1e-8);
 }
 
 template<>
@@ -297,9 +297,9 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_kastaun>(FLOOR_ON
     const Real u_add      = m::max(0., uflr_max - P(m_p.UU, k, j, i));
     // We compute rho u^0 and T^00 using the existing velocities to determine Lorentz factor.
     // This is a guaranteed overestimate of the fluid contributions to these quantities
-    const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
+    //const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
     // Alternatively, add less than will produce our floored values
-    //const Real uvec[NVEC] = {0.};
+    const Real uvec[NVEC] = {0.};
     const Real B[NVEC] = {0.};
 
     // 2. Calculate the increase in conserved mass/energy corresponding to the new material.
@@ -311,10 +311,109 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::normal_kastaun>(FLOOR_ON
     U(m_u.RHO, k, j, i) += rho_ut;
     U(m_u.UU, k, j, i)  += T[0]; // Actually T^0_0 + rho u^t
 
-    // Recover new primitive variables.  Use Kastaun with safe parameters so we don't fail often
+    // Recover new primitive variables
     return Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                     25, 1e-12, true);
+                                                     25, 1e-14);
 }
+
+// KOKKOS_INLINE_FUNCTION rho_to_slow()
+// {
+
+//     // No floors/floors_inner distinction, TODO?
+//     const Real rhoh_denom_max = SQR(floors.gamma_max) *
+//                                 m::sqrt(1 - 1 / SQR(floors.gamma_max));
+
+//     //const Real rho = std::max(P(m_p.RHO, k, j, i), rhoflr_max);
+//     //const Real u = std::max(P(m_p.UU, k, j, i), uflr_max);
+//     const Real rho = P(m_p.RHO, k, j, i);
+//     const Real u = P(m_p.UU, k, j, i);
+//     const Real rhoh = rho + gam * u;
+//     const Real alpha  = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
+//     const Real a_over_g = alpha / G.gdet(Loci::center, j, i);
+//     Real Scov[3] = {U(m_u.U1, k, j, i) * a_over_g,
+//                     U(m_u.U2, k, j, i) * a_over_g,
+//                     U(m_u.U3, k, j, i) * a_over_g};
+//     Real Scon[3];
+//     Real gupper[GR_DIM][GR_DIM], glower[GR_DIM][GR_DIM];
+//     G.gcon(Loci::center, j, i, gupper);
+//     G.gcov(Loci::center, j, i, glower);
+//     Scon[0] = ((gupper[1][1] - gupper[0][1]*gupper[0][1]/gupper[0][0])*Scov[0] +
+//                 (gupper[1][2] - gupper[0][1]*gupper[0][2]/gupper[0][0])*Scov[1] +
+//                 (gupper[1][3] - gupper[0][1]*gupper[0][3]/gupper[0][0])*Scov[2]);
+
+//     Scon[1] = ((gupper[2][1] - gupper[0][2]*gupper[0][1]/gupper[0][0])*Scov[0] +
+//                 (gupper[2][2] - gupper[0][2]*gupper[0][2]/gupper[0][0])*Scov[1] +
+//                 (gupper[2][3] - gupper[0][2]*gupper[0][3]/gupper[0][0])*Scov[2]);
+
+//     Scon[2] = ((gupper[3][1] - gupper[0][3]*gupper[0][1]/gupper[0][0])*Scov[0] +
+//                 (gupper[3][2] - gupper[0][3]*gupper[0][2]/gupper[0][0])*Scov[1] +
+//                 (gupper[3][3] - gupper[0][3]*gupper[0][3]/gupper[0][0])*Scov[2]);
+//     Real Ssq = 0.0;
+//     SPACELOOP(ii) Ssq += Scon[ii] * Scov[ii];
+
+//     const Real rhoh_min = m::sqrt(Ssq) / rhoh_denom_max;
+//     if (rhoh < rhoh_min) {
+//         fflagl |= Floors::FFlag::INVERTER_GAMMA;
+//         // Proportional increases to rho,u preserve temperature
+//         // TODO could play with this ratio
+//         P(m_p.RHO, k, j, i) = rho * rhoh_min/rhoh;
+//         P(m_p.UU, k, j, i) = u * rhoh_min/rhoh;
+
+//         Real Bvec[] = {0.0, 0.0, 0.0};
+//         SPACELOOP(ii) Bvec[ii] = P(m_u.B1 + ii, k, j, i) * alpha;
+//         Real BdotS = 0.;
+//         SPACELOOP(ii) BdotS += Bvec[ii] * Scov[ii];
+//         Real Bsq = 0.;
+//         SPACELOOP2(ii, jj) Bsq += glower[ii + 1][jj + 1] * Bvec[ii] * Bvec[jj];
+//         Real Sparsq = BdotS * BdotS / Bsq;
+//         Real Sperpsq = Ssq - Sparsq;
+//         Real Spar[3], Sperp[3];
+//         SPACELOOP(ii) Spar[ii] = BdotS * Bvec[ii] / Bsq;
+//         SPACELOOP(ii) Sperp[ii] = Scon[ii] - Spar[ii];
+
+//         auto func_W = [&] (Real W) {
+//             const Real rhohW2 = rhoh_min * W * W;
+//             return Sparsq / SQR(rhohW2) +
+//             Sperpsq / SQR(rhohW2 + Bsq) +
+//             1. / (W * W) - 1.;
+//         };
+
+//         Real zm = 1.;
+//         Real zp = floors.gamma_max;
+//         Real z = 0.5*(zm + zp);
+
+//         Real fm = func_W(zm);
+//         Real fp = func_W(zp);
+
+//         bool vel_solve_failed = false;
+//         for (int iter = 0; iter < 30; ++iter) {
+//             z =  (zm*fp - zp*fm) / (fp-fm);  // linear interpolation to point f(z)=0
+//             Real f = func_W(z);
+//             // Quit if convergence reached
+//             if ((m::abs(f) < 1e-8) || (m::abs(zm-zp) < 1e-10)) {
+//                 // Return failure if 
+//                 vel_solve_failed = m::abs(f) > 1e-8;
+//                 break;
+//             }
+//             // assign zm-->zp if root bracketed by [z,zp]
+//             if (f*fp < 0.0) {
+//                 zm = zp;
+//                 fm = fp;
+//                 zp = z;
+//                 fp = f;
+//             } else {  // assign zp-->z if root bracketed by [zm,z]
+//                 fm = 0.5*fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
+//                 zp = z;
+//                 fp = f;
+//             }
+//         }
+
+//         SPACELOOP(ii) P(m_p.U1+ii, k, j, i) = z * (Spar[ii] / (rhoh_min * z * z) +
+//                                                 Sperp[ii] / (rhoh_min * z * z + Bsq));
+//         // TODO(CEP) record when solve fails?
+//         // TODO(CEP) Fallthrough
+//     }
+// }
 
 /**
  * Apply just the geometric floors to a set of local primitives.

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -455,6 +455,12 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Local& P, co
 
     P(m.RHO) += m::max(0., rhoflr_geom - P(m.RHO));
     P(m.UU)  += m::max(0., uflr_geom - P(m.UU));
+    // These are a last-ditch *after* the usual floor applications.  Keep them stable
+    if (fflag) {
+        P(m.U1) = 0.;
+        P(m.U2) = 0.;
+        P(m.U3) = 0.;
+    }
 
     return fflag;
 }
@@ -490,6 +496,12 @@ KOKKOS_INLINE_FUNCTION int apply_geo_floors(const GRCoordinates& G, Global& P, c
 
     P(m.RHO, k, j, i) += m::max(0., rhoflr_geom - P(m.RHO, k, j, i));
     P(m.UU, k, j, i)  += m::max(0., uflr_geom - P(m.UU, k, j, i));
+    // These are a last-ditch *after* the usual floor applications.  Keep them stable
+    if (fflag) {
+        P(m.U1, k, j, i) = 0.;
+        P(m.U2, k, j, i) = 0.;
+        P(m.U3, k, j, i) = 0.;
+    }
 
     return fflag;
 }

--- a/kharma/floors/floors_functions.hpp
+++ b/kharma/floors/floors_functions.hpp
@@ -64,6 +64,7 @@ KOKKOS_INLINE_FUNCTION void apply_ceilings(const GRCoordinates& G, const Variabl
     Real u_over_rho = P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
 
     // 1. Limit gamma with respect to normal observer
+    // TODO ADJUST RHO
     if (gamma > myfloors.gamma_max) {
         Real f = m::sqrt((SQR(myfloors.gamma_max) - 1.) / (SQR(gamma) - 1.));
         VLOOP P(m_p.U1+v, k, j, i) *= f;
@@ -179,7 +180,7 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::fluid>(FLOOR_ONE_ARGS)
 {
     P(m_p.RHO, k, j, i) += m::max(0., rhoflr_max - P(m_p.RHO, k, j, i));
     P(m_p.UU, k, j, i)  += m::max(0., uflr_max - P(m_p.UU, k, j, i));
-    return 0;
+    return -1;
 }
 
 template<>
@@ -253,7 +254,7 @@ KOKKOS_INLINE_FUNCTION int apply_floors<InjectionFrame::drift>(FLOOR_ONE_ARGS)
     P(m_p.U1, k, j, i) = Dtmp.ucon[1] + (beta[1] * Dtmp.ucon[0]);
     P(m_p.U2, k, j, i) = Dtmp.ucon[2] + (beta[2] * Dtmp.ucon[0]);
     P(m_p.U3, k, j, i) = Dtmp.ucon[3] + (beta[3] * Dtmp.ucon[0]);
-    return 0;
+    return -1;
 }
 
 // There's a way to avoid code duplication here, but it imposes more template madness

--- a/kharma/floors/floors_impl.hpp
+++ b/kharma/floors/floors_impl.hpp
@@ -111,13 +111,13 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                                         U(b), m_u);
                 }
 
-                // Record the pflag if we applied normal floors
+                // Record the pflag if we applied normal floors -- successful or not
                 if (pflag_l >= 0) pflag(b, 0, k, j, i) = pflag_l;
 
                 // Apply ceilings *after* floors, to make the temperature ceiling better-behaved
                 apply_ceilings(G, P(b), m_p, gam, k, j, i, floors, floors_inner, U(b), m_u);
 
-                // P->U *if we inverted correctly* (or didn't invert)
+                // P->U if we inverted *correctly* (or didn't invert)
                 if (pflag_l <= 0)
                     Flux::p_to_u_mhd(G, P(b), m_p, emhd_params, gam, k, j, i, U(b), m_u, Loci::center);
             }

--- a/kharma/floors/floors_impl.hpp
+++ b/kharma/floors/floors_impl.hpp
@@ -73,10 +73,11 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
     const IndexRange block = IndexRange{0, P.GetDim(5) - 1};
     pmb0->par_for("apply_floors", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
         KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
-            if (static_cast<int>(fflag(b, 0, k, j, i))) {
+            if (static_cast<int>(fflag(b, 0, k, j, i)) || static_cast<int>(pflag(b, 0, k, j, i))) {
                 const auto& G = P.GetCoords(b);
-                // apply_floors can involve another U_to_P call.  Hide the pflag in bottom 5 bits and retrieve both
-                int pflag_l = 0;
+                // apply_floors can involve another U_to_P call, capture that flag
+                // this is the default return for "no inversion"
+                int pflag_l = -1;
                 // These would be constexpr except Nvidia doesn't like lambda-capture in constexpr ifs
                 if (frame == InjectionFrame::mixed_fluid_normal) {
                     if (G.r(k, j, i) > switch_r) {
@@ -110,15 +111,15 @@ TaskStatus ApplyFloorsInFrame(MeshData<Real> *md, IndexDomain domain)
                                         U(b), m_u);
                 }
 
-                // Record the pflag if nonzero, that is, if *either* the initial inversion or
-                // post-floor inversion failed.
-                if (pflag_l) pflag(b, 0, k, j, i) = pflag_l;
+                // Record the pflag if we applied normal floors
+                if (pflag_l >= 0) pflag(b, 0, k, j, i) = pflag_l;
 
                 // Apply ceilings *after* floors, to make the temperature ceiling better-behaved
                 apply_ceilings(G, P(b), m_p, gam, k, j, i, floors, floors_inner, U(b), m_u);
 
-                // P->U for any modified zones
-                Flux::p_to_u_mhd(G, P(b), m_p, emhd_params, gam, k, j, i, U(b), m_u, Loci::center);
+                // P->U *if we inverted correctly* (or didn't invert)
+                if (pflag_l <= 0)
+                    Flux::p_to_u_mhd(G, P(b), m_p, emhd_params, gam, k, j, i, U(b), m_u, Loci::center);
             }
         }
     );

--- a/kharma/flux/flux.cpp
+++ b/kharma/flux/flux.cpp
@@ -181,8 +181,9 @@ std::shared_ptr<KHARMAPackage> Flux::Initialize(ParameterInput *pin, std::shared
     params.Add("use_fofc", use_fofc);
 
     if (use_fofc) {
-        if (!packages->AllPackages().count("Floors"))
-            throw std::runtime_error("First-order Flux Corrections cannot be used without floors!");
+        // TODO reintroduce this check later when we've actually loaded floors?
+        // if (!packages->AllPackages().count("Floors"))
+        //     throw std::runtime_error("First-order Flux Corrections cannot be used without floors!");
 
         // FOFC-specific options
         bool use_glf = pin->GetOrAddBoolean("fofc", "use_glf", false);

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -35,6 +35,7 @@
 #include "flux.hpp"
 
 #include "domain.hpp"
+#include "floors_functions.hpp"
 #include "inverter.hpp"
 
 using namespace parthenon;
@@ -52,6 +53,24 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
     auto pflag = guess->PackVariables(std::vector<std::string>{"pflag"});
     auto fofcflag = guess->PackVariables(std::vector<std::string>{"fofcflag"});
 
+    PackIndexMap cons_map, prims_map;
+    std::vector<MetadataFlag> prims_flags = {Metadata::GetUserFlag("Primitive"), Metadata::Cell};
+    std::vector<MetadataFlag> cons_flags = {Metadata::Conserved, Metadata::Cell};
+    const auto& P = guess->PackVariables(prims_flags, prims_map);
+    const auto& U = guess->PackVariablesAndFluxes(cons_flags, cons_map);
+    const VarMap m_u(cons_map, true), m_p(prims_map, false);
+
+    const Real gam = pmb0->packages.Get("GRMHD")->Param<Real>("gamma");
+
+    // Use values from floors package if it's enabled, otherwise any we've been asked to apply
+    const Floors::Prescription floors = pmb0->packages.AllPackages().count("Floors") ?
+                                        pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription") :
+                                        pmb0->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
+    const Floors::Prescription floors_inner = pmb0->packages.AllPackages().count("Floors") ?
+                                        pmb0->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner") :
+                                        pmb0->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
+
+
     // Parameters
     const auto& pars = pmb0->packages.Get("Flux")->AllParams();
     const bool spherical = pmb0->coords.coords.is_spherical();
@@ -67,15 +86,19 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
     const IndexRange3 b = KDomain::GetRange(guess, IndexDomain::entire);
     const IndexRange block = IndexRange{0, fofcflag.GetDim(5) - 1};
     pmb0->par_for("fofc_mark", block.s, block.e, b.ks, b.ke, b.js, b.je, b.is, b.ie,
-        KOKKOS_LAMBDA (const int &b, const int &k, const int &j, const int &i) {
-            const auto& G = fofcflag.GetCoords(b);
+        KOKKOS_LAMBDA (const int &bl, const int &k, const int &j, const int &i) {
+            const auto& G = fofcflag.GetCoords(bl);
             // if cell failed to invert or would call floors...
             // TODO preserve cause in the fofcflag
-            if (static_cast<int>(fflag(b, 0, k, j, i)) || //Inverter::failed(pflag(b, 0, k, j, i)) ||
-                (spherical && G.r(k, j, i) < fofc_radius)) {
-                fofcflag(b, 0, k, j, i) = 1;
+            // If the solve failed, because we reconstructed a
+            // negative or zero internal energy (even after floors!)
+            Real rhomin_geom, umin_geom;
+            determine_geo_floors(G, P(bl), m_p, gam, k, j, i, floors, floors_inner, rhomin_geom, umin_geom);
+            const Real umin = umin_geom;
+            if (Inverter::failed(pflag(bl, 0, k, j, i)) && (P(bl, m_p.UU, k, j, i) < umin)) {
+                fofcflag(bl, 0, k, j, i) = 1;
             } else {
-                fofcflag(b, 0, k, j, i) = 0;
+                fofcflag(bl, 0, k, j, i) = 0;
             }
         }
     );

--- a/kharma/flux/fofc.cpp
+++ b/kharma/flux/fofc.cpp
@@ -55,7 +55,7 @@ TaskStatus Flux::MarkFOFC(MeshData<Real> *guess)
 
     PackIndexMap cons_map, prims_map;
     std::vector<MetadataFlag> prims_flags = {Metadata::GetUserFlag("Primitive"), Metadata::Cell};
-    std::vector<MetadataFlag> cons_flags = {Metadata::Conserved, Metadata::Cell};
+    std::vector<MetadataFlag> cons_flags = {Metadata::WithFluxes, Metadata::Cell};
     const auto& P = guess->PackVariables(prims_flags, prims_map);
     const auto& U = guess->PackVariablesAndFluxes(cons_flags, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
@@ -163,7 +163,7 @@ TaskStatus Flux::FOFC(MeshData<Real> *md, MeshData<Real> *guess)
     // It will be filled according to m_u/cons_map, which does not contain B
     PackIndexMap cons_map, prims_map;
     std::vector<MetadataFlag> prims_flags = {Metadata::GetUserFlag("Primitive"), Metadata::Cell};
-    std::vector<MetadataFlag> cons_flags = {Metadata::Conserved, Metadata::Cell};
+    std::vector<MetadataFlag> cons_flags = {Metadata::WithFluxes, Metadata::Cell};
     const auto& P_all = md->PackVariables(prims_flags, prims_map);
     const auto& U_all = md->PackVariablesAndFluxes(cons_flags, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);

--- a/kharma/flux/get_flux.hpp
+++ b/kharma/flux/get_flux.hpp
@@ -112,7 +112,7 @@ inline TaskStatus GetFlux(MeshData<Real> *md)
     const auto& cmin  = md->PackVariables(std::vector<std::string>{"Flux.cmin"});
 
     const auto& P_all = md->PackVariables(std::vector<MetadataFlag>{Metadata::GetUserFlag("Primitive"), Metadata::Cell}, prims_map);
-    const auto& U_all = md->PackVariablesAndFluxes(std::vector<MetadataFlag>{Metadata::Conserved, Metadata::Cell}, cons_map);
+    const auto& U_all = md->PackVariablesAndFluxes(std::vector<MetadataFlag>{Metadata::WithFluxes, Metadata::Cell}, cons_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
     const auto& Pl_all = md->PackVariables(std::vector<std::string>{"Flux.Pl"});

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -208,7 +208,13 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
         hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T00>, "Egas"));
         hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T01>, "X1_Mom"));
         hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T02>, "X2_Mom"));
-        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T03>, "Ang_Mom"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::mix_T03>, "X3_Mom"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::abs_rhou0>, "AbsMass"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::abs_mix_T00>, "AbsEgas"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::abs_mix_T01>, "AbsX1_Mom"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::abs_mix_T02>, "AbsX2_Mom"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::Total<Reductions::Var::abs_mix_T03>, "AbsX3_Mom"));        
     }
     // TODO these are probably more useful at/within/without certain radii
     if (do_all || KHARMA::FieldIsOutput(pin, "luminosities")) {
@@ -229,7 +235,7 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
             hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::ldot>, "Ldot_5M"));
         }
 
-        // Add event-horizon fluxes by default as a check
+        // Add versions from the in-code fluxes by default as a check
         if (true || do_all || KHARMA::FieldIsOutput(pin, "eh_fluxes_flux")) {
             hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt0<Reductions::Var::mdot_flux>, "Mdot_Flux"));
             hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAtEH<Reductions::Var::mdot_flux>, "Mdot_EH_Flux"));

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -248,6 +248,44 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
             hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumAt5M<Reductions::Var::ldot_flux>, "Ldot_5M_Flux"));
         }
     }
+    // Record all fluid conserved quantities in or out of the domain
+    if (KHARMA::FieldIsOutput(pin, "debug_conservation")) {
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX1<Reductions::Var::Uflux1RHO>, "InnerX1RHO"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX1<Reductions::Var::Uflux1UU>, "InnerX1UU"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX1<Reductions::Var::Uflux1U1>, "InnerX1U1"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX1<Reductions::Var::Uflux1U2>, "InnerX1U2"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX1<Reductions::Var::Uflux1U3>, "InnerX1U3"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX1<Reductions::Var::Uflux1RHO>, "OuterX1RHO"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX1<Reductions::Var::Uflux1UU>, "OuterX1UU"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX1<Reductions::Var::Uflux1U1>, "OuterX1U1"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX1<Reductions::Var::Uflux1U2>, "OuterX1U2"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX1<Reductions::Var::Uflux1U3>, "OuterX1U3"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX2<Reductions::Var::Uflux2RHO>, "InnerX2RHO"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX2<Reductions::Var::Uflux2UU>, "InnerX2UU"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX2<Reductions::Var::Uflux2U1>, "InnerX2U1"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX2<Reductions::Var::Uflux2U2>, "InnerX2U2"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX2<Reductions::Var::Uflux2U3>, "InnerX2U3"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX2<Reductions::Var::Uflux2RHO>, "OuterX2RHO"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX2<Reductions::Var::Uflux2UU>, "OuterX2UU"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX2<Reductions::Var::Uflux2U1>, "OuterX2U1"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX2<Reductions::Var::Uflux2U2>, "OuterX2U2"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX2<Reductions::Var::Uflux2U3>, "OuterX2U3"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX3<Reductions::Var::Uflux3RHO>, "InnerX3RHO"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX3<Reductions::Var::Uflux3UU>, "InnerX3UU"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX3<Reductions::Var::Uflux3U1>, "InnerX3U1"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX3<Reductions::Var::Uflux3U2>, "InnerX3U2"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumInnerX3<Reductions::Var::Uflux3U3>, "InnerX3U3"));
+
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX3<Reductions::Var::Uflux3RHO>, "OuterX3RHO"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX3<Reductions::Var::Uflux3UU>, "OuterX3UU"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX3<Reductions::Var::Uflux3U1>, "OuterX3U1"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX3<Reductions::Var::Uflux3U2>, "OuterX3U2"));
+        hst_vars.emplace_back(parthenon::HistoryOutputVar(UserHistoryOperation::sum, Reductions::SumOuterX3<Reductions::Var::Uflux3U3>, "OuterX3U3"));
+    }
     // add callbacks for HST output to the Params struct, identified by the `hist_param_key`
     pkg->AddParam<>(parthenon::hist_param_key, hst_vars);
 

--- a/kharma/grmhd/grmhd.cpp
+++ b/kharma/grmhd/grmhd.cpp
@@ -544,7 +544,7 @@ void CancelBoundaryU3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                 parthenon::par_for_inner(member, bi.ks, bi.ke,
                     [&](const int& k) {
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              25, 1e-12, false);
+                                                              25, 1e-12);
                     }
                 );
             }
@@ -641,7 +641,7 @@ void CancelBoundaryT3(MeshBlockData<Real> *rc, IndexDomain domain, bool coarse)
                     U(m_u.U3, k, jf, i) -= T3_avg;
                     // Recover primitive GRMHD variables from our modified U
                     Inverter::u_to_p<Inverter::Type::kastaun>(G, U, m_u, gam, k, jf, i, P, m_p, Loci::center,
-                                                              25, 1e-12, false);
+                                                              25, 1e-12);
                     // Floor them
                     int fflag = Floors::apply_geo_floors(G, P, m_p, gam, k, jf, i, floors, floors, Loci::center);
                     // Recalculate U on anything we floored

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -54,9 +54,9 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     // Bail if we're not enabled
     const bool fix_average = pmb->packages.Get("Inverter")->Param<bool>("fix_average_neighbors");
     const bool fix_atmo = pmb->packages.Get("Inverter")->Param<bool>("fix_atmosphere");
-    const bool velrecover = pmb->packages.Get("Inverter")->Param<bool>("vel_recovery");
+    const bool backstop = pmb->packages.Get("Inverter")->Param<bool>("backstop");
     // Velocity recovery replaces other fixups (TODO(BSP) should it always?)
-    if (velrecover) return Inverter::VelRecover(rc);
+    if (backstop) return Inverter::Backstop(rc);
     if (!fix_average && !fix_atmo) return TaskStatus::complete;
 
     Flag("Inverter::FixUtoP");
@@ -159,14 +159,15 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     return TaskStatus::complete;
 }
 
-TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
+TaskStatus Inverter::Backstop(MeshBlockData<Real> *rc)
 {
-    Flag("Inverter::VelRecover");
+    Flag("Inverter::Backstop");
     auto pmb = rc->GetBlockPointer();
 
     auto &pars = pmb->packages.Get("Inverter")->AllParams();
     const Real tol = pars.Get<Real>("err_tol");
-    const bool momentum_steal = pars.Get<bool>("momentum_steal");
+    const bool fix_recover_vel = pars.Get<bool>("fix_recover_vel");
+    const bool fix_recover_u = pars.Get<bool>("fix_recover_u");
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
@@ -196,8 +197,8 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
     const auto& G = pmb->coords;
 
     // Minimum internal energy to set here. Can be anything small
-    //const Real umin = floors.u_min_const;
-    const Real umin = 1e-15;
+    const Real umin = floors.u_min_const;
+    //const Real umin = 1e-15;
 
     // If after the first round of floors, we still reconstructed 
     pmb->par_for("fix_U_to_P_energy", b.ks, b.ke, b.js, b.je, b.is, b.ie,
@@ -227,7 +228,7 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                 // If we're below the at-rest energy (within tolerance),
                 // just bump it to that and kill all kinetic energy
                 if ((Trest[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i) > -tol ||
-                    !momentum_steal) {
+                    (!fix_recover_vel && !fix_recover_u)) {
                     // W = 1
                     P(m_p.RHO, k, j, i) = D;
                     P(m_p.UU, k, j, i) = umin;
@@ -235,6 +236,61 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                     P(m_p.U2, k, j, i) = 0.;
                     P(m_p.U3, k, j, i) = 0.;
                     fflagl |= Floors::FFlag::FIXUP_ENERGY;
+                } else if (fix_recover_u) {
+                    // If the user really wants it, add the extra energy to the internal energy,
+                    // preserving T00 by increasing u above umin
+                    const Real uvec0[NVEC] = {0.};
+                    auto f = [&] (Real u) {
+                        // Calculate tensor (we only need T0)
+                        Real rho_ut, T[GR_DIM];
+                        GRMHD::p_to_u_mhd(G, D, u, uvec0, B_P, gam, k, j, i, rho_ut, T);
+                        // Check that it matches
+                        return (T[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i);
+                    };
+
+                    // Rootfind for u that gives us T00
+                    bool e_solve_failed = false;
+                    Real um = umin, up = 1.;
+                    Real uu;
+                    if (f(up) * f(um) > 0.) {
+                        e_solve_failed = true;
+                        fflagl |= Floors::FFlag::FIXUP_U_RANGE;
+                    } else {
+                        Real uc = (up + um) / 2.;
+                        while (1) {
+                            Real resv = m::abs(f(uc));
+                            if ((resv < tol) || (m::abs((up - um) / 2) < tol/10)) {
+                                uu = uc;
+                                e_solve_failed = (resv > tol);
+                                break;
+                            }
+                            // Same sign as right side -> center now right side
+                            if (f(uc) * f(up) > 0.)
+                                up = uc;
+                            else // default to shifting window up -> slower
+                                um = uc;
+                            uc = (um + up) / 2.;
+                        }
+                    }
+
+                    if (!e_solve_failed) {
+                        // Set zero velocity with new UU
+                        P(m_p.RHO, k, j, i) = D;
+                        P(m_p.UU, k, j, i) = uu;
+                        P(m_p.U1, k, j, i) = 0.;
+                        P(m_p.U2, k, j, i) = 0.;
+                        P(m_p.U3, k, j, i) = 0.;
+                        fflagl |= Floors::FFlag::FIXUP_U;
+                    } else {
+                        // The only reason this *should* fail is if we missed
+                        // somehow (i.e., round-off) that we really do lack the rest energy
+                        P(m_p.RHO, k, j, i) = D;
+                        P(m_p.UU, k, j, i) = umin;
+                        P(m_p.U1, k, j, i) = 0.;
+                        P(m_p.U2, k, j, i) = 0.;
+                        P(m_p.U3, k, j, i) = 0.;
+                        fflagl |= Floors::FFlag::FIXUP_U_FAILED;
+                    }
                 } else {
                     // Otherwise, solve for the Lorentz factor which makes the internal energy
                     // at least the minimum (basically, pulling from the kinetic energy)
@@ -254,11 +310,11 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
 
                     // Rootfind for iW that would have produced the current u
                     bool e_solve_failed = false;
-                    Real iWm = 1/W, iWp = 1.;
+                    Real iWm = 1/m::min(W, 50.), iWp = 1.;
                     Real iW;
                     if (f(iWp) * f(iWm) > 0.) {
                         e_solve_failed = true;
-                        fflagl |= Floors::FFlag::FIXUP_MOMENTUM_RANGE;
+                        fflagl |= Floors::FFlag::FIXUP_VEL_RANGE;
                     } else {
                         Real iWc = (iWp + iWm) / 2.;
                         while (1) {
@@ -279,12 +335,25 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
 
                     // Compute what we really need
                     Real gamma_fac = m::sqrt((SQR(1./iW) - 1.) / (SQR(W) - 1.));
-                    // if (gamma_fac > 1) {
-                    //     fprintf(stderr, "correcting gamma_fac: %g\n", gamma_fac);
-                    //     gamma_fac = 0.;
-                    //     iW = 1.; // Set solve to be whatever W was
-                    // }
-                    if (!e_solve_failed && gamma_fac <= 1) {
+                    if (gamma_fac > 1 && !e_solve_failed) {
+                        fflagl |= Floors::FFlag::FIXUP_VEL_GAMMA;
+                        e_solve_failed = true;
+                        // TO PRINT (for verifying this only happens via round-off error)
+                        // Refresh initial T, we used it in solve
+                        // Real T[GR_DIM];
+                        // GRMHD::p_to_u_mhd(G, P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+                        //                     uvec, B_P, gam, k, j, i, rho_ut, T);
+                        // Compute T from solved vals to compare
+                        // Real Tsolved[GR_DIM] = {0.};
+                        // const Real uvecr[NDIM] = {uvec[0]*gamma_fac, uvec[1]*gamma_fac, uvec[2]*gamma_fac};
+                        // GRMHD::p_to_u_mhd(G, D * iW, umin, uvecr, B_P, gam, k, j, i, rho_ut, Tsolved);
+                        // printf("bad gamma recovery: total deficit %g rest deficit %g remaining deficit %g\nfinal gamma_fac: %g rho %g u %g uvec %g %g %g B %g %g %g\n",
+                        //         (T[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i),
+                        //         (Trest[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i),
+                        //         (Tsolved[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i), gamma_fac,
+                        //         D * iW, umin, uvecr[0], uvecr[1], uvecr[2], B_P[0], B_P[1], B_P[2]);
+                    }
+                    if (!e_solve_failed) {
                         // Rescale just the density & velocities with new iW
                         // TODO(CEP) still limit iW >= etc
                         P(m_p.RHO, k, j, i) = D * iW;
@@ -292,40 +361,20 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                         P(m_p.U1, k, j, i) *= gamma_fac;
                         P(m_p.U2, k, j, i) *= gamma_fac;
                         P(m_p.U3, k, j, i) *= gamma_fac;
-                        fflagl |= Floors::FFlag::FIXUP_MOMENTUM;
+                        fflagl |= Floors::FFlag::FIXUP_VEL;
                     } else {
-                        // The only reason this *should* fail is if we missed
-                        // somehow that we really do lack the rest energy
-                        // OR due to round-off we solved for a higher vel than we had
-                        if (gamma_fac > 1 && !e_solve_failed) {
-                            fflagl |= Floors::FFlag::FIXUP_MOMENTUM_GAMMA;
-                            // Refresh initial T, we used it in solve
-                            Real T[GR_DIM];
-                            GRMHD::p_to_u_mhd(G, P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
-                                                uvec, B_P, gam, k, j, i, rho_ut, T);
-                            // Compute T from solved vals to compare
-                            Real Tsolved[GR_DIM] = {0.};
-                            const Real uvecr[NDIM] = {uvec[0]*gamma_fac, uvec[1]*gamma_fac, uvec[2]*gamma_fac};
-                            GRMHD::p_to_u_mhd(G, D * iW, umin, uvecr, B_P, gam, k, j, i, rho_ut, Tsolved);
-                            printf("bad gamma recovery: total deficit %g rest deficit %g remaining deficit %g\nfinal gamma_fac: %g rho %g u %g uvec %g %g %g B %g %g %g\n",
-                                    (T[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i),
-                                    (Trest[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i),
-                                    (Tsolved[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i), gamma_fac,
-                                    D * iW, umin, uvecr[0], uvecr[1], uvecr[2], B_P[0], B_P[1], B_P[2]);
-                        } else {
-                            fflagl |= Floors::FFlag::FIXUP_MOMENTUM_FAILED;
-                        }
                         P(m_p.RHO, k, j, i) = D;
                         P(m_p.UU, k, j, i) = umin;
                         P(m_p.U1, k, j, i) = 0.;
                         P(m_p.U2, k, j, i) = 0.;
                         P(m_p.U3, k, j, i) = 0.;
+                        fflagl |= Floors::FFlag::FIXUP_VEL_FAILED;
                     }
                 }
 
-                // Reapply ceilings TODO(CEP) gamma ceiling doesn't adjust rho!
-                //apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors_inner, U, m_u);
-                // Set remaining floors the dumb way if they're still low
+                // Set remaining floors the dumb way if they're *still* low
+                // Verified this basically never happens. Not sure if it's possible
+                // TODO should this just be up to SMALL and not the constant floor?
                 if (P(m_p.RHO, k, j, i) < floors.rho_min_const) {
                     P(m_p.RHO, k, j, i) = floors.rho_min_const;
                     fflagl |= Floors::FFlag::FIXUP_RHO_DIRECT;
@@ -336,6 +385,7 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                 }
                 fflag(0, k, j, i) = fflagl;
 
+                // We definitely fixed a zone that definitely needed fixing.  Respect primitive vars
                 GRMHD::p_to_u(G, P, m_p, gam, k, j, i, U, m_u);
             }
         }

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -54,6 +54,9 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     // Bail if we're not enabled
     const bool fix_average = pmb->packages.Get("Inverter")->Param<bool>("fix_average_neighbors");
     const bool fix_atmo = pmb->packages.Get("Inverter")->Param<bool>("fix_atmosphere");
+    const bool velrecover = pmb->packages.Get("Inverter")->Param<bool>("vel_recovery");
+    // Velocity recovery replaces other fixups (TODO(CEP) should it always?)
+    if (velrecover) return Inverter::VelRecover(rc);
     if (!fix_average && !fix_atmo) return TaskStatus::complete;
 
     Flag("Inverter::FixUtoP");
@@ -116,7 +119,6 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
         }
     );
 
-    // Re-apply floors to fixed zones
     // Use values from floors package if it's enabled, otherwise any we've been asked to apply
     const Floors::Prescription floors = pmb->packages.AllPackages().count("Floors") ?
                                         pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription") :
@@ -142,7 +144,9 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
             if (failed(pflag(k, j, i))) {
                 // Make sure all fixed values still abide by floors
                 // TODO Full floors instead of just geo?
-                Floors::apply_geo_floors(G, P, m_p, gam, k, j, i, floors, floors_inner);
+                int fflagl = fflag(0, k, j, i);
+                fflagl |= Floors::apply_geo_floors(G, P, m_p, gam, k, j, i, floors, floors_inner);
+                fflag(0, k, j, i) = fflagl;
 
                 // Make sure to keep lockstep
                 // This will only be run for GRMHD, so we can call its p_to_u
@@ -151,6 +155,164 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
         }
     );
 
+    EndFlag();
+    return TaskStatus::complete;
+}
+
+TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
+{
+    Flag("Inverter::VelRecover");
+    auto pmb = rc->GetBlockPointer();
+
+    auto &pars = pmb->packages.Get("Inverter")->AllParams();
+    const Real tol = pars.Get<Real>("err_tol");
+
+    const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
+
+    // Use values from floors package if it's enabled, otherwise any we've been asked to apply
+    const Floors::Prescription floors = pmb->packages.AllPackages().count("Floors") ?
+                                        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription") :
+                                        pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
+    const Floors::Prescription floors_inner = pmb->packages.AllPackages().count("Floors") ?
+                                        pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner") :
+                                        pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
+
+    // Get floor flag
+    GridScalar fflag = rc->Get("fflag").data;
+
+    // We need the full packs of prims/cons in order to fix internal energy
+    // Pack new variables
+    PackIndexMap prims_map, cons_map;
+    auto U = GRMHD::PackMHDCons(rc, cons_map);
+    auto P = GRMHD::PackMHDPrims(rc, prims_map);
+    const VarMap m_u(cons_map, true), m_p(prims_map, false);
+    // Get new sizes
+    const int nvar = P.GetDim(4);
+
+    const IndexRange3 b = KDomain::GetPhysicalRange(rc);
+
+    const auto& G = pmb->coords;
+
+    // Minimum internal energy to set here. Can be anything small
+    // const Real umin = floors.u_min_const;
+    const Real umin = 1e-15;
+
+    const Real bad_vel_tolerance = 200*tol;
+
+    // If after the first round of floors, we still reconstructed 
+    pmb->par_for("fix_U_to_P_energy", b.ks, b.ke, b.js, b.je, b.is, b.ie,
+        KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
+            // If we reconstructed a negative or zero internal energy (even after floors!)
+            // const Real rho = P(m_p.RHO, k, j, i);
+            // const Real u = P(m_p.UU, k, j, i);
+            const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
+            const Real B_P[NVEC] = {P(m_p.B1, k, j, i), P(m_p.B2, k, j, i), P(m_p.B3, k, j, i)};
+            Real rho_ut, T[GR_DIM];
+            // GRMHD::p_to_u_mhd(G, rho, u, uvec, B_P, gam, k, j, i, rho_ut, T);
+            if (P(m_p.UU, k, j, i) < umin) {
+                // ((m::abs((T[1] - U(m_u.U1, k, j, i)) / U(m_u.U1, k, j, i)) > bad_vel_tolerance) &&
+                //  (m::abs(U(m_u.U1, k, j, i)) > bad_vel_tolerance)) ||
+                // ((m::abs((T[2] - U(m_u.U2, k, j, i)) / U(m_u.U2, k, j, i)) > bad_vel_tolerance) &&
+                //  (m::abs(U(m_u.U2, k, j, i) > bad_vel_tolerance))) ||
+                // ((m::abs((T[3] - U(m_u.U3, k, j, i)) / U(m_u.U3, k, j, i)) > bad_vel_tolerance) &&
+                //  (m::abs(U(m_u.U3, k, j, i) > bad_vel_tolerance)))) {
+                // Add to existing floor flags
+                int fflagl = fflag(0, k, j, i);
+
+                // Calculate P->U on the inverted values
+                const Real D = U(m_u.RHO, k, j, i) /
+                                    (m::sqrt(-G.gcon(Loci::center, j, i, 0, 0)) * G.gdet(Loci::center, j, i));
+                const Real W = GRMHD::lorentz_calc(G, uvec, k, j, i, Loci::center);
+
+                // Calculate the total energy of the fluid at rest
+                const Real uvec0[NVEC] = {0.};
+                GRMHD::p_to_u_mhd(G, D, umin, uvec0, B_P, gam, k, j, i, rho_ut, T);
+                // If we're below the at-rest energy, just bump it to that and kill all kinetic energy
+                if (m::abs(T[0]) >= m::abs(U(m_u.UU, k, j, i))) {
+                    // W = 1
+                    P(m_p.RHO, k, j, i) = D;
+                    P(m_p.UU, k, j, i) = umin;
+                    P(m_p.U1, k, j, i) = 0.;
+                    P(m_p.U2, k, j, i) = 0.;
+                    P(m_p.U3, k, j, i) = 0.;
+                    fflagl |= Floors::FFlag::FIXUP_ENERGY;
+                } else {
+                    // Otherwise, solve for the Lorentz factor which makes the internal energy
+                    // at least the minimum (basically, pulling from the kinetic energy)
+                    // This really should be a guaranteed solve!
+                    auto f = [&] (Real iW) {
+                        // Rescale velocity
+                        Real gamma_fac = m::sqrt((SQR(1./iW) - 1.) / (SQR(W) - 1.));
+                        const Real uv[NVEC] = {gamma_fac * uvec[0],
+                                            gamma_fac * uvec[1],
+                                            gamma_fac * uvec[2]};
+                        // Rescale rest mass
+                        const Real rho = D * iW;
+
+                        // Calculate tensor (we only need T0)
+                        GRMHD::p_to_u_mhd(G, rho, umin, uv, B_P, gam, k, j, i, rho_ut, T);
+                        // Check that it matches
+                        return (T[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i);
+                    };
+
+                    // Rootfind for iW that would have produced the current u
+                    bool e_solve_failed = false;
+                    Real iWm = 1 / 51., iWp = 1.;
+                    Real iW;
+                    if (f(iWp) * f(iWm) > 0.) {
+                        e_solve_failed = true;
+                    } else {
+                        Real iWc = 0.75;
+                        while (1) {
+                            Real resv = m::abs(f(iWc));
+                            if ((resv < tol) || (m::abs((iWp - iWm) / 2) < tol)) {
+                                iW = iWc;
+                                e_solve_failed = (resv > tol);
+                                break;
+                            }
+                            // Same sign as right side -> center now right side
+                            if (f(iWc) * f(iWp) > 0.)
+                                iWp = iWc;
+                            else // default to shifting window up -> slower
+                                iWm = iWc;
+                            iWc = (iWm + iWp) / 2.;
+                        }
+                    }
+
+                    // Compute what we really need
+                    Real gamma_fac = m::sqrt((SQR(1./iW) - 1.) / (SQR(W) - 1.));
+                    if (!e_solve_failed && gamma_fac < 1) {
+                        // Rescale just the density & velocities with new iW
+                        P(m_p.RHO, k, j, i) = D * iW;
+                        P(m_p.UU, k, j, i) = umin;
+                        P(m_p.U1, k, j, i) *= gamma_fac;
+                        P(m_p.U2, k, j, i) *= gamma_fac;
+                        P(m_p.U3, k, j, i) *= gamma_fac;
+                        fflagl |= Floors::FFlag::FIXUP_MOMENTUM;
+                    } else {
+                        // The only reason this *should* fail is if we missed
+                        // somehow that we really do lack the rest energy
+                        P(m_p.RHO, k, j, i) = D;
+                        P(m_p.UU, k, j, i) = umin;
+                        P(m_p.U1, k, j, i) = 0.;
+                        P(m_p.U2, k, j, i) = 0.;
+                        P(m_p.U3, k, j, i) = 0.;
+                        fflagl |= Floors::FFlag::FIXUP_ENERGY;
+                    }
+                }
+                fflag(0, k, j, i) = fflagl;
+
+                // Reapply ceilings
+                apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors_inner, U, m_u);
+                // Set remaining floors the dumb way if they're still low
+                // TODO(CEP) record
+                P(m_p.RHO, k, j, i) = m::max(P(m_p.RHO, k, j, i), floors.rho_min_const);
+                P(m_p.UU, k, j, i) = m::max(P(m_p.UU, k, j, i), floors.u_min_const);
+
+                GRMHD::p_to_u(G, P, m_p, gam, k, j, i, U, m_u);
+            }
+        }
+    );
     EndFlag();
     return TaskStatus::complete;
 }

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -197,7 +197,7 @@ TaskStatus Inverter::Backstop(MeshBlockData<Real> *rc)
     const auto& G = pmb->coords;
 
     // Minimum internal energy to set here. Can be anything small
-    const Real umin = floors.u_min_const;
+    //const Real umin = floors.u_min_const;
     //const Real umin = 1e-15;
 
     // If after the first round of floors, we still reconstructed 
@@ -205,6 +205,9 @@ TaskStatus Inverter::Backstop(MeshBlockData<Real> *rc)
         KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
             // If the solve failed, because we reconstructed a
             // negative or zero internal energy (even after floors!)
+            Real rhomin_geom, umin_geom;
+            determine_geo_floors(G, P, m_p, gam, k, j, i, floors, floors_inner, rhomin_geom, umin_geom);
+            const Real umin = umin_geom;
             if (failed(pflag(k, j, i)) && (P(m_p.UU, k, j, i) < umin)) {
                 // const Real rho = P(m_p.RHO, k, j, i);
                 // const Real u = P(m_p.UU, k, j, i);

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -166,8 +166,8 @@ TaskStatus Inverter::Backstop(MeshBlockData<Real> *rc)
 
     auto &pars = pmb->packages.Get("Inverter")->AllParams();
     const Real tol = pars.Get<Real>("err_tol");
-    const bool fix_recover_vel = pars.Get<bool>("fix_recover_vel");
-    const bool fix_recover_u = pars.Get<bool>("fix_recover_u");
+    const bool backstop_recover_vel = pars.Get<bool>("backstop_recover_vel");
+    const bool backstop_recover_u = pars.Get<bool>("backstop_recover_u");
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
@@ -228,7 +228,7 @@ TaskStatus Inverter::Backstop(MeshBlockData<Real> *rc)
                 // If we're below the at-rest energy (within tolerance),
                 // just bump it to that and kill all kinetic energy
                 if ((Trest[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i) > -tol ||
-                    (!fix_recover_vel && !fix_recover_u)) {
+                    (!backstop_recover_vel && !backstop_recover_u)) {
                     // W = 1
                     P(m_p.RHO, k, j, i) = D;
                     P(m_p.UU, k, j, i) = umin;
@@ -236,7 +236,7 @@ TaskStatus Inverter::Backstop(MeshBlockData<Real> *rc)
                     P(m_p.U2, k, j, i) = 0.;
                     P(m_p.U3, k, j, i) = 0.;
                     fflagl |= Floors::FFlag::FIXUP_ENERGY;
-                } else if (fix_recover_u) {
+                } else if (backstop_recover_u) {
                     // If the user really wants it, add the extra energy to the internal energy,
                     // preserving T00 by increasing u above umin
                     const Real uvec0[NVEC] = {0.};

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -166,6 +166,7 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
 
     auto &pars = pmb->packages.Get("Inverter")->AllParams();
     const Real tol = pars.Get<Real>("err_tol");
+    const bool momentum_steal = pars.Get<bool>("momentum_steal");
 
     const Real gam = pmb->packages.Get("GRMHD")->Param<Real>("gamma");
 
@@ -177,8 +178,9 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                                         pmb->packages.Get("Floors")->Param<Floors::Prescription>("prescription_inner") :
                                         pmb->packages.Get("Inverter")->Param<Floors::Prescription>("inverter_prescription");
 
-    // Get floor flag
+    // Get flags
     GridScalar fflag = rc->Get("fflag").data;
+    GridScalar pflag = rc->Get("pflag").data;
 
     // We need the full packs of prims/cons in order to fix internal energy
     // Pack new variables
@@ -194,29 +196,22 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
     const auto& G = pmb->coords;
 
     // Minimum internal energy to set here. Can be anything small
-    // const Real umin = floors.u_min_const;
+    //const Real umin = floors.u_min_const;
     const Real umin = 1e-15;
-
-    const Real bad_vel_tolerance = 200*tol;
 
     // If after the first round of floors, we still reconstructed 
     pmb->par_for("fix_U_to_P_energy", b.ks, b.ke, b.js, b.je, b.is, b.ie,
         KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
-            // If we reconstructed a negative or zero internal energy (even after floors!)
-            // const Real rho = P(m_p.RHO, k, j, i);
-            // const Real u = P(m_p.UU, k, j, i);
-            const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
-            const Real B_P[NVEC] = {P(m_p.B1, k, j, i), P(m_p.B2, k, j, i), P(m_p.B3, k, j, i)};
-            Real rho_ut, T[GR_DIM];
-            // GRMHD::p_to_u_mhd(G, rho, u, uvec, B_P, gam, k, j, i, rho_ut, T);
-            if (P(m_p.UU, k, j, i) < umin) {
-                // ((m::abs((T[1] - U(m_u.U1, k, j, i)) / U(m_u.U1, k, j, i)) > bad_vel_tolerance) &&
-                //  (m::abs(U(m_u.U1, k, j, i)) > bad_vel_tolerance)) ||
-                // ((m::abs((T[2] - U(m_u.U2, k, j, i)) / U(m_u.U2, k, j, i)) > bad_vel_tolerance) &&
-                //  (m::abs(U(m_u.U2, k, j, i) > bad_vel_tolerance))) ||
-                // ((m::abs((T[3] - U(m_u.U3, k, j, i)) / U(m_u.U3, k, j, i)) > bad_vel_tolerance) &&
-                //  (m::abs(U(m_u.U3, k, j, i) > bad_vel_tolerance)))) {
-                // Add to existing floor flags
+            // If the solve failed, because we reconstructed a
+            // negative or zero internal energy (even after floors!)
+            if (failed(pflag(k, j, i)) && (P(m_p.UU, k, j, i) < umin)) {
+                // const Real rho = P(m_p.RHO, k, j, i);
+                // const Real u = P(m_p.UU, k, j, i);
+                const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
+                const Real B_P[NVEC] = {P(m_p.B1, k, j, i), P(m_p.B2, k, j, i), P(m_p.B3, k, j, i)};
+                // Real rho_ut, T[GR_DIM];
+                // GRMHD::p_to_u_mhd(G, rho, u, uvec, B_P, gam, k, j, i, rho_ut, T);
+    
                 int fflagl = fflag(0, k, j, i);
 
                 // Calculate P->U on the inverted values
@@ -226,9 +221,13 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
 
                 // Calculate the total energy of the fluid at rest
                 const Real uvec0[NVEC] = {0.};
-                GRMHD::p_to_u_mhd(G, D, umin, uvec0, B_P, gam, k, j, i, rho_ut, T);
-                // If we're below the at-rest energy, just bump it to that and kill all kinetic energy
-                if (m::abs(T[0]) >= m::abs(U(m_u.UU, k, j, i))) {
+                Real rho_ut = 0.;
+                Real Trest[GR_DIM] = {0.};
+                GRMHD::p_to_u_mhd(G, D, umin, uvec0, B_P, gam, k, j, i, rho_ut, Trest);
+                // If we're below the at-rest energy (within tolerance),
+                // just bump it to that and kill all kinetic energy
+                if ((Trest[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i) > -tol ||
+                    !momentum_steal) {
                     // W = 1
                     P(m_p.RHO, k, j, i) = D;
                     P(m_p.UU, k, j, i) = umin;
@@ -246,26 +245,25 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                         const Real uv[NVEC] = {gamma_fac * uvec[0],
                                             gamma_fac * uvec[1],
                                             gamma_fac * uvec[2]};
-                        // Rescale rest mass
-                        const Real rho = D * iW;
-
                         // Calculate tensor (we only need T0)
-                        GRMHD::p_to_u_mhd(G, rho, umin, uv, B_P, gam, k, j, i, rho_ut, T);
+                        Real rho_ut, T[GR_DIM];
+                        GRMHD::p_to_u_mhd(G, D * iW, umin, uv, B_P, gam, k, j, i, rho_ut, T);
                         // Check that it matches
                         return (T[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i);
                     };
 
                     // Rootfind for iW that would have produced the current u
                     bool e_solve_failed = false;
-                    Real iWm = 1 / 51., iWp = 1.;
+                    Real iWm = 1/W, iWp = 1.;
                     Real iW;
                     if (f(iWp) * f(iWm) > 0.) {
                         e_solve_failed = true;
+                        fflagl |= Floors::FFlag::FIXUP_MOMENTUM_RANGE;
                     } else {
-                        Real iWc = 0.75;
+                        Real iWc = (iWp + iWm) / 2.;
                         while (1) {
                             Real resv = m::abs(f(iWc));
-                            if ((resv < tol) || (m::abs((iWp - iWm) / 2) < tol)) {
+                            if ((resv < tol) || (m::abs((iWp - iWm) / 2) < tol/10)) {
                                 iW = iWc;
                                 e_solve_failed = (resv > tol);
                                 break;
@@ -281,8 +279,14 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
 
                     // Compute what we really need
                     Real gamma_fac = m::sqrt((SQR(1./iW) - 1.) / (SQR(W) - 1.));
-                    if (!e_solve_failed && gamma_fac < 1) {
+                    // if (gamma_fac > 1) {
+                    //     fprintf(stderr, "correcting gamma_fac: %g\n", gamma_fac);
+                    //     gamma_fac = 0.;
+                    //     iW = 1.; // Set solve to be whatever W was
+                    // }
+                    if (!e_solve_failed && gamma_fac <= 1) {
                         // Rescale just the density & velocities with new iW
+                        // TODO(CEP) still limit iW >= etc
                         P(m_p.RHO, k, j, i) = D * iW;
                         P(m_p.UU, k, j, i) = umin;
                         P(m_p.U1, k, j, i) *= gamma_fac;
@@ -292,22 +296,45 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                     } else {
                         // The only reason this *should* fail is if we missed
                         // somehow that we really do lack the rest energy
+                        // OR due to round-off we solved for a higher vel than we had
+                        if (gamma_fac > 1 && !e_solve_failed) {
+                            fflagl |= Floors::FFlag::FIXUP_MOMENTUM_GAMMA;
+                            // Refresh initial T, we used it in solve
+                            Real T[GR_DIM];
+                            GRMHD::p_to_u_mhd(G, P(m_p.RHO, k, j, i), P(m_p.UU, k, j, i),
+                                                uvec, B_P, gam, k, j, i, rho_ut, T);
+                            // Compute T from solved vals to compare
+                            Real Tsolved[GR_DIM] = {0.};
+                            const Real uvecr[NDIM] = {uvec[0]*gamma_fac, uvec[1]*gamma_fac, uvec[2]*gamma_fac};
+                            GRMHD::p_to_u_mhd(G, D * iW, umin, uvecr, B_P, gam, k, j, i, rho_ut, Tsolved);
+                            printf("bad gamma recovery: total deficit %g rest deficit %g remaining deficit %g\nfinal gamma_fac: %g rho %g u %g uvec %g %g %g B %g %g %g\n",
+                                    (T[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i),
+                                    (Trest[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i),
+                                    (Tsolved[0] - U(m_u.UU, k, j, i)) / U(m_u.UU, k, j, i), gamma_fac,
+                                    D * iW, umin, uvecr[0], uvecr[1], uvecr[2], B_P[0], B_P[1], B_P[2]);
+                        } else {
+                            fflagl |= Floors::FFlag::FIXUP_MOMENTUM_FAILED;
+                        }
                         P(m_p.RHO, k, j, i) = D;
                         P(m_p.UU, k, j, i) = umin;
                         P(m_p.U1, k, j, i) = 0.;
                         P(m_p.U2, k, j, i) = 0.;
                         P(m_p.U3, k, j, i) = 0.;
-                        fflagl |= Floors::FFlag::FIXUP_ENERGY;
                     }
                 }
-                fflag(0, k, j, i) = fflagl;
 
-                // Reapply ceilings
-                apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors_inner, U, m_u);
+                // Reapply ceilings TODO(CEP) gamma ceiling doesn't adjust rho!
+                //apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors_inner, U, m_u);
                 // Set remaining floors the dumb way if they're still low
-                // TODO(BSP) record
-                P(m_p.RHO, k, j, i) = m::max(P(m_p.RHO, k, j, i), floors.rho_min_const);
-                P(m_p.UU, k, j, i) = m::max(P(m_p.UU, k, j, i), floors.u_min_const);
+                if (P(m_p.RHO, k, j, i) < floors.rho_min_const) {
+                    P(m_p.RHO, k, j, i) = floors.rho_min_const;
+                    fflagl |= Floors::FFlag::FIXUP_RHO_DIRECT;
+                }
+                if (P(m_p.UU, k, j, i) < floors.u_min_const) {
+                    P(m_p.UU, k, j, i) = floors.u_min_const;
+                    fflagl |= Floors::FFlag::FIXUP_U_DIRECT;
+                }
+                fflag(0, k, j, i) = fflagl;
 
                 GRMHD::p_to_u(G, P, m_p, gam, k, j, i, U, m_u);
             }

--- a/kharma/inverter/fixup.cpp
+++ b/kharma/inverter/fixup.cpp
@@ -55,7 +55,7 @@ TaskStatus Inverter::FixUtoP(MeshBlockData<Real> *rc)
     const bool fix_average = pmb->packages.Get("Inverter")->Param<bool>("fix_average_neighbors");
     const bool fix_atmo = pmb->packages.Get("Inverter")->Param<bool>("fix_atmosphere");
     const bool velrecover = pmb->packages.Get("Inverter")->Param<bool>("vel_recovery");
-    // Velocity recovery replaces other fixups (TODO(CEP) should it always?)
+    // Velocity recovery replaces other fixups (TODO(BSP) should it always?)
     if (velrecover) return Inverter::VelRecover(rc);
     if (!fix_average && !fix_atmo) return TaskStatus::complete;
 
@@ -305,7 +305,7 @@ TaskStatus Inverter::VelRecover(MeshBlockData<Real> *rc)
                 // Reapply ceilings
                 apply_ceilings(G, P, m_p, gam, k, j, i, floors, floors_inner, U, m_u);
                 // Set remaining floors the dumb way if they're still low
-                // TODO(CEP) record
+                // TODO(BSP) record
                 P(m_p.RHO, k, j, i) = m::max(P(m_p.RHO, k, j, i), floors.rho_min_const);
                 P(m_p.UU, k, j, i) = m::max(P(m_p.UU, k, j, i), floors.u_min_const);
 

--- a/kharma/inverter/invert_template.hpp
+++ b/kharma/inverter/invert_template.hpp
@@ -98,6 +98,5 @@ template<Type inverter>
 KOKKOS_INLINE_FUNCTION int u_to_p(const GRCoordinates& G, const VariablePack<Real>& U, const VarMap& m_u,
                                               const Real& gam, const int& k, const int& j, const int& i,
                                               const VariablePack<Real>& P, const VarMap& m_p,
-                                              const Loci& loc, const int& max_iterations, const Real& tol,
-                                              const bool recover_velocity);
+                                              const Loci& loc, const int& max_iterations, const Real& tol);
 } // namespace Inverter

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -66,44 +66,21 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
 
     // Solver options
     // Any other Noble et al. implemented for fun should use lower tol/iter count, see Noble+06
-    Real err_tol = pin->GetOrAddReal("inverter", "err_tol", (use_kastaun) ? 1e-12 : 1e-8);
+    Real err_tol = pin->GetOrAddReal("inverter", "err_tol", (use_kastaun) ? 1e-14 : 1e-8);
     params.Add("err_tol", err_tol);
     int iter_max = pin->GetOrAddInteger("inverter", "iter_max", (use_kastaun) ? 25 : 8);
     params.Add("iter_max", iter_max);
 
-    // Floor options
-    // Use a custom block for inverter floors to allow customization.  Not sure anyone *wants* that but...
-    if (!pin->DoesBlockExist("inverter_floors")) {
-        params.Add("inverter_prescription", Floors::MakePrescription(pin, "floors"));
-            if (pin->DoesBlockExist("floors_inner"))
-                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
-            else
-                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
-    } else {
-        params.Add("inverter_prescription", Floors::MakePrescription(pin, "inverter_floors"));
-        params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "inverter_floors"), "inverter_floors"));
-    }
-
     // Fixup options
-    // Whether to apply Normal frame floors right after the inversion
-    bool apply_floors_with_inversion = pin->GetOrAddBoolean("inverter", "apply_floors_with_inversion", use_kastaun);
-    params.Add("apply_floors_with_inversion", apply_floors_with_inversion);
-    // Tolerance in the momenta before a zone is considered failed and the unsolvable velocity zeroed out
-    // Can't be set individually right now, set == 100*solver_tol
-    // Real bad_vel_tolerance = pin->GetOrAddReal("inverter", "bad_vel_tolerance", 1e-8);
-    // params.Add("bad_vel_tolerance", bad_vel_tolerance);
-
     // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun failures are more dire
     bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);
     params.Add("fix_average_neighbors", fix_average_neighbors);
-    // Fix by zeroing the velocity, for particularly nasty zones.  Applied immediately rather than in fixup
-    // Generally you don't want this -- if you're eliminating velocity and therefore momentum, better to
-    // eliminate inertia too by setting floor density/temp
-    bool fix_zero_velocity = pin->GetOrAddBoolean("inverter", "fix_zero_velocity", false);
-    params.Add("fix_zero_velocity", fix_zero_velocity);
     // Fix by replacing with floors, uvec=0. Backstop for states which are just impossible to use
-    bool fix_atmosphere = pin->GetOrAddBoolean("inverter", "fix_atmosphere", true);
+    bool fix_atmosphere = pin->GetOrAddBoolean("inverter", "fix_atmosphere", !use_kastaun);
     params.Add("fix_atmosphere", fix_atmosphere);
+    // New velocity recovery: steal enough KE to make temperature nonnegative
+    bool vel_recovery = pin->GetOrAddBoolean("inverter", "vel_recovery", use_kastaun);
+    params.Add("vel_recovery", vel_recovery);
 
     // Flag denoting UtoP inversion failures
     // Needs boundary sync if the fixup code will use neighbors, and if
@@ -160,7 +137,7 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
     auto P = GRMHD::PackMHDPrims(rc, prims_map);
     const VarMap m_u(cons_map, true), m_p(prims_map, false);
 
-    auto fflag = rc->PackVariables(std::vector<std::string>{"fflag"});
+    // auto fflag = rc->PackVariables(std::vector<std::string>{"fflag"});
     auto pflag = rc->PackVariables(std::vector<std::string>{"pflag"});
 
     if (U.GetDim(4) == 0 || pflag.GetDim(4) == 0)
@@ -171,11 +148,6 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
     auto &pars = pmb->packages.Get("Inverter")->AllParams();
     const Real err_tol = pars.Get<Real>("err_tol");
     const int iter_max = pars.Get<int>("iter_max");
-    const bool apply_floors_with_inversion = pars.Get<bool>("apply_floors_with_inversion");
-    //const Real bad_vel_tolerance = pars.Get<Real>("bad_vel_tolerance");
-    const bool fix_zero_velocity = pars.Get<bool>("fix_zero_velocity");
-    const Floors::Prescription inverter_floors       = pars.Get<Floors::Prescription>("inverter_prescription");
-    const Floors::Prescription inverter_floors_inner = pars.Get<Floors::Prescription>("inverter_prescription_inner");
 
     // If we set the floors package to use normal frame w/Kastaun inverter, *or*
     // if we disabled the floors package, go ahead and apply all floors in this function
@@ -186,172 +158,16 @@ inline void BlockPerformInversion(MeshBlockData<Real> *rc, IndexDomain domain, b
 
     const auto& G = pmb->coords;
 
-    // No floors/floors_inner distinction, TODO?
-    const Real rhoh_denom_max = SQR(inverter_floors.gamma_max) *
-                                m::sqrt(1 - 1 / SQR(inverter_floors.gamma_max));
-
-    // Get the primitives from our conserved versions
     // Notice by default, we recover variables for only the physical (interior or interior-ghost)
     // zones!  These are the only ones which are filled at our point in the step
     const IndexRange3 b = (domain == IndexDomain::entire)
                           ? KDomain::GetPhysicalRange(rc) : KDomain::GetRange(rc, domain, coarse);
+
+    // Get the basic/primitive variables from the conserved quantities
     pmb->par_for("U_to_P", b.ks, b.ke, b.js, b.je, b.is, b.ie,
         KOKKOS_LAMBDA (const int &k, const int &j, const int &i) {
             int pflagl = Inverter::u_to_p<inverter>(G, U, m_u, gam, k, j, i, P, m_p, Loci::center,
-                                                    iter_max, err_tol, false);
-
-            // Apply floors immediately, attempting to correct bad values
-            // from either failed or "successful" inversions
-            if (apply_floors_with_inversion) {
-                Real rhoflr_max, uflr_max;
-                int fflagl = 0; // There are no prior floors, reset
-                if (normal_frame_floors) {
-                    fflagl |= Floors::determine_floors(G, P, m_p, gam, k, j, i, inverter_floors, inverter_floors_inner,
-                        rhoflr_max, uflr_max);
-                } else {
-                    // Bare minimum floors for numerics, then we apply the rest in user-selected frame
-                    rhoflr_max = inverter_floors.rho_min_const;
-                    uflr_max = inverter_floors.u_min_const;
-                    if (P(m_p.RHO, k, j, i) < rhoflr_max) fflagl |= Floors::FFlag::GEOM_RHO;
-                    if (P(m_p.UU, k, j, i) < uflr_max) fflagl |= Floors::FFlag::GEOM_U;
-                }
-                if (fflagl) {
-                    // Add a floor to density which controls wayward velocities
-                    bool used_rho_to_slow = false;
-                    if (inverter_floors.use_rho_to_slow) {
-                        //const Real rho = std::max(P(m_p.RHO, k, j, i), rhoflr_max);
-                        //const Real u = std::max(P(m_p.UU, k, j, i), uflr_max);
-                        const Real rho = P(m_p.RHO, k, j, i);
-                        const Real u = P(m_p.UU, k, j, i);
-                        const Real rhoh = rho + gam * u;
-                        const Real alpha  = 1. / m::sqrt(-G.gcon(Loci::center, j, i, 0, 0));
-                        const Real a_over_g = alpha / G.gdet(Loci::center, j, i);
-                        Real Scov[3] = {U(m_u.U1, k, j, i) * a_over_g,
-                                        U(m_u.U2, k, j, i) * a_over_g,
-                                        U(m_u.U3, k, j, i) * a_over_g};
-                        Real Scon[3];
-                        Real gupper[GR_DIM][GR_DIM], glower[GR_DIM][GR_DIM];
-                        G.gcon(Loci::center, j, i, gupper);
-                        G.gcov(Loci::center, j, i, glower);
-                        Scon[0] = ((gupper[1][1] - gupper[0][1]*gupper[0][1]/gupper[0][0])*Scov[0] +
-                                    (gupper[1][2] - gupper[0][1]*gupper[0][2]/gupper[0][0])*Scov[1] +
-                                    (gupper[1][3] - gupper[0][1]*gupper[0][3]/gupper[0][0])*Scov[2]);
-
-                        Scon[1] = ((gupper[2][1] - gupper[0][2]*gupper[0][1]/gupper[0][0])*Scov[0] +
-                                    (gupper[2][2] - gupper[0][2]*gupper[0][2]/gupper[0][0])*Scov[1] +
-                                    (gupper[2][3] - gupper[0][2]*gupper[0][3]/gupper[0][0])*Scov[2]);
-
-                        Scon[2] = ((gupper[3][1] - gupper[0][3]*gupper[0][1]/gupper[0][0])*Scov[0] +
-                                    (gupper[3][2] - gupper[0][3]*gupper[0][2]/gupper[0][0])*Scov[1] +
-                                    (gupper[3][3] - gupper[0][3]*gupper[0][3]/gupper[0][0])*Scov[2]);
-                        Real Ssq = 0.0;
-                        SPACELOOP(ii) Ssq += Scon[ii] * Scov[ii];
-
-                        const Real rhoh_min = m::sqrt(Ssq) / rhoh_denom_max;
-                        if (rhoh < rhoh_min) {
-                            fflagl |= Floors::FFlag::INVERTER_GAMMA;
-                            // Proportional increases to rho,u preserve temperature
-                            // TODO could play with this ratio
-                            P(m_p.RHO, k, j, i) = rho * rhoh_min/rhoh;
-                            P(m_p.UU, k, j, i) = u * rhoh_min/rhoh;
-
-                            Real Bvec[] = {0.0, 0.0, 0.0};
-                            SPACELOOP(ii) Bvec[ii] = P(m_u.B1 + ii, k, j, i) * alpha;
-                            Real BdotS = 0.;
-                            SPACELOOP(ii) BdotS += Bvec[ii] * Scov[ii];
-                            Real Bsq = 0.;
-                            SPACELOOP2(ii, jj) Bsq += glower[ii + 1][jj + 1] * Bvec[ii] * Bvec[jj];
-                            Real Sparsq = BdotS * BdotS / Bsq;
-                            Real Sperpsq = Ssq - Sparsq;
-                            Real Spar[3], Sperp[3];
-                            SPACELOOP(ii) Spar[ii] = BdotS * Bvec[ii] / Bsq;
-                            SPACELOOP(ii) Sperp[ii] = Scon[ii] - Spar[ii];
-
-                            auto func_W = [&] (Real W) {
-                                const Real rhohW2 = rhoh_min * W * W;
-                                return Sparsq / SQR(rhohW2) +
-                                Sperpsq / SQR(rhohW2 + Bsq) +
-                                1. / (W * W) - 1.;
-                            };
-
-                            Real zm = 1.;
-                            Real zp = inverter_floors.gamma_max;
-                            Real z = 0.5*(zm + zp);
-
-                            Real fm = func_W(zm);
-                            Real fp = func_W(zp);
-
-                            bool vel_solve_failed = false;
-                            for (int iter = 0; iter < 30; ++iter) {
-                                z =  (zm*fp - zp*fm) / (fp-fm);  // linear interpolation to point f(z)=0
-                                Real f = func_W(z);
-                                // Quit if convergence reached
-                                if ((m::abs(f) < 1e-8) || (m::abs(zm-zp) < 1e-10)) {
-                                    // Return failure if 
-                                    vel_solve_failed = m::abs(f) > 1e-8;
-                                    break;
-                                }
-                                // assign zm-->zp if root bracketed by [z,zp]
-                                if (f*fp < 0.0) {
-                                    zm = zp;
-                                    fm = fp;
-                                    zp = z;
-                                    fp = f;
-                                } else {  // assign zp-->z if root bracketed by [zm,z]
-                                    fm = 0.5*fm; // 1/2 comes from "Illinois algorithm" to accelerate convergence
-                                    zp = z;
-                                    fp = f;
-                                }
-                            }
-
-                            if (!vel_solve_failed) {
-                                SPACELOOP(ii) P(m_p.U1+ii, k, j, i) = z * (Spar[ii] / (rhoh_min * z * z) +
-                                                                        Sperp[ii] / (rhoh_min * z * z + Bsq));
-                                // Even if Kastaun hit max_iter, we managed to reset everything correctly
-                                pflagl = static_cast<int>(Inverter::Status::success);
-                                used_rho_to_slow = true;
-                            } else {
-                                // This should basically NEVER happen
-                                // Only if the numbers are just floating-point gibberish
-                                pflagl = static_cast<int>(Inverter::Status::bad_velocity);
-                            }
-                        }
-                    }
-
-                    // If we haven't used floors to adjust the velocity, apply them in NOF
-                    if (!used_rho_to_slow) {
-                        // Apply floors to P -- this calls inversion again
-                        pflagl = Floors::apply_floors<Floors::InjectionFrame::normal_kastaun>(G, P, m_p, gam, k, j, i,
-                                rhoflr_max, uflr_max, U, m_u);
-                        apply_ceilings(G, P, m_p, gam, k, j, i, inverter_floors, inverter_floors_inner, U, m_u);
-                    }
-                }
-
-                // If we recovered the velocity, mark we used the gamma ceiling
-                if (pflagl == static_cast<int>(Inverter::Status::floor)) {
-                    fflagl |= Floors::FFlag::INVERTER_GAMMA;
-                    pflagl = static_cast<int>(Inverter::Status::success);
-                // If we failed to recover the velocity, optionally zero it here
-                // otherwise it will just get set to atmosphere later
-                } else if (fix_zero_velocity &&
-                           pflagl == static_cast<int>(Inverter::Status::bad_velocity)) {
-                    P(m_p.U1, k, j, i) = 0.;
-                    P(m_p.U2, k, j, i) = 0.;
-                    P(m_p.U3, k, j, i) = 0.;
-                    pflagl = static_cast<int>(Inverter::Status::success);
-                }
-                // If we applied floors but we won't fix later, update U
-                if (fflagl && !pflagl) {
-                    // This is explicitly a GRMHD-only function, we don't need to account for
-                    // EMHD here.  Also this is done next anyway in the KHARMA driver,
-                    // but we want to eventually remove that function.
-                    GRMHD::p_to_u(G, P, m_p, gam, k, j, i, U, m_u, Loci::center);
-                }
-
-                fflag(0, k, j, i) = fflagl;
-            }
-
-            // If we're applying floors, record the *post-floor* flag since we only care if that failed
+                                                    iter_max, err_tol);
             pflag(0, k, j, i) = pflagl;
         }
     );

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -97,6 +97,7 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     // stealing some or all KE and adding any shortfall
     bool backstop = pin->GetOrAddBoolean("inverter", "backstop", use_kastaun);
     params.Add("backstop", backstop);
+    // Note these aren't called if the backstop isn't enabled!
     bool backstop_recover_vel = pin->GetOrAddBoolean("inverter", "backstop_recover_vel", true);
     params.Add("backstop_recover_vel", backstop_recover_vel);
     bool backstop_recover_u = pin->GetOrAddBoolean("inverter", "backstop_recover_u", false);

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -71,6 +71,23 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     int iter_max = pin->GetOrAddInteger("inverter", "iter_max", (use_kastaun) ? 25 : 8);
     params.Add("iter_max", iter_max);
 
+    bool momentum_steal = pin->GetOrAddBoolean("inverter", "momentum_steal", true);
+    params.Add("momentum_steal", momentum_steal);
+
+    // TODO only need these if Floors aren't loaded
+    // Floor options
+    // Use a custom block for inverter floors to allow customization.  Not sure anyone *wants* that but...
+    if (!pin->DoesBlockExist("inverter_floors")) {
+        params.Add("inverter_prescription", Floors::MakePrescription(pin, "floors"));
+            if (pin->DoesBlockExist("floors_inner"))
+                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors_inner"));
+            else
+                params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "floors"), "floors"));
+    } else {
+        params.Add("inverter_prescription", Floors::MakePrescription(pin, "inverter_floors"));
+        params.Add("inverter_prescription_inner", Floors::MakePrescriptionInner(pin, Floors::MakePrescription(pin, "inverter_floors"), "inverter_floors"));
+    }
+
     // Fixup options
     // Fix by averaging neighboring cells.  Enabled by default for 1Dw, but Kastaun failures are more dire
     bool fix_average_neighbors = pin->GetOrAddBoolean("inverter", "fix_average_neighbors", !use_kastaun);

--- a/kharma/inverter/inverter.cpp
+++ b/kharma/inverter/inverter.cpp
@@ -71,9 +71,6 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     int iter_max = pin->GetOrAddInteger("inverter", "iter_max", (use_kastaun) ? 25 : 8);
     params.Add("iter_max", iter_max);
 
-    bool momentum_steal = pin->GetOrAddBoolean("inverter", "momentum_steal", true);
-    params.Add("momentum_steal", momentum_steal);
-
     // TODO only need these if Floors aren't loaded
     // Floor options
     // Use a custom block for inverter floors to allow customization.  Not sure anyone *wants* that but...
@@ -95,9 +92,18 @@ std::shared_ptr<KHARMAPackage> Inverter::Initialize(ParameterInput *pin, std::sh
     // Fix by replacing with floors, uvec=0. Backstop for states which are just impossible to use
     bool fix_atmosphere = pin->GetOrAddBoolean("inverter", "fix_atmosphere", !use_kastaun);
     params.Add("fix_atmosphere", fix_atmosphere);
-    // New velocity recovery: steal enough KE to make temperature nonnegative
-    bool vel_recovery = pin->GetOrAddBoolean("inverter", "vel_recovery", use_kastaun);
-    params.Add("vel_recovery", vel_recovery);
+
+    // New "backstop" code: ensure positive internal energy by
+    // stealing some or all KE and adding any shortfall
+    bool backstop = pin->GetOrAddBoolean("inverter", "backstop", use_kastaun);
+    params.Add("backstop", backstop);
+    bool backstop_recover_vel = pin->GetOrAddBoolean("inverter", "backstop_recover_vel", true);
+    params.Add("backstop_recover_vel", backstop_recover_vel);
+    bool backstop_recover_u = pin->GetOrAddBoolean("inverter", "backstop_recover_u", false);
+    params.Add("backstop_recover_u", backstop_recover_u);
+    if (backstop && backstop_recover_vel && backstop_recover_u) {
+        throw std::runtime_error("Inverter parameters error: cannot recover with backstop_recover_vel and backstop_recover_u!  Please choose one option.");
+    }
 
     // Flag denoting UtoP inversion failures
     // Needs boundary sync if the fixup code will use neighbors, and if

--- a/kharma/inverter/inverter.hpp
+++ b/kharma/inverter/inverter.hpp
@@ -89,6 +89,14 @@ inline TaskStatus MeshFixUtoP(MeshData<Real> *md) {
 }
 
 /**
+ * Ensure minimum temperature in a stable way:
+ * 1. If possible, preserve total energy by stealing kinetic energy
+ * 2. If not (i.e., rest energy of B exceeds total energy), add energy to
+ *    ensure B and u but no velocity
+ */
+TaskStatus VelRecover(MeshBlockData<Real> *rc);
+
+/**
  * Count up all nonzero PFlags on md.  Used for history file reductions.
  */
 int CountPFlags(MeshData<Real> *md);

--- a/kharma/inverter/inverter.hpp
+++ b/kharma/inverter/inverter.hpp
@@ -94,7 +94,7 @@ inline TaskStatus MeshFixUtoP(MeshData<Real> *md) {
  * 2. If not (i.e., rest energy of B exceeds total energy), add energy to
  *    ensure B and u but no velocity
  */
-TaskStatus VelRecover(MeshBlockData<Real> *rc);
+TaskStatus Backstop(MeshBlockData<Real> *rc);
 
 /**
  * Count up all nonzero PFlags on md.  Used for history file reductions.

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -254,7 +254,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     KastaunResidual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, gam);
 
     // SOLVE
-    // TODO(CEP) better or faster solver?  (Optionally) skip bracketing?
+    // TODO(BSP) better or faster solver?  (Optionally) skip bracketing?
     // Need to find initial bracket. Requires separate solve
     Real zm = 0.;
     Real zp = 1.; // This is the lowest specific enthalpy admitted by the EOS
@@ -328,7 +328,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
             fp = f;
         }
     }
-    // TODO(CEP) make sure we really don't want to set P for this case
+    // TODO(BSP) make sure we really don't want to set P for this case
     // is it filled with last step, or zero?
     if (iter >= max_iterations) return static_cast<int>(Status::max_iter);
 

--- a/kharma/inverter/kastaun.hpp
+++ b/kharma/inverter/kastaun.hpp
@@ -130,6 +130,7 @@ class KastaunResidual {
             const Real vhatsq = vhatsq_mu(mu, rbarsq);
             const Real iWhat = iWhat_mu(vhatsq);
             const Real What = 1.0 / iWhat;
+            // TODO technically we should only limit P>0, and allow returning negative u
             const Real rhohat = std::max(rhohat_mu(iWhat), 0.);
             const Real ehat = std::max(ehat_mu(mu, qbar, rbarsq, vhatsq, What), 0.);
             // TODO this is ideal-only
@@ -168,8 +169,7 @@ template <>
 KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const VariablePack<Real>& U, const VarMap& m_u,
                                               const Real& gam, const int& k, const int& j, const int& i,
                                               const VariablePack<Real>& P, const VarMap& m_p,
-                                              const Loci& loc, const int& max_iterations, const Real& tol,
-                                              const bool recover_velocity)
+                                              const Loci& loc, const int& max_iterations, const Real& tol)
 {
     // Shouldn't need this, KHARMA should die on NaN
     // But it's here for debugging
@@ -254,7 +254,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     KastaunResidual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, gam);
 
     // SOLVE
-    // TODO(BSP) better or faster solver?  (Optionally) skip bracketing?
+    // TODO(CEP) better or faster solver?  (Optionally) skip bracketing?
     // Need to find initial bracket. Requires separate solve
     Real zm = 0.;
     Real zp = 1.; // This is the lowest specific enthalpy admitted by the EOS
@@ -328,7 +328,9 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
             fp = f;
         }
     }
-    // TODO keep track iterations actually used
+    // TODO(CEP) make sure we really don't want to set P for this case
+    // is it filled with last step, or zero?
+    if (iter >= max_iterations) return static_cast<int>(Status::max_iter);
 
     // Just unwrap everything into primitive vars as-is
     const Real mu = z;
@@ -340,81 +342,24 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::kastaun>(const GRCoordinates& G, const V
     const Real qbar = res.qbar_mu(mu, x);
     // These values should be as *raw* as possible, whether or not they respect the floors
     // (or even physics).  We will add material and try again if they're bad
-    P(m_p.RHO, k, j, i) = std::max(res.rhohat_mu(iW), 0.);
-    P(m_p.UU, k, j, i) = std::max(res.ehat_mu(mu, qbar, rbarsq, vsq, W) * P(m_p.RHO, k, j, i), 0.);
-    // TODO make sure W*mu*x really should be >0
+    Real rho = res.rhohat_mu(iW);
+    P(m_p.RHO, k, j, i) = m::max(rho, 0.);
+    Real u = res.ehat_mu(mu, qbar, rbarsq, vsq, W) * P(m_p.RHO, k, j, i);
+    P(m_p.UU, k, j, i) = m::max(u, 0.);
     // Latter part is a vector/signed quantity, don't set a minimum at 0
-    SPACELOOP(ii) P(m_p.U1 + ii, k, j, i) = std::max(W * mu * x, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
+    Real mag_vel = W * mu * x;
+    SPACELOOP(ii) P(m_p.U1 + ii, k, j, i) = std::max(mag_vel, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
 
-    // If we should try to recover velocity, do it in this function to re-use the residual object
-    if (!recover_velocity) {
-        // Mark for fix only if convergence is not established within max_iterations (should be *extremely* rare)
-        return (iter < max_iterations) ? static_cast<int>(Status::success) : static_cast<int>(Status::max_iter);
-    } else {
-        // Calculate P->U on the inverted values
-        const Real rho = P(m_p.RHO, k, j, i);
-        const Real u = P(m_p.UU, k, j, i);
-        const Real uvec[NVEC] = {P(m_p.U1, k, j, i), P(m_p.U2, k, j, i), P(m_p.U3, k, j, i)};
-        const Real B_P[NVEC] = {P(m_p.B1, k, j, i), P(m_p.B2, k, j, i), P(m_p.B3, k, j, i)};
-        Real rho_ut = 0., T[GR_DIM] = {0.};
-        GRMHD::p_to_u_mhd(G, rho, u, uvec, B_P, gam, k, j, i, rho_ut, T);
-        const Real bad_vel_tolerance = 200 * tol;
-        // If we didn't conserve momentum within a loose tolerance based on the solver tol...
-        if ((std::abs((T[1] - U(m_u.U1, k, j, i)) / U(m_u.U1, k, j, i)) > bad_vel_tolerance) ||
-            (std::abs((T[2] - U(m_u.U2, k, j, i)) / U(m_u.U2, k, j, i)) > bad_vel_tolerance) ||
-            (std::abs((T[3] - U(m_u.U3, k, j, i)) / U(m_u.U3, k, j, i)) > bad_vel_tolerance)) {
-
-            // ...then solve so function ehat(mu) Kastaun matches the existing value,
-            // and use that to reset the velocities.
-            // This prioritizes the new thermal energy in the total T^0_0,
-            // but dumps any extra back into the velocities to be less disruptive.
-            // TODO either set this on better theory or redo the algebra and condense it
-            const Real e_actual = P(m_p.UU, k, j, i) / P(m_p.RHO, k, j, i);
-            auto f = [&] (Real mu) {
-                Real x = res.x_mu(mu);
-                Real rbarsq = res.rbarsq_mu(mu, x);
-                Real vsq = res.vhatsq_mu(mu, rbarsq);
-                Real W = 1. / res.iWhat_mu(vsq);
-                Real qbar = res.qbar_mu(mu, x);
-                return (W * (qbar - mu * rbarsq) + vsq * W * W /
-                            (1.0 + W))
-                        - e_actual;
-            };
-
-            // Rootfind for mu that would have produced the current e
-            bool e_solve_failed = false;
-            Real mu = z, mum = 0., mup = 1.;
-            if (f(mum) * f(mup) > 0.) {
-                e_solve_failed = true;
-            } else {
-                while (1) {
-                    Real muc = (mum + mup) / 2.;
-                    Real resv = m::abs(f(muc));
-                    if (resv < 1e-8 || m::abs((mup - mum) / 2) < 1e-10) {
-                        mu = muc;
-                        e_solve_failed = (resv > 1e-8);
-                        break;
-                    }
-                    // Same sign as left side -> center now left side
-                    if (f(muc) * f(mum) > 0.)
-                        mum = muc;
-                    else
-                        mup = muc;
-                }
-            }
-
-            // Reset only velocities with new mu
-            const Real x = res.x_mu(mu);
-            const Real rbarsq = res.rbarsq_mu(mu, x);
-            const Real vsq = res.vhatsq_mu(mu, rbarsq);
-            const Real iW = res.iWhat_mu(vsq);
-            const Real W = 1.0 / iW;
-            SPACELOOP(ii) P(m_p.U1 + ii, k, j, i) = std::max(W * mu * x, 0.) * (rcon[ii] + mu * bdotr * bu[ii]);
-            return (e_solve_failed) ? static_cast<int>(Status::bad_velocity) : static_cast<int>(Status::floor);
-        } else {
-            return static_cast<int>(Status::success);
-        }
+    if (rho <= 0.) {
+        return static_cast<int>(Status::neg_rho);
+    } else if (u <= 0.) {
+        return static_cast<int>(Status::neg_u);
+    } else if (mag_vel <= 0.) {
+        return static_cast<int>(Status::bad_gamma);
     }
+
+    // Mark for fix only if convergence is not established within max_iterations (should be *extremely* rare)
+    return static_cast<int>(Status::success);
 }
 
 }

--- a/kharma/inverter/onedw.hpp
+++ b/kharma/inverter/onedw.hpp
@@ -94,7 +94,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
 {
     // TODO try inline floors in the old 1Dw?  Probably not relevant anymore
     // Catch negative density
-    // TODO(CEP) if we start to see this hit, fix it here by returning P=P_floors
+    // TODO(BSP) if we start to see this hit, fix it here by returning P=P_floors
     if (U(m_u.RHO, k, j, i) <= 0.) {
         return static_cast<int>(Status::neg_input);
     }
@@ -130,7 +130,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
     const Real QdB = dot(Bcon, Qcov);
     const Real Qdotn = dot(Qcon, ncov);
 
-    // TODO(CEP) check, test if this gets hit unlike above
+    // TODO(BSP) check, test if this gets hit unlike above
     // if (U(m_u.UU, k, j, i) <= gdet*(1e-8) + gdet*Bsq/2) {
 
     // }

--- a/kharma/inverter/onedw.hpp
+++ b/kharma/inverter/onedw.hpp
@@ -90,12 +90,11 @@ template <>
 KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const VariablePack<Real>& U, const VarMap& m_u,
                                               const Real& gam, const int& k, const int& j, const int& i,
                                               const VariablePack<Real>& P, const VarMap& m_p,
-                                              const Loci& loc, const int& max_iterations, const Real& tol,
-                                              const bool recover_velocity)
+                                              const Loci& loc, const int& max_iterations, const Real& tol)
 {
     // TODO try inline floors in the old 1Dw?  Probably not relevant anymore
     // Catch negative density
-    // TODO(BSP) if we start to see this hit, fix it here by returning P=P_floors
+    // TODO(CEP) if we start to see this hit, fix it here by returning P=P_floors
     if (U(m_u.RHO, k, j, i) <= 0.) {
         return static_cast<int>(Status::neg_input);
     }
@@ -131,7 +130,7 @@ KOKKOS_INLINE_FUNCTION int u_to_p<Type::onedw>(const GRCoordinates& G, const Var
     const Real QdB = dot(Bcon, Qcov);
     const Real Qdotn = dot(Qcon, ncov);
 
-    // TODO(BSP) check, test if this gets hit unlike above
+    // TODO(CEP) check, test if this gets hit unlike above
     // if (U(m_u.UU, k, j, i) <= gdet*(1e-8) + gdet*Bsq/2) {
 
     // }

--- a/kharma/ismr/ismr.cpp
+++ b/kharma/ismr/ismr.cpp
@@ -151,7 +151,7 @@ TaskStatus ISMR::DerefinePoles(MeshData<Real> *md)
                         // The usual inverter is not EMHD-aware, so it's going to dump all of T into the
                         // ideal GRMHD fluid variables
                         Inverter::u_to_p<Inverter::Type::kastaun>(G, vars_utop, m_u, gam, k, j_c, i, P, m_p,
-                                                                  Loci::center, 8, 1e-8, false);
+                                                                  Loci::center, 25, 1e-12);
                         // Consistent with that, we zero out the EMHD extra variables.  This switches theories to
                         // evolving ideal GRMHD in ISMR region, but conserves the components of T themselves
                         if (m_u.Q >= 0) vars_utop(m_u.Q, k, j_c, i) = 0.;

--- a/kharma/kharma.cpp
+++ b/kharma/kharma.cpp
@@ -365,15 +365,6 @@ Packages_t KHARMA::ProcessPackages(std::unique_ptr<ParameterInput> &pin)
         pin->GetOrAddBoolean("emhd", "ideal_guess", false) || pin->GetOrAddBoolean("fofc", "on", false)) {
         t_inverter = tl.AddTask(t_grmhd, KHARMA::AddPackage, packages, Inverter::Initialize, pin.get());
     }
-    // Floors package is only loaded if floors aren't disabled
-    // Respect legacy version for a while
-    bool floors_on_default = true;
-    if (pin->DoesParameterExist("floors", "disable_floors")) {
-        floors_on_default = !pin->GetBoolean("floors", "disable_floors");
-    }
-    if (pin->GetOrAddBoolean("floors", "on", floors_on_default)) {
-        auto t_floors = tl.AddTask(t_inverter, KHARMA::AddPackage, packages, Floors::Initialize, pin.get());
-    }
     // Reductions, needed by most other packages
     auto t_reductions = tl.AddTask(t_none, KHARMA::AddPackage, packages, Reductions::Initialize, pin.get());
 
@@ -448,6 +439,9 @@ Packages_t KHARMA::ProcessPackages(std::unique_ptr<ParameterInput> &pin)
     // And any dirichlet/constant boundaries
     // TODO avoid init if Parthenon will be handling all boundaries?
     KHARMA::AddPackage(packages, KBoundaries::Initialize, pin.get());
+
+    // Now we alsways load floors package -- "on=false" and "disable_floors" map to "disable_call"!
+    KHARMA::AddPackage(packages, Floors::Initialize, pin.get());
 
     // Load the implicit package last, if there are *any* variables that need implicit evolution
     // This lets us just count by flag, rather than checking all the possible parameters that would

--- a/kharma/prob/problem.cpp
+++ b/kharma/prob/problem.cpp
@@ -122,7 +122,7 @@ void KHARMA::ProblemGenerator(MeshBlock *pmb, ParameterInput *pin)
         status = ReadKharmaRestart(rc, pin);
     } else if (prob == "gizmo") {
         status = InitializeGIZMO(rc, pin);
-    } else if (prob == "vacuum" || prob == "bz_monopole") {
+    } else if (prob == "vacuum" || prob == "bz_monopole" || prob == "split_monopole") {
         // No need for a separate initializer, just seed w/floors
         status = Floors::ApplyInitialFloors(pin, rc.get(), IndexDomain::interior);
     }

--- a/kharma/prob/seed_B.cpp
+++ b/kharma/prob/seed_B.cpp
@@ -114,6 +114,7 @@ TaskStatus SeedBFieldType(MeshBlockData<Real> *rc, ParameterInput *pin, IndexDom
     // Shortcut to field values for easy fields
     if constexpr (Seed == BSeedType::constant ||
                   Seed == BSeedType::monopole ||
+                  Seed == BSeedType::split_monopole_const ||
                   Seed == BSeedType::orszag_tang ||
                   Seed == BSeedType::wave ||
                   Seed == BSeedType::shock_tube)
@@ -442,6 +443,10 @@ TaskStatus SeedBField(MeshData<Real> *md, ParameterInput *pin)
             status = SeedBFieldType<BSeedType::gaussian>(rc, pin);
         } else if (b_field_type == "bz_monopole") {
             status = SeedBFieldType<BSeedType::bz_monopole>(rc, pin);
+        } else if (b_field_type == "split_monopole") {
+            status = SeedBFieldType<BSeedType::split_monopole>(rc, pin);
+        } else if (b_field_type == "split_monopole_const") {
+            status = SeedBFieldType<BSeedType::split_monopole_const>(rc, pin);
         } else if (b_field_type == "vertical") {
             status = SeedBFieldType<BSeedType::vertical>(rc, pin);
         } else if (b_field_type == "r1s2") {

--- a/kharma/prob/seed_B.hpp
+++ b/kharma/prob/seed_B.hpp
@@ -52,7 +52,8 @@ TaskStatus NormalizeBField(MeshData<Real> *md, ParameterInput *pin);
 
 // Internal representation of the field initialization preference, used for templating
 enum BSeedType{constant, monopole, orszag_tang, orszag_tang_a, wave, shock_tube,
-                sane, mad, mad_quadrupole, r3s3, r5s5, gaussian, bz_monopole, vertical, r1s2};
+                sane, mad, mad_quadrupole, r3s3, r5s5, gaussian, bz_monopole,
+                split_monopole, split_monopole_const, vertical, r1s2};
 
 #define SEEDA_ARGS GReal *x, const GReal *dxc, double rho, double rin, double min_A, double A0, double arg1, double rb
 
@@ -75,6 +76,13 @@ KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::bz_monopole>(SEEDA_ARGS)
 {
     return 1. - m::cos(x[2]);
 }
+
+template<>
+KOKKOS_INLINE_FUNCTION Real seed_a<BSeedType::split_monopole>(SEEDA_ARGS)
+{
+    return 1. - m::abs(m::cos(x[2]));
+}
+
 
 // BR's smoothed poloidal in-torus, EHT standard MAD
 template<>
@@ -150,11 +158,25 @@ KOKKOS_INLINE_FUNCTION void seed_b(SEEDB_ARGS) { B1 = 0./0.; B2 = 0./0.; B3 = 0.
 template<>
 KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::constant>(SEEDB_ARGS) {}
 
-// Reduce radial component by the cube of radius
+// Reduce set constant radial component by the cube of radius
 template<>
 KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::monopole>(SEEDB_ARGS)
 {
     B1 /= (x[1]*x[1]*x[1]);
+}
+// template<>
+// KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::split_monopole>(SEEDB_ARGS)
+// {
+//     if (x[2] < phase) {
+//         B1 /= (x[1]*x[1]*x[1]);
+//     } else {
+//         B1 /= -(x[1]*x[1]*x[1]);
+//     }
+// }
+template<>
+KOKKOS_INLINE_FUNCTION void seed_b<BSeedType::split_monopole_const>(SEEDB_ARGS)
+{
+    B1 = (x[2] < phase) ? B1 : -B1;
 }
 
 // For mhdmodes or linear waves tests

--- a/kharma/reductions/reductions.cpp
+++ b/kharma/reductions/reductions.cpp
@@ -66,8 +66,15 @@ std::shared_ptr<KHARMAPackage> Reductions::Initialize(ParameterInput *pin, std::
     params.Add("allreduce_pool", allreduce_pool, true);
 
     // Reductions sometimes need global elements of the simulation we don't otherwise keep
-    params.Add("domain_r_in", (GReal) pin->GetReal("coordinates", "r_in"));
-    params.Add("domain_r_eh", (GReal) pin->GetReal("coordinates", "r_eh"));
+    if (pin->GetReal("coordinates", "spherical")) {
+        params.Add("domain_r_in", (GReal) pin->GetReal("coordinates", "r_in"));
+        params.Add("domain_r_eh", (GReal) pin->GetReal("coordinates", "r_eh"));
+        params.Add("domain_r_out", (GReal) pin->GetReal("coordinates", "r_out"));
+    } else {
+        params.Add("domain_r_in", 0.);
+        params.Add("domain_r_eh", 0.);
+        params.Add("domain_r_out", 0.);
+    }
 
     return pkg;
 }

--- a/kharma/reductions/reductions.hpp
+++ b/kharma/reductions/reductions.hpp
@@ -117,34 +117,66 @@ Real Total(MeshData<Real> *md)
 template<Var var>
 Real SumInnerX1(MeshData<Real> *md)
 {
-    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
-        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in"), -1, false);
+    auto pmesh = md->GetMeshPointer();
+    auto x1min = pmesh->mesh_size.xmin(X1DIR);
+    Real Xnative[GR_DIM] = {0., x1min, 0., 0.}, Xembed[GR_DIM] = {0.};
+    pmesh->block_list[0]->coords.coords.coord_to_embed(Xnative, Xembed);
+
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md, Xembed[1], -1, false);
 }
 template<Var var>
 Real SumOuterX1(MeshData<Real> *md)
 {
-    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
-        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_out"), -1, true);
+    auto pmesh = md->GetMeshPointer();
+    auto x1max = pmesh->mesh_size.xmax(X1DIR);
+    Real Xnative[GR_DIM] = {0., x1max, 0., 0.}, Xembed[GR_DIM] = {0.};
+    pmesh->block_list[0]->coords.coords.coord_to_embed(Xnative, Xembed);
+
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md, Xembed[1], -1, true);
 }
 template<Var var>
 Real SumInnerX2(MeshData<Real> *md)
 {
-    return Reductions::ConeReduction<var, UserHistoryOperation::sum, Real>(md, 0., -1, false);
+    auto pmesh = md->GetMeshPointer();
+    auto x1max = pmesh->mesh_size.xmax(X1DIR);
+    auto x2min = pmesh->mesh_size.xmin(X2DIR);
+    Real Xnative[GR_DIM] = {0., x1max, x2min, 0.}, Xembed[GR_DIM] = {0.};
+    pmesh->block_list[0]->coords.coords.coord_to_embed(Xnative, Xembed);
+
+    return Reductions::ConeReduction<var, UserHistoryOperation::sum, Real>(md, Xembed[2], -1, false);
 }
 template<Var var>
 Real SumOuterX2(MeshData<Real> *md)
 {
-    return Reductions::ConeReduction<var, UserHistoryOperation::sum, Real>(md, M_PI, -1, true);
+    auto pmesh = md->GetMeshPointer();
+    auto x1max = pmesh->mesh_size.xmax(X1DIR);
+    auto x2max = pmesh->mesh_size.xmax(X2DIR);
+    Real Xnative[GR_DIM] = {0., x1max, x2max, 0.}, Xembed[GR_DIM] = {0.};
+    pmesh->block_list[0]->coords.coords.coord_to_embed(Xnative, Xembed);
+
+    return Reductions::ConeReduction<var, UserHistoryOperation::sum, Real>(md, Xembed[2], -1, true);
 }
 template<Var var>
 Real SumInnerX3(MeshData<Real> *md)
 {
-    return Reductions::PlaneReduction<var, UserHistoryOperation::sum, Real>(md, 0., -1, false);
+    auto pmesh = md->GetMeshPointer();
+    auto x1max = pmesh->mesh_size.xmax(X1DIR);
+    auto x3min = pmesh->mesh_size.xmin(X3DIR);
+    Real Xnative[GR_DIM] = {0., x1max, 0., x3min}, Xembed[GR_DIM] = {0.};
+    pmesh->block_list[0]->coords.coords.coord_to_embed(Xnative, Xembed);
+
+    return Reductions::PlaneReduction<var, UserHistoryOperation::sum, Real>(md, Xembed[3], -1, false);
 }
 template<Var var>
 Real SumOuterX3(MeshData<Real> *md)
 {
-    return Reductions::PlaneReduction<var, UserHistoryOperation::sum, Real>(md, M_2_PI, -1, true);
+    auto pmesh = md->GetMeshPointer();
+    auto x1max = pmesh->mesh_size.xmax(X1DIR);
+    auto x3max = pmesh->mesh_size.xmax(X3DIR);
+    Real Xnative[GR_DIM] = {0., x1max, 0., x3max}, Xembed[GR_DIM] = {0.};
+    pmesh->block_list[0]->coords.coords.coord_to_embed(Xnative, Xembed);
+
+    return Reductions::PlaneReduction<var, UserHistoryOperation::sum, Real>(md, Xembed[3], -1, true);
 }
 
 /**

--- a/kharma/reductions/reductions.hpp
+++ b/kharma/reductions/reductions.hpp
@@ -38,6 +38,7 @@
 #include "flux_functions.hpp"
 #include "grmhd_functions.hpp"
 #include "types.hpp"
+#include <cmath>
 
 namespace Reductions {
 
@@ -58,21 +59,34 @@ std::shared_ptr<KHARMAPackage> Initialize(ParameterInput *pin, std::shared_ptr<P
  * Just set equal min/max, 2D slices are detected
  */
 template<Var var, UserHistoryOperation op, typename T>
-T DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel=-1);
+T DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel=-1, bool plane_outward=false);
 // Defaults -- use numeric limits to set some indices unrestricted
 static constexpr Real real_max = std::numeric_limits<GReal>::max();
 template<Var var, UserHistoryOperation op, typename T>
-T DomainReduction(MeshData<Real> *md, int channel=-1) {
+T DomainReduction(MeshData<Real> *md, int channel=-1, bool plane_outward=false) {
     const GReal startx[3] = {-real_max, -real_max, -real_max};
     const GReal stopx[3] = {real_max, real_max, real_max};
-    return DomainReduction<var, op, T>(md, startx, stopx, channel);
+    return DomainReduction<var, op, T>(md, startx, stopx, channel, plane_outward);
 }
 template<Var var, UserHistoryOperation op, typename T>
-T ShellReduction(MeshData<Real> *md, GReal r, int channel=-1) {
+T ShellReduction(MeshData<Real> *md, GReal r, int channel=-1, bool plane_outward=false) {
     const GReal startx[3] = {r, -real_max, -real_max};
     const GReal stopx[3] = {r, real_max, real_max};
-    return DomainReduction<var, op, T>(md, startx, stopx, channel);
+    return DomainReduction<var, op, T>(md, startx, stopx, channel, plane_outward);
 }
+template<Var var, UserHistoryOperation op, typename T>
+T ConeReduction(MeshData<Real> *md, GReal th, int channel=-1, bool plane_outward=false) {
+    const GReal startx[3] = {-real_max, th, -real_max};
+    const GReal stopx[3] = {-real_max, th, real_max};
+    return DomainReduction<var, op, T>(md, startx, stopx, channel, plane_outward);
+}
+template<Var var, UserHistoryOperation op, typename T>
+T PlaneReduction(MeshData<Real> *md, GReal phi, int channel=-1, bool plane_outward=false) {
+    const GReal startx[3] = {-real_max, -real_max, phi};
+    const GReal stopx[3] = {-real_max, real_max, phi};
+    return DomainReduction<var, op, T>(md, startx, stopx, channel, plane_outward);
+}
+// TODO(CEP) alternate names for XYZ?  Or just don't bother
 
 // Parthenon doesn't allow taking options, so we define some common reductions
 template<Var var>
@@ -96,6 +110,41 @@ template<Var var>
 Real Total(MeshData<Real> *md)
 {
     return Reductions::DomainReduction<var, UserHistoryOperation::sum, Real>(md);
+}
+
+// Values gained/lost through faces
+// TODO(CEP) SPHERICAL ONLY RIGHT NOW
+template<Var var>
+Real SumInnerX1(MeshData<Real> *md)
+{
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
+        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_in"), -1, false);
+}
+template<Var var>
+Real SumOuterX1(MeshData<Real> *md)
+{
+    return Reductions::ShellReduction<var, UserHistoryOperation::sum, Real>(md,
+        md->GetMeshPointer()->packages.Get("Reductions")->Param<GReal>("domain_r_out"), -1, true);
+}
+template<Var var>
+Real SumInnerX2(MeshData<Real> *md)
+{
+    return Reductions::ConeReduction<var, UserHistoryOperation::sum, Real>(md, 0., -1, false);
+}
+template<Var var>
+Real SumOuterX2(MeshData<Real> *md)
+{
+    return Reductions::ConeReduction<var, UserHistoryOperation::sum, Real>(md, M_PI, -1, true);
+}
+template<Var var>
+Real SumInnerX3(MeshData<Real> *md)
+{
+    return Reductions::PlaneReduction<var, UserHistoryOperation::sum, Real>(md, 0., -1, false);
+}
+template<Var var>
+Real SumOuterX3(MeshData<Real> *md)
+{
+    return Reductions::PlaneReduction<var, UserHistoryOperation::sum, Real>(md, M_2_PI, -1, true);
 }
 
 /**

--- a/kharma/reductions/reductions_impl.hpp
+++ b/kharma/reductions/reductions_impl.hpp
@@ -176,7 +176,8 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
                 G.coord_embed(k, j, i, Loci::center, x);
                 if (trivial1 || trivial2 || trivial3) {
                     if (plane_outward) {
-                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, xin);
+                        G.coord_embed(k, j, i, Loci::center, xin);
+                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, x);
                     } else {
                         G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
                     }
@@ -199,7 +200,8 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
                 G.coord_embed(k, j, i, Loci::center, x);
                 if (trivial1 || trivial2 || trivial3) {
                     if (plane_outward) {
-                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, xin);
+                        G.coord_embed(k, j, i, Loci::center, xin);
+                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, x);
                     } else {
                         G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
                     }
@@ -223,7 +225,8 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
                 G.coord_embed(k, j, i, Loci::center, x);
                 if (trivial1 || trivial2 || trivial3) {
                     if (plane_outward) {
-                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, xin);
+                        G.coord_embed(k, j, i, Loci::center, xin);
+                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, x);
                     } else {
                         G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
                     }

--- a/kharma/reductions/reductions_impl.hpp
+++ b/kharma/reductions/reductions_impl.hpp
@@ -125,7 +125,7 @@ T Reductions::CheckOnAll(MeshData<Real> *md, int channel)
 
 // TODO additionally template on return type to avoid counting flags with Reals
 template<Reductions::Var var, UserHistoryOperation op, typename T>
-T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel)
+T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const GReal stopx[3], int channel, bool plane_outward)
 {
     Flag("DomainReduction");
     auto pmesh = md->GetMeshPointer();
@@ -174,8 +174,13 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
                 const auto& G = U.GetCoords(b);
                 GReal x[GR_DIM], xin[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, x);
-                if (trivial1 || trivial2 || trivial3)
-                    G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                if (trivial1 || trivial2 || trivial3) {
+                    if (plane_outward) {
+                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, xin);
+                    } else {
+                        G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                    }
+                }
                 if(INSIDE) {
                     local_result += reduction_var<var>(REDUCE_FUNCTION_CALL) *
                         ((trivial3) ? 1. : G.Dxc<3>(k)) * ((trivial2) ? 1. : G.Dxc<2>(j)) * ((trivial1) ? 1. : G.Dxc<1>(i));
@@ -192,8 +197,13 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
                 const auto& G = U.GetCoords(b);
                 GReal x[GR_DIM], xin[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, x);
-                if (trivial1 || trivial2 || trivial3)
-                    G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                if (trivial1 || trivial2 || trivial3) {
+                    if (plane_outward) {
+                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, xin);
+                    } else {
+                        G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                    }
+                }
                 if(INSIDE) {
                     const Real val = reduction_var<var>(REDUCE_FUNCTION_CALL) *
                         ((trivial3) ? 1. : G.Dxc<3>(k)) * ((trivial2) ? 1. : G.Dxc<2>(j)) * ((trivial1) ? 1. : G.Dxc<1>(i));
@@ -211,8 +221,13 @@ T Reductions::DomainReduction(MeshData<Real> *md, const GReal startx[3], const G
                 const auto& G = U.GetCoords(b);
                 GReal x[GR_DIM], xin[GR_DIM];
                 G.coord_embed(k, j, i, Loci::center, x);
-                if (trivial1 || trivial2 || trivial3)
-                    G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                if (trivial1 || trivial2 || trivial3) {
+                    if (plane_outward) {
+                        G.coord_embed(k + trivial3, j + trivial2, i + trivial1, Loci::center, xin);
+                    } else {
+                        G.coord_embed(k - trivial3, j - trivial2, i - trivial1, Loci::center, xin);
+                    }
+                }
                 if(INSIDE) {
                     const Real val = reduction_var<var>(REDUCE_FUNCTION_CALL) *
                         ((trivial3) ? 1. : G.Dxc<3>(k)) * ((trivial2) ? 1. : G.Dxc<2>(j)) * ((trivial1) ? 1. : G.Dxc<1>(i));

--- a/kharma/reductions/reductions_variables.hpp
+++ b/kharma/reductions/reductions_variables.hpp
@@ -61,7 +61,10 @@ enum class Var{phi, bsq, gas_pressure, beta, rhou0, mix_T00, mix_T01, mix_T02, m
                nan_ctop, zero_ctop, neg_rho, neg_u, neg_rhout,
                Uflux1RHO, Uflux1UU, Uflux1U1, Uflux1U2, Uflux1U3,
                Uflux2RHO, Uflux2UU, Uflux2U1, Uflux2U2, Uflux2U3,
-               Uflux3RHO, Uflux3UU, Uflux3U1, Uflux3U2, Uflux3U3};
+               Uflux3RHO, Uflux3UU, Uflux3U1, Uflux3U2, Uflux3U3,
+               rhou0add, T00add, T01add, T02add, T03add,
+               rhou0sub, T00sub, T01sub, T02sub, T03sub,
+               rhou0change, T00change, T01change, T02change, T03change};
 
 // Function template for all reductions.
 template<Var T>
@@ -194,6 +197,85 @@ template <>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::ldot_flux>(REDUCE_FUNCTION_ARGS)
 {
     return U.flux(X1DIR, m_u.U3, k, j, i);
+}
+
+// Amount of conserved fluid vars added to grid/subtracted from grid
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::rhou0add>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.RHOADD, k, j, i) > 0. ? U(m_u.RHOADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T00add>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T0ADD, k, j, i) > 0. ? U(m_u.T0ADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T01add>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T1ADD, k, j, i) > 0. ? U(m_u.T1ADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T02add>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T2ADD, k, j, i) > 0. ? U(m_u.T2ADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T03add>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T3ADD, k, j, i) > 0. ? U(m_u.T3ADD, k, j, i) : 0.;
+}
+
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::rhou0sub>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.RHOADD, k, j, i) < 0. ? U(m_u.RHOADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T00sub>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T0ADD, k, j, i) < 0. ? U(m_u.T0ADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T01sub>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T1ADD, k, j, i) < 0. ? U(m_u.T1ADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T02sub>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T2ADD, k, j, i) < 0. ? U(m_u.T2ADD, k, j, i) : 0.;
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T03sub>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T3ADD, k, j, i) < 0. ? U(m_u.T3ADD, k, j, i) : 0.;
+}
+// Total change as a check
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::rhou0change>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.RHOADD, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T00change>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T0ADD, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T01change>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T1ADD, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T02change>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T2ADD, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::T03change>(REDUCE_FUNCTION_ARGS)
+{
+    return U(m_u.T3ADD, k, j, i);
 }
 
 // Fluxes of conserved fluid vars, X1

--- a/kharma/reductions/reductions_variables.hpp
+++ b/kharma/reductions/reductions_variables.hpp
@@ -56,6 +56,7 @@ namespace Reductions {
 // HIPCC doesn't like passing function pointers as we used to do,
 // and it doesn't vectorize anyway. Look forward to more of this pattern in the code
 enum class Var{phi, bsq, gas_pressure, beta, rhou0, mix_T00, mix_T01, mix_T02, mix_T03,
+               abs_rhou0, abs_mix_T00, abs_mix_T01, abs_mix_T02, abs_mix_T03,
                mdot, edot, ldot, mdot_flux, edot_flux, ldot_flux, eht_lum, jet_lum,
                nan_ctop, zero_ctop, neg_rho, neg_u, neg_rhout};
 
@@ -117,6 +118,31 @@ template <>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::mix_T03>(REDUCE_FUNCTION_ARGS)
 {
     return U(m_u.U3, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::abs_rhou0>(REDUCE_FUNCTION_ARGS)
+{
+    return m::abs(U(m_u.RHO, k, j, i));
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::abs_mix_T00>(REDUCE_FUNCTION_ARGS)
+{
+    return m::abs(U(m_u.UU, k, j, i));
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::abs_mix_T01>(REDUCE_FUNCTION_ARGS)
+{
+    return m::abs(U(m_u.U1, k, j, i));
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::abs_mix_T02>(REDUCE_FUNCTION_ARGS)
+{
+    return m::abs(U(m_u.U2, k, j, i));
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::abs_mix_T03>(REDUCE_FUNCTION_ARGS)
+{
+    return m::abs(U(m_u.U3, k, j, i));
 }
 
 // Accretion rates: return a zone's contribution to the surface integral

--- a/kharma/reductions/reductions_variables.hpp
+++ b/kharma/reductions/reductions_variables.hpp
@@ -315,7 +315,8 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::zero_ctop>(REDUCE_FUNCTION_ARGS)
 {
     Real is_zero = 0;
     VLOOP {
-        if(m::max(cmax(v, k, j, i), cmin(v, k, j, i)) <= 0.) {
+        if (m::max(cmax(v, k, j, i), cmin(v, k, j, i)) <= 0.
+            && cmax.GetDim(v + 1) != 1) {
             is_zero = 1.; // once per zone
 #if DEBUG
 #ifndef KOKKOS_ENABLE_SYCL
@@ -332,7 +333,8 @@ KOKKOS_INLINE_FUNCTION Real reduction_var<Var::nan_ctop>(REDUCE_FUNCTION_ARGS)
 {
     Real is_nan = 0.;
     VLOOP {
-        if(m::isnan(m::max(cmax(v, k, j, i), cmin(v, k, j, i)))) {
+        if (m::isnan(m::max(cmax(v, k, j, i), cmin(v, k, j, i)))
+            && cmax.GetDim(v + 1) != 1) {
             is_nan = 1.;
 #if DEBUG
 #ifndef KOKKOS_ENABLE_SYCL

--- a/kharma/reductions/reductions_variables.hpp
+++ b/kharma/reductions/reductions_variables.hpp
@@ -58,7 +58,10 @@ namespace Reductions {
 enum class Var{phi, bsq, gas_pressure, beta, rhou0, mix_T00, mix_T01, mix_T02, mix_T03,
                abs_rhou0, abs_mix_T00, abs_mix_T01, abs_mix_T02, abs_mix_T03,
                mdot, edot, ldot, mdot_flux, edot_flux, ldot_flux, eht_lum, jet_lum,
-               nan_ctop, zero_ctop, neg_rho, neg_u, neg_rhout};
+               nan_ctop, zero_ctop, neg_rho, neg_u, neg_rhout,
+               Uflux1RHO, Uflux1UU, Uflux1U1, Uflux1U2, Uflux1U3,
+               Uflux2RHO, Uflux2UU, Uflux2U1, Uflux2U2, Uflux2U3,
+               Uflux3RHO, Uflux3UU, Uflux3U1, Uflux3U2, Uflux3U3};
 
 // Function template for all reductions.
 template<Var T>
@@ -191,6 +194,87 @@ template <>
 KOKKOS_INLINE_FUNCTION Real reduction_var<Var::ldot_flux>(REDUCE_FUNCTION_ARGS)
 {
     return U.flux(X1DIR, m_u.U3, k, j, i);
+}
+
+// Fluxes of conserved fluid vars, X1
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux1RHO>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X1DIR, m_u.RHO, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux1UU>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X1DIR, m_u.UU, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux1U1>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X1DIR, m_u.U1, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux1U2>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X1DIR, m_u.U2, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux1U3>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X1DIR, m_u.U3, k, j, i);
+}
+
+// Fluxes of conserved fluid vars, X2
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux2RHO>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X2DIR, m_u.RHO, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux2UU>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X2DIR, m_u.UU, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux2U1>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X2DIR, m_u.U1, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux2U2>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X2DIR, m_u.U2, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux2U3>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X2DIR, m_u.U3, k, j, i);
+}
+
+// Fluxes of conserved fluid vars, X3
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux3RHO>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X3DIR, m_u.RHO, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux3UU>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X3DIR, m_u.UU, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux3U1>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X3DIR, m_u.U1, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux3U2>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X3DIR, m_u.U2, k, j, i);
+}
+template <>
+KOKKOS_INLINE_FUNCTION Real reduction_var<Var::Uflux3U3>(REDUCE_FUNCTION_ARGS)
+{
+    return U.flux(X3DIR, m_u.U3, k, j, i);
 }
 
 // Luminosity proxy from (for example) Porth et al 2019.

--- a/kharma/types.hpp
+++ b/kharma/types.hpp
@@ -135,6 +135,8 @@ class VarMap {
         int8_t KTOT, K_CONSTANT, K_HOWES, K_KAWAZURA, K_WERNER, K_ROWAN, K_SHARMA;
         // Implicit-solver variables: constraint damping, EGRMHD
         int8_t PSI, Q, DP;
+        // Added material
+        int8_t RHOADD, T0ADD, T1ADD, T2ADD, T3ADD;
         // Total struct size ~20 bytes, < 1 vector of 4 doubles
 
         VarMap(parthenon::PackIndexMap& name_map, bool is_cons)
@@ -162,6 +164,11 @@ class VarMap {
                 // Extended MHD
                 Q = name_map["cons.q"].first;
                 DP = name_map["cons.dP"].first;
+
+                // Added material
+                RHOADD = name_map["Floors.rhou0add"].first;
+                T0ADD = name_map["Floors.Tadd"].first;
+
             } else {
                 // HD
                 RHO = name_map["prims.rho"].first;
@@ -206,6 +213,15 @@ class VarMap {
             } else {
                 Bf2 = -1;
                 Bf3 = -1;
+            }
+            if (T0ADD >= 0) {
+                T1ADD = T0ADD + 1;
+                T2ADD = T0ADD + 2;
+                T3ADD = T0ADD + 3;
+            } else {
+                T1ADD = -1;
+                T2ADD = -1;
+                T3ADD = -1;
             }
         }
 

--- a/kharma/types.hpp
+++ b/kharma/types.hpp
@@ -70,8 +70,9 @@ constexpr TE E2 = TE::E2;
 constexpr TE E3 = TE::E3;
 constexpr TE NN = TE::NN;
 
-// Any basic type manips, see LocOf in decs etc etc
+// Any basic type manips, see loc_of in decs etc etc
 // Host-only because the templating/types are weird on device
+// TODO(CEP) make host/device?
 template<typename T>
 inline TE FaceOf(const T& dir) {
     return (dir == X1DIR) ? F1 : ((dir == X2DIR) ? F2 : F3);

--- a/pars/bondi/bondi.par
+++ b/pars/bondi/bondi.par
@@ -65,7 +65,7 @@ disable_floors = true
 <inverter>
 # Don't hide problems by being cute about inversion
 # We should never hit inversion failures in this problem
-vel_recovery = false
+backstop = false
 fix_average_neighbors = true
 
 <boundaries>

--- a/pars/bondi/bondi.par
+++ b/pars/bondi/bondi.par
@@ -65,7 +65,7 @@ disable_floors = true
 <inverter>
 # Don't hide problems by being cute about inversion
 # We should never hit inversion failures in this problem
-apply_floors_with_inversion = false
+vel_recovery = false
 fix_average_neighbors = true
 
 <boundaries>

--- a/pars/tests/explosion.par
+++ b/pars/tests/explosion.par
@@ -42,13 +42,12 @@ gamma = 1.333333
 type = kharma
 
 <flux>
-type = hlle
-reconstruction = ppm
+type = llf
+reconstruction = weno5
 
 <inverter>
 type = kastaun
-fix_average_neighbors = false
-fix_atmosphere = true
+err_tol = 1e-14
 
 <explosion>
 rho_out = 1e-4
@@ -58,13 +57,16 @@ rho_min_const = 1e-10
 u_min_const = 1e-10
 
 <fofc>
-on = true
+on = false
+#consistent_face_b = false
 
 <b_field>
 solver = face_ct
 ct_scheme = gs05_c
 type = constant
-B10 = 1.0
+# Balsara uses ~250
+B10 = 1.e4
+#B20 = 50.0
 
 <debug>
 verbose = 1
@@ -73,6 +75,7 @@ extra_checks = 2
 
 <parthenon/output0>
 file_type = hdf5
+write_xdmf = false
 dt = 0.1
 single_precision_output = true
 variables = prims, fflag, pflag

--- a/pars/tests/split_monopole.par
+++ b/pars/tests/split_monopole.par
@@ -1,0 +1,72 @@
+# Monopole in vacuum
+# Useful for testing floor values, since the whole domain will be
+# set to whatever the floor values are
+
+# The current values are very conservative, try it with `fofc/on=true`
+# and remove the ceiling on sigma to exercise KHARMA a bit more.
+# Hard mode: gamma=5/3, weno5 reconstruction
+
+<parthenon/job>
+problem_id = bz_monopole
+
+<parthenon/mesh>
+nx1 = 2048
+nx2 = 2048
+nx3 = 1
+
+<parthenon/meshblock>
+nx1 = 512
+nx2 = 512
+nx3 = 1
+
+<coordinates>
+base = spherical_ks
+transform = mks
+r_out = 100.
+a = 0.9375
+hslope = 0.3
+mks_smooth = 0.5
+poly_xt = 0.82
+poly_alpha = 14.0
+correct_connections = true
+
+<parthenon/time>
+tlim = 3000.0
+nlim = -1
+
+<debug>
+verbose = 1
+extra_checks = 1
+flag_verbose = 2
+
+<GRMHD>
+cfl = 0.7
+gamma = 1.666667
+
+<flux>
+type = llf
+reconstruction = weno5
+
+<fofc>
+on = false
+pcp = false
+
+<b_field>
+type = split_monopole
+norm = false
+B10 = 1
+phase = 1.5707963267948966
+
+<floors>
+rho_min_geom = 1e-6
+u_min_geom = 1e-8
+
+<parthenon/output0>
+file_type = hdf5
+dt = 1.0
+single_precision_output = true
+variables = prims, jcon, fflag, pflag, divB
+
+<parthenon/output1>
+file_type = hst
+dt = 0.1

--- a/run.sh
+++ b/run.sh
@@ -44,6 +44,13 @@ HOST=$(hostname -f)
 ARGS=${ARGS:-$(cat $KHARMA_DIR/make_args)}
 SOURCE_DIR=$(dirname "$(readlink -f "$0")")
 
+# Parse options in a slightly less insane way than before
+# At least this checks for the full space-separated word as a flag
+args_array=($ARGS)
+option() {
+  printf '%s\0' "${args_array[@]}" | grep -Fxqz -- $1
+}
+
 # A machine config in .config overrides our defaults
 if [ -f $HOME/.config/kharma.sh ]; then
   source $HOME/.config/kharma.sh
@@ -133,11 +140,12 @@ if [ -z "$EXE_NAME" ]; then
 fi
 
 # Run based on preferences
+# TODO Use a subdirectory for dumps with -d
 # TODO can we just set +x to print commands, like does that play nice with exec?
 if [ -z "$MPI_EXE" ]; then
   echo "Running $PROF_EXE $PROF_OPTS $KHARMA_DIR/$EXE_NAME $@ $KHARMA_PROF_OPTS"
-  exec $PROF_EXE $PROF_OPTS $KHARMA_DIR/$EXE_NAME "$@" $KHARMA_PROF_OPTS
+  exec $PROF_EXE $PROF_OPTS $KHARMA_DIR/$EXE_NAME -d dumps_kharma "$@" $KHARMA_PROF_OPTS
 else
   echo "Running $MPI_EXE -n $MPI_NUM_PROCS $MPI_EXTRA_ARGS $KHARMA_DIR/$EXE_NAME $@"
-  exec $MPI_EXE -n $MPI_NUM_PROCS $MPI_EXTRA_ARGS $KHARMA_DIR/$EXE_NAME "$@"
+  exec $MPI_EXE -n $MPI_NUM_PROCS $MPI_EXTRA_ARGS $KHARMA_DIR/$EXE_NAME -d dumps_kharma "$@"
 fi


### PR DESCRIPTION
This splits out the velocity recovery stuff I was doing in `u_to_p` back into three different functions:
1. Unmodified Kastaun u_to_p
2. Unmodified coordinate frame floors
3. New "velocity recovery" fixup step, replacing traditional averaging/entropy/etc.

Doing everything in the `u_to_p` function was always a halfway solution, and once we got rid of any re-use of the solver variables this was natural.

It does eliminate `rho_to_slow` option -- this is effectively just a floor on `rho` and `u` at a particular level, and the plan is to bring it back as an option/call with the other floors.