### PR TITLE
Fix end-simulation hang

### DIFF
--- a/kharma/main.cpp
+++ b/kharma/main.cpp
@@ -240,9 +240,10 @@ int main(int argc, char *argv[])
     }
 
     // Parthenon cleanup includes Kokkos, MPI
-    Flag("ParthenonFinalize");
-    pman.ParthenonFinalize();
-    EndFlag();
+    // TODO(CEP) BUT IT HANGS
+    //Flag("ParthenonFinalize");
+    //pman.ParthenonFinalize();
+    //EndFlag();
 
     return 0;
 }

--- a/kharma/main.cpp
+++ b/kharma/main.cpp
@@ -237,13 +237,15 @@ int main(int argc, char *argv[])
         //MPIBarrier();
         auto driver_status = driver.Execute();
         EndFlag();
+
+        // TODO(CEP) Figure this out instead of circumventing
+        exit(0);
     }
 
     // Parthenon cleanup includes Kokkos, MPI
-    // TODO(CEP) BUT IT HANGS
-    //Flag("ParthenonFinalize");
-    //pman.ParthenonFinalize();
-    //EndFlag();
+    Flag("ParthenonFinalize");
+    pman.ParthenonFinalize();
+    EndFlag();
 
     return 0;
 }


### PR DESCRIPTION
This fixes hanging at the end of a completed simulation the dumb way, by exiting.

Given where the exit needs to be placed, I believe the hang is when de-allocating the Driver object or something related to it.  This seems related to de-allocation woes in Parthenon proper, but only KHARMA still seems to experience the hang with the latest Parthenon checked out.

Going to just merge immediately since this is confirmed working.